### PR TITLE
Add IMessageHandler.cs and subscriber mapping.

### DIFF
--- a/src/AWS.Messaging/Configuration/SubscriberMapping.cs
+++ b/src/AWS.Messaging/Configuration/SubscriberMapping.cs
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Configuration;
+
+/// <summary>
+/// Maps the <see cref="AWS.Messaging.IMessageHandler{T}"/> to the type of message being processed.
+/// </summary>
+public class SubscriberMapping
+{
+    /// <summary>
+    /// The <see cref="AWS.Messaging.IMessageHandler{T}"/> that will process the message.
+    /// </summary>
+    public Type HandlerType { get; }
+
+    /// <summary>
+    /// The .NET type used as the container for the message data.
+    /// </summary>
+    public Type MessageType { get; }
+
+    /// <summary>
+    /// The identifier used as the indicator in the incoming message that maps to the HandlerType. If this
+    /// is not set then the FullName of type specified in the MessageType is used.
+    /// </summary>
+    public string MessageTypeIdentifier { get; }
+
+    /// <summary>
+    /// Constructs an instance of HandlerMapping
+    /// </summary>
+    /// <param name="handlerType">The type that implements <see cref="IMessageHandler{T}"/></param>
+    /// <param name="messageType">The type that will be message data will deserialized into</param>
+    /// <param name="messageTypeIdentifier">Optional message type identifier. If not set the full name of the messageType is used.</param>
+    public SubscriberMapping(Type handlerType, Type messageType, string? messageTypeIdentifier = null)
+    {
+        HandlerType = handlerType;
+        MessageType = messageType;
+
+        MessageTypeIdentifier = messageTypeIdentifier ?? messageType.FullName!;
+    }
+}

--- a/src/AWS.Messaging/IMessageHandler.cs
+++ b/src/AWS.Messaging/IMessageHandler.cs
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging;
+
+/// <summary>
+/// This interface is implemented by the users of this library for each type of message that should be processed.
+///
+/// The implementation of this interface is where the business logic for processing a particular message type is written.
+/// The message type is indicated by the generic type T for the interface. The library will call the handler whenever
+/// the message type is read from the message source.
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public interface IMessageHandler<T>
+{
+    /// <summary>
+    /// This method is where the business logic for processing the message will start.
+    ///
+    /// If the message was successfully processed and should them <see cref="MessageProcessStatus.Success()"/> should be returned. The
+    /// underlying service like SQS will be told the message has been processed and can be removed.
+    ///
+    /// If an exception is thrown from this method the status is treated as <see cref="MessageProcessStatus.Failed()"/>.
+    /// </summary>
+    /// <param name="messageEnvelope">The message read from the message source wrapped around a message envelope containing message metadata.</param>
+    /// <param name="token">The optional cancellation token.</param>
+    /// <returns>The status of the processed message. For example whether the message was successfully processed.</returns>
+    Task<MessageProcessStatus> HandleAsync(MessageEnvelope<T> messageEnvelope, CancellationToken token = default(CancellationToken));
+}

--- a/src/AWS.Messaging/MessageProcessStatus.cs
+++ b/src/AWS.Messaging/MessageProcessStatus.cs
@@ -1,0 +1,59 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AWS.Messaging;
+
+/// <summary>
+/// Status returned after processing messages from the <see cref="AWS.Messaging.IMessageHandler{T}"/>.
+/// The status informs the <see cref="AWS.Messaging.Services.IMessageManager"/> what should be done with the message
+/// after the message has been attempted to be processed.
+///
+/// For example using the <see cref="MessageProcessStatus.Success()"/> would tell the <see cref="AWS.Messaging.Services.IMessageManager"/> to delete
+/// the message from the underlying service like SQS.
+/// </summary>
+public sealed class MessageProcessStatus
+{
+    // A class is used instead of an enum to represent status for possible future features of returning
+    // a status with data. For example if we add a "DelayRetry" status that would require extra data
+    // for how long the delay should happen.
+
+    private enum StatusType { Success, Failed }
+
+    private readonly StatusType _statusType;
+
+    private static readonly MessageProcessStatus _success = new MessageProcessStatus(StatusType.Success);
+    private static readonly MessageProcessStatus _failed = new MessageProcessStatus(StatusType.Failed);
+
+    private MessageProcessStatus(StatusType statusType)
+    {
+        _statusType = statusType;
+    }
+
+    /// <summary>
+    /// Creates a success status return
+    /// </summary>
+    /// <returns></returns>
+    public static MessageProcessStatus Success() => _success;
+
+    /// <summary>
+    /// Creates a failed status return
+    /// </summary>
+    /// <returns></returns>
+    public static MessageProcessStatus Failed() => _failed;
+
+    /// <summary>
+    /// Returns true if the status is success.
+    /// </summary>
+    public bool IsSuccess => _statusType == StatusType.Success;
+
+    /// <summary>
+    /// Returns true if the status is failed.
+    /// </summary>
+    public bool IsFailed => _statusType == StatusType.Failed;
+}

--- a/src/AWS.Messaging/Services/IMessagePoller.cs
+++ b/src/AWS.Messaging/Services/IMessagePoller.cs
@@ -5,7 +5,7 @@ namespace AWS.Messaging.Services;
 
 /// <summary>
 /// Instances of <see cref="AWS.Messaging.Services.IMessagePoller" /> handle polling for messages from the underlying AWS service. Once
-/// messages are received from the underlying service they are deserialized into MessageEnvelop&lt;T&gt;
+/// messages are received from the underlying service they are deserialized into <see cref="AWS.Messaging.MessageEnvelope{T}"/>;
 /// and handed off to the IMessageManager for processing.
 ///
 /// The <see cref="AWS.Messaging.Services.IMessagePoller" /> abstracts around the underlying service and also provides the utility methods used

--- a/test/AWS.Messaging.UnitTests/ConfigurationTests.cs
+++ b/test/AWS.Messaging.UnitTests/ConfigurationTests.cs
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Threading;
+using System.Threading.Tasks;
+using AWS.Messaging.Configuration;
+using Xunit;
+
+namespace AWS.Messaging.UnitTests;
+
+public class ConfigurationTests
+{
+    [Fact]
+    public void SubscriberMappingNoMessageIdentifier()
+    {
+        var mapping = new SubscriberMapping(typeof(PurchaseOrderHandler), typeof(PurchaseOrder));
+        Assert.Equal("AWS.Messaging.UnitTests.ConfigurationTests+PurchaseOrder", mapping.MessageTypeIdentifier);
+    }
+
+    [Fact]
+    public void SubscriberMappingWithMessageIdentifier()
+    {
+        var mapping = new SubscriberMapping(typeof(PurchaseOrderHandler), typeof(PurchaseOrder), "PO");
+        Assert.Equal("PO", mapping.MessageTypeIdentifier);
+    }
+
+    public class PurchaseOrderHandler : IMessageHandler<PurchaseOrder>
+    {
+        public Task<MessageProcessStatus> HandleAsync(MessageEnvelope<PurchaseOrder> messageEnvelope, CancellationToken token = default)
+        {
+            return Task.FromResult(MessageProcessStatus.Success());
+        }
+    }
+
+    public class PurchaseOrder
+    {
+        public string Id { get; set; }
+    }
+}

--- a/test/AWS.Messaging.UnitTests/MessageProcessStatusTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessageProcessStatusTests.cs
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Threading;
+using System.Threading.Tasks;
+using AWS.Messaging.Configuration;
+using Xunit;
+
+namespace AWS.Messaging.UnitTests;
+
+public class MessageProcessStatusTests
+{
+    [Fact]
+    public void IsSuccess()
+    {
+        var status = MessageProcessStatus.Success();
+        Assert.True(status.IsSuccess);
+        Assert.False(status.IsFailed);
+    }
+
+    [Fact]
+    public void IsFailed()
+    {
+        var status = MessageProcessStatus.Failed();
+        Assert.False(status.IsSuccess);
+        Assert.True(status.IsFailed);
+    }
+}


### PR DESCRIPTION
*Description of changes:*
Add the IMessageHandler interface along with the subscriber mapping. I'm skipping adding the configuration methods for filling out the subscriber mapping because Phil is currently working on some designs in this area. Should be a easy add later once Phil's PR is done.

I choose to not make `MessageProcessStatus` an enum and instead using a class to represent the status. I wanted to future proof status to later be able to return additional data with the status. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
