### PR TITLE
feat: Add MessageEnvelope class that adheres to the CloudEvents specification

### DIFF
--- a/src/AWS.Messaging/AWS.Messaging.csproj
+++ b/src/AWS.Messaging/AWS.Messaging.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.62" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
   </ItemGroup>
   

--- a/src/AWS.Messaging/MessageEnvelope.cs
+++ b/src/AWS.Messaging/MessageEnvelope.cs
@@ -1,0 +1,80 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text.Json.Serialization;
+
+namespace AWS.Messaging;
+
+/// <summary>
+/// Generic class for MessageEnvelope objects.
+/// This class adheres to the CloudEvents specification v1.0 and contains all the attributes that are marked as required by the spec.
+/// The CloudEvent spec can be found <see href="https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md">here.</see>
+/// </summary>
+public class MessageEnvelope<T>
+{
+    /// <summary>
+    /// Specifies the envelope ID
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// Specifies the source of the event.
+    /// This can be the organization publishing the event or the process that produced the event.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public Uri Source { get; set; }
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public string Version { get; set; }
+
+    /// <summary>
+    /// The type of event that occurred. This represents the language agnostic type that is used to deserialize the envelope message into a .NET type.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; set; }
+
+    /// <summary>
+    /// The timestamp when the event occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public DateTime TimeStamp { get; set; }
+
+    /// <summary>
+    /// The application message that will be processed.
+    /// </summary>
+    [JsonPropertyName("data")]
+    public T Message { get; set; }
+
+    /// <summary>
+    /// This stores different metadata that is not modeled as a top-level property in MessageEnvelope class.
+    /// </summary>
+    [JsonExtensionData]
+    public Dictionary<string, object>? Metadata { get; set; } = new Dictionary<string, object>();
+
+    /// <summary>
+    /// Stores metadata related to Amazon SQS.
+    /// </summary>
+    public SQSMetadata? SQSMetadata { get; set; }
+
+    /// <summary>
+    /// Creates a MessageEnvelope object that is aligned with CloudEvents specification v1.0
+    /// </summary>
+    public MessageEnvelope(string id,
+        Uri source,
+        string version,
+        string type,
+        DateTime timeStamp,
+        T message)
+    {
+        Id = id;
+        Source = source;
+        Version = version;
+        Type = type;
+        TimeStamp = timeStamp;
+        Message = message;
+    }
+}

--- a/src/AWS.Messaging/SQSMetadata.cs
+++ b/src/AWS.Messaging/SQSMetadata.cs
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.SQS.Model;
+
+namespace AWS.Messaging
+{
+    /// <summary>
+    /// Contains metadata related to Amazon SQS.
+    /// </summary>
+    public class SQSMetadata
+    {
+        /// <summary>
+        /// Specifies the token used for de-duplication of sent messages. This parameter applies only to FIFO (first-in-first-out) queues.
+        /// </summary>
+        public string? MessageDeduplicationId { get; set; }
+
+        /// <summary>
+        /// The tag that specifies that a message belongs to a specific message group. This parameter applies only to FIFO (first-in-first-out) queues.
+        /// </summary>
+        public string? MessageGroupId { get; set; }
+
+        /// <summary>
+        /// Each message attribute consists of a Name, Type, and Value.For more information, see Amazon SQS message attributes (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-metadata.html#sqs-message-attributes)
+        /// </summary>
+        public Dictionary<string, MessageAttributeValue> MessageAttributes { get; set; } = new Dictionary<string, MessageAttributeValue>();
+    }
+}

--- a/test/AWS.Messaging.UnitTests/AWS.Messaging.UnitTests.csproj
+++ b/test/AWS.Messaging.UnitTests/AWS.Messaging.UnitTests.csproj
@@ -9,4 +9,17 @@
     <ProjectReference Include="..\..\src\AWS.Messaging\AWS.Messaging.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/test/AWS.Messaging.UnitTests/MessageEnvelopeTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessageEnvelopeTests.cs
@@ -1,0 +1,70 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Xunit;
+
+namespace AWS.Messaging.UnitTests;
+
+public class MessageEnvelopeTests
+{
+    [Fact]
+    public void MessageEnvelope_AdheresTo_CloudEventsSpec()
+    {
+        // ARRANGE
+        var cloudEventJSON =
+            @"{
+               ""id"":""A1234"",
+               ""source"":""/backend-service/order-placed"",
+               ""specversion"":""1.0"",
+               ""type"":""order-info"",
+               ""time"":""2018-04-05T17:31:00"",
+               ""data"":{
+                  ""name"":""Bob"",
+                  ""city"":""my-city"",
+                  ""merchandise"":""t-shirt""
+               },
+               ""SQSMetadata"":{
+                  ""MessageDeduplicationId"":""dedup-id"",
+                  ""MessageGroupId"":""group-id"",
+                  ""MessageAttributes"":{
+                     ""MyNameAttribute"":{
+                        ""StringValue"":""John Doe""
+                     }
+                  }
+               },
+               ""some-metadata"":""random-string""
+            }";
+
+        // ACT
+        var messageEnvelope = JsonSerializer.Deserialize<MessageEnvelope<OrderInfo>>(cloudEventJSON);
+
+        // ASSERT
+        Assert.Equal("A1234", messageEnvelope.Id);
+        Assert.Equal("1.0", messageEnvelope.Version);
+        Assert.Equal("order-info", messageEnvelope.Type);
+        Assert.Equal("/backend-service/order-placed", messageEnvelope.Source.ToString());
+        Assert.Equal(new DateTime(2018, 4, 5, 17, 31, 0), messageEnvelope.TimeStamp);
+        Assert.Equal("Bob", messageEnvelope.Message.Name);
+        Assert.Equal("my-city", messageEnvelope.Message.City);
+        Assert.Equal("t-shirt", messageEnvelope.Message.Merchandise);
+        Assert.Equal("random-string", ((JsonElement)messageEnvelope.Metadata["some-metadata"]).Deserialize<string>());
+        Assert.Equal("dedup-id", messageEnvelope.SQSMetadata.MessageDeduplicationId);
+        Assert.Equal("group-id", messageEnvelope.SQSMetadata.MessageGroupId);
+        Assert.Equal("John Doe", messageEnvelope.SQSMetadata.MessageAttributes["MyNameAttribute"].StringValue);
+    }
+}
+
+public class OrderInfo
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    [JsonPropertyName("city")]
+    public string City { get; set; }
+
+    [JsonPropertyName("merchandise")]
+    public string Merchandise { get; set; }
+}


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6661

*Description of changes:*
This PR adds the `MessageEnvelope` POCO that adheres to the [CloudEvents spec](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md).

It includes all the required attributes defined by the spec (**_id, source, specversion, type_**) along with 2 optional attributes (**_time, data_**). 

I have included the `Metadata` property which can store service specific message attributes. The envelope de-serialization logic can use the `Publisher` property to identify which AWS service (SQS/SNS/EventBridge) published the message and can populate  service specific message attributes from the metadata JSON.

**This is not the final implementation**. This POCO will evolve and we may add additonal properties depending on the type of uses-cases we serve. The initial implementation is sufficient to get the ball rolling on serialization, routing and message pump epics.


**_Why didn't we use the native CloudEvents SDK?_**
1. It models the `data` attribute as an `object` and not as a generic.
2. It does not allow us to model AWS specific metadata like message group IDs and other service specific attributes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
