### PR TITLE
feat: add message bus and sample app

### DIFF
--- a/AWS.Messaging.sln
+++ b/AWS.Messaging.sln
@@ -17,7 +17,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AWS.Messaging.IntegrationTests", "test\AWS.Messaging.IntegrationTests\AWS.Messaging.IntegrationTests.csproj", "{A4D5F664-E3A3-411A-9327-05913794021C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Messaging.IntegrationTests", "test\AWS.Messaging.IntegrationTests\AWS.Messaging.IntegrationTests.csproj", "{A4D5F664-E3A3-411A-9327-05913794021C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "sampleapps", "sampleapps", "{1AA8985B-897C-4BD5-9735-FD8B33FEBFFB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PublisherAPI", "sampleapps\PublisherAPI\PublisherAPI.csproj", "{A7F3DA5F-0D7A-4D8A-837D-F78F4A4E3CA7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -37,6 +41,10 @@ Global
 		{A4D5F664-E3A3-411A-9327-05913794021C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A4D5F664-E3A3-411A-9327-05913794021C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A4D5F664-E3A3-411A-9327-05913794021C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A7F3DA5F-0D7A-4D8A-837D-F78F4A4E3CA7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7F3DA5F-0D7A-4D8A-837D-F78F4A4E3CA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7F3DA5F-0D7A-4D8A-837D-F78F4A4E3CA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7F3DA5F-0D7A-4D8A-837D-F78F4A4E3CA7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -45,6 +53,7 @@ Global
 		{CD480303-CA3D-4A2F-AD9A-0E56C43FFCF0} = {2D0A561B-0B97-4259-8603-3AF5437BB652}
 		{BC3F831E-1BF0-4A94-87F4-8CA3F1E2D86C} = {80DB2C77-6ADD-4A60-B27D-763BDF9659D3}
 		{A4D5F664-E3A3-411A-9327-05913794021C} = {80DB2C77-6ADD-4A60-B27D-763BDF9659D3}
+		{A7F3DA5F-0D7A-4D8A-837D-F78F4A4E3CA7} = {1AA8985B-897C-4BD5-9735-FD8B33FEBFFB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7B2B759D-6455-4089-8173-3F1619567B36}

--- a/sampleapps/PublisherAPI/Controllers/PublisherController.cs
+++ b/sampleapps/PublisherAPI/Controllers/PublisherController.cs
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Messaging;
+using Microsoft.AspNetCore.Mvc;
+using PublisherAPI.Models;
+
+namespace PublisherAPI.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class PublisherController : ControllerBase
+{
+    private readonly IMessagePublisher _messagePublisher;
+
+    public PublisherController(IMessagePublisher messagePublisher)
+    {
+        _messagePublisher = messagePublisher;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> PublishMessage([FromBody] ChatMessage message)
+    {
+        if (message == null)
+        {
+            return BadRequest("A chat message was not used.");
+        }
+        if (string.IsNullOrEmpty(message.MessageDescription))
+        {
+            return BadRequest("The MessageDescription cannot be null or empty.");
+        }
+
+        await _messagePublisher.PublishAsync(message);
+
+        return Ok();
+    }
+}

--- a/sampleapps/PublisherAPI/Models/ChatMessage.cs
+++ b/sampleapps/PublisherAPI/Models/ChatMessage.cs
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace PublisherAPI.Models;
+
+public class ChatMessage
+{
+    public string MessageDescription { get; set; } = string.Empty;
+}

--- a/sampleapps/PublisherAPI/Program.cs
+++ b/sampleapps/PublisherAPI/Program.cs
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using PublisherAPI.Models;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+
+builder.Services.AddControllers();
+builder.Services.AddAWSMessageBus(builder =>
+{
+    builder.AddSQSPublisher<ChatMessage>("https://sqs.us-west-2.amazonaws.com/012345678910/MPF");
+});
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/sampleapps/PublisherAPI/Properties/launchSettings.json
+++ b/sampleapps/PublisherAPI/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:2324",
+      "sslPort": 44370
+    }
+  },
+  "profiles": {
+    "PublisherAPI": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7204;http://localhost:5279",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/sampleapps/PublisherAPI/PublisherAPI.csproj
+++ b/sampleapps/PublisherAPI/PublisherAPI.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AWS.Messaging\AWS.Messaging.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/sampleapps/PublisherAPI/appsettings.Development.json
+++ b/sampleapps/PublisherAPI/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/sampleapps/PublisherAPI/appsettings.json
+++ b/sampleapps/PublisherAPI/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/AWS.Messaging/AWS.Messaging.csproj
+++ b/src/AWS.Messaging/AWS.Messaging.csproj
@@ -11,7 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.62" />
+    <PackageReference Include="AWSSDK.EventBridge" Version="3.7.101.7" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.2" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.5" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.69" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
   </ItemGroup>

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Configuration;
+
+/// <summary>
+/// This builder interface is used to configure the AWS messaging framework, including adding publishers and subscribers.
+/// </summary>
+public interface IMessageBusBuilder
+{
+    /// <summary>
+    /// Adds an SQS Publisher to the framework which will handle publishing
+    /// the defined message type to the specified SQS queues URL.
+    /// </summary>
+    /// <param name="queueUrl">The SQS queue URL to publish the message to.</param>
+    /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
+    IMessageBusBuilder AddSQSPublisher<TMessage>(string queueUrl, string? messageTypeIdentifier = null);
+
+    /// <summary>
+    /// Adds an SNS Publisher to the framework which will handle publishing
+    /// the defined message type to the specified SNS topic URL.
+    /// </summary>
+    /// <param name="topicUrl">The SNS topic URL to publish the message to.</param>
+    /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
+    IMessageBusBuilder AddSNSPublisher<TMessage>(string topicUrl, string? messageTypeIdentifier = null);
+
+    /// <summary>
+    /// Adds an EventBridge Publisher to the framework which will handle publishing
+    /// the defined message type to the specified EventBridge event bus URL.
+    /// </summary>
+    /// <param name="eventBusUrl">The EventBridge event bus URL to publish the message to.</param>
+    /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
+    IMessageBusBuilder AddEventBridgePublisher<TMessage>(string eventBusUrl, string? messageTypeIdentifier = null);
+}

--- a/src/AWS.Messaging/Configuration/PublisherMapping.cs
+++ b/src/AWS.Messaging/Configuration/PublisherMapping.cs
@@ -22,7 +22,7 @@ public class PublisherMapping : IPublisherMapping
 
     /// <summary>
     /// Creates a mapping object for the specified message type as well as the AWS service to publisher to.
-    /// This object will be used internally by the system to properly route the user-defined message.
+    /// This object will be used internally by the framework to properly route the user-defined message.
     /// </summary>
     /// <param name="messageType">The Type of the message</param>
     /// <param name="publisherConfiguration">The publisher configuration</param>

--- a/src/AWS.Messaging/Exceptions.cs
+++ b/src/AWS.Messaging/Exceptions.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using AWS.Messaging.Configuration;
+
 namespace AWS.Messaging;
 
 /// <summary>
@@ -15,7 +17,7 @@ public abstract class AWSMessagingException : Exception
 }
 
 /// <summary>
-/// Thrown if the type full name cannot be retrieved.
+/// Thrown if the message type full name cannot be retrieved.
 /// </summary>
 public class InvalidMessageTypeException : AWSMessagingException
 {
@@ -45,4 +47,37 @@ public class ConfigurationException : AWSMessagingException
     /// Creates an instance of <see cref="AWS.Messaging.ConfigurationException" />
     /// </summary>
     public ConfigurationException(string message, Exception? innerException = null) : base(message, innerException) { }
+}
+
+/// <summary>
+/// Thrown if the publisher type full name cannot be retrieved.
+/// </summary>
+public class InvalidPublisherTypeException : AWSMessagingException
+{
+    /// <summary>
+    /// Creates an instance of <see cref="InvalidPublisherTypeException"/>.
+    /// </summary>
+    public InvalidPublisherTypeException(string message, Exception? innerException = null) : base(message, innerException) { }
+}
+
+/// <summary>
+/// Thrown if the a publisher mapping cannot be found for a specific message type.
+/// </summary>
+public class MissingMessageTypeConfigurationException : AWSMessagingException
+{
+    /// <summary>
+    /// Creates an instance of <see cref="MissingMessageTypeConfigurationException"/>.
+    /// </summary>
+    public MissingMessageTypeConfigurationException(string message, Exception? innerException = null) : base(message, innerException) { }
+}
+
+/// <summary>
+/// Thrown if a publisher type outside of <see cref="PublisherTargetType"/> is provided.
+/// </summary>
+public class UnsupportedPublisherException : AWSMessagingException
+{
+    /// <summary>
+    /// Creates an instance of <see cref="UnsupportedPublisherException"/>.
+    /// </summary>
+    public UnsupportedPublisherException(string message, Exception? innerException = null) : base(message, innerException) { }
 }

--- a/src/AWS.Messaging/Extensions/ServiceCollectionExtensions.cs
+++ b/src/AWS.Messaging/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Messaging.Configuration;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Adds extension methods to <see cref="IServiceCollection"/> to allow the configuration of the framework at application startup.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the <see cref="IMessageBusBuilder"/> to the dependency injection framework 
+    /// to allow access to the framework components throughout the application.
+    /// Allows the configuration of the messaging framework by exposing methods to add publishers and subscribers.
+    /// </summary>
+    /// <param name="services"><see cref="IServiceCollection"/></param>
+    /// <param name="builder">An action to define the message framework configuration using <see cref="MessageBusBuilder"/></param>
+    public static IServiceCollection AddAWSMessageBus(this IServiceCollection services, Action<MessageBusBuilder> builder)
+    {
+        var messageBusBuilder = new MessageBusBuilder();
+
+        builder(messageBusBuilder);
+        messageBusBuilder.Build(services);
+
+        return services;
+    }
+}

--- a/src/AWS.Messaging/IMessagePublisher.cs
+++ b/src/AWS.Messaging/IMessagePublisher.cs
@@ -18,7 +18,7 @@ public interface IMessagePublisher
     /// configuration done during startup. It retrieves the <see cref="PublisherMapping"/> corresponding to the
     /// message type, which contains the routing information of the provided message type.
     /// The method wraps the message in a <see cref="MessageEnvelope"/> which contains metadata for the provided
-    /// message that enables the proper transportation of the message throughout the system.
+    /// message that enables the proper transportation of the message throughout the framework.
     /// This method is accessible by injecting <see cref="IMessagePublisher"/> into the application code
     /// using the dependency injection framework.
     /// </summary>

--- a/src/AWS.Messaging/MessagePublisher.cs
+++ b/src/AWS.Messaging/MessagePublisher.cs
@@ -1,0 +1,59 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Messaging.Configuration;
+
+namespace AWS.Messaging;
+
+/// <summary>
+/// The message publisher allows publishing messages from application code to configured AWS services.
+/// It exposes the <see cref="PublishAsync{T}(T, CancellationToken)"/> method which takes in a user-defined message
+/// and looks up the corresponding <see cref="PublisherMapping"/> in order to route it to the appropriate AWS services.
+/// </summary>
+public class MessagePublisher : IMessagePublisher
+{
+    private readonly IMessageConfiguration _messageConfiguration;
+
+    /// <summary>
+    /// Creates an instance of <see cref="MessagePublisher"/>.
+    /// </summary>
+    public MessagePublisher(IMessageConfiguration messageConfiguration)
+    {
+        _messageConfiguration = messageConfiguration;
+    }
+
+    /// <summary>
+    /// Accepts a user-defined message which is then published to an AWS service based on the
+    /// configuration done during startup. It retrieves the <see cref="PublisherMapping"/> corresponding to the
+    /// message type, which contains the routing information of the provided message.
+    /// The method wraps the message in a <see cref="MessageEnvelope"/> which contains metadata
+    /// that enables the proper transportation of the message throughout the framework.
+    /// </summary>
+    /// <param name="message">The message to be sent.</param>
+    /// <param name="token">The cancellation token used to cancel the request.</param>
+    public async Task PublishAsync<T>(T message, CancellationToken token = default)
+    {
+        var mapping = _messageConfiguration.GetPublisherMapping(typeof(T));
+        if (mapping == null)
+        {
+            throw new MissingMessageTypeConfigurationException($"The framework is not configured to accept messages of type '{typeof(T).FullName}'.");
+        }
+
+        switch (mapping.PublishTargetType)
+        {
+            case PublisherTargetType.SQS_PUBLISHER:
+                // TODO
+                break;
+            case PublisherTargetType.SNS_PUBLISHER:
+                // TODO
+                break;
+            case PublisherTargetType.EVENTBRIDGE_PUBLISHER:
+                // TODO
+                break;
+            default:
+                throw new UnsupportedPublisherException($"The publisher type '{mapping.PublishTargetType}' is not supported.");
+        }
+
+        await Task.CompletedTask;
+    }
+}

--- a/test/AWS.Messaging.UnitTests/MessageBusBuilderTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessageBusBuilderTests.cs
@@ -1,0 +1,115 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.EventBridge;
+using Amazon.Extensions.NETCore.Setup;
+using Amazon.SimpleNotificationService;
+using Amazon.SQS;
+using AWS.Messaging.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AWS.Messaging.UnitTests;
+
+public class MessageBusBuilderTests
+{
+    private readonly IServiceCollection _serviceCollection;
+
+    public MessageBusBuilderTests()
+    {
+        _serviceCollection = new ServiceCollection();
+        _serviceCollection.AddDefaultAWSOptions(new AWSOptions
+        {
+            Region = Amazon.RegionEndpoint.USWest2
+        });
+    }
+
+    [Fact]
+    public void BuildMessageBus()
+    {
+        _serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPublisher<OrderInfo>("sqsQueueUrl");
+        });
+
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+
+        var messageConfiguration = serviceProvider.GetService<IMessageConfiguration>();
+        Assert.NotNull(messageConfiguration);
+
+        var messagePublisher = serviceProvider.GetService<IMessagePublisher>();
+        Assert.NotNull(messagePublisher);
+    }
+
+    [Fact]
+    public void MessageBus_NoBuild_NoServices()
+    {
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+
+        var messageConfiguration = serviceProvider.GetService<IMessageConfiguration>();
+        Assert.Null(messageConfiguration);
+
+        var messagePublisher = serviceProvider.GetService<IMessagePublisher>();
+        Assert.Null(messagePublisher);
+    }
+
+    [Fact]
+    public void MessageBus_AddSQSQueue()
+    {
+        _serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPublisher<OrderInfo>("sqsQueueUrl");
+        });
+
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+
+        var sqsClient = serviceProvider.GetService<IAmazonSQS>();
+        Assert.NotNull(sqsClient);
+
+        var snsClient = serviceProvider.GetService<IAmazonSimpleNotificationService>();
+        Assert.Null(snsClient);
+
+        var eventBridgeClient = serviceProvider.GetService<IAmazonEventBridge>();
+        Assert.Null(eventBridgeClient);
+    }
+
+    [Fact]
+    public void MessageBus_AddSNSTopic()
+    {
+        _serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSNSPublisher<OrderInfo>("snsTopicUrl");
+        });
+
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+
+        var snsClient = serviceProvider.GetService<IAmazonSimpleNotificationService>();
+        Assert.NotNull(snsClient);
+
+        var sqsClient = serviceProvider.GetService<IAmazonSQS>();
+        Assert.Null(sqsClient);
+
+        var eventBridgeClient = serviceProvider.GetService<IAmazonEventBridge>();
+        Assert.Null(eventBridgeClient);
+    }
+
+    [Fact]
+    public void MessageBus_AddEventBus()
+    {
+        _serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddEventBridgePublisher<OrderInfo>("eventBusUrl");
+        });
+
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+
+        var eventBridgeClient = serviceProvider.GetService<IAmazonEventBridge>();
+        Assert.NotNull(eventBridgeClient);
+
+        var snsClient = serviceProvider.GetService<IAmazonSimpleNotificationService>();
+        Assert.Null(snsClient);
+
+        var sqsClient = serviceProvider.GetService<IAmazonSQS>();
+        Assert.Null(sqsClient);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6672

*Description of changes:*
Added more pieces to of the publisher and message bus to create a better connection of the components of the system. There are TODOs in certain places since this is not an implementation PR. Also added a working sample app that registers the Message Bus and adds an SQS queue that invokes the message publisher.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
