### PR TITLE
feat: Add default message serializer used by the framework

### DIFF
--- a/sampleapps/PublisherAPI/Program.cs
+++ b/sampleapps/PublisherAPI/Program.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Text.Json;
 using PublisherAPI.Models;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -11,6 +12,13 @@ builder.Services.AddControllers();
 builder.Services.AddAWSMessageBus(builder =>
 {
     builder.AddSQSPublisher<ChatMessage>("https://sqs.us-west-2.amazonaws.com/012345678910/MPF");
+    builder.ConfigureSerializationOptions(options =>
+    {
+        options.SystemTextJsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy= JsonNamingPolicy.CamelCase,
+        };
+    });
 });
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -45,4 +45,9 @@ public interface IMessageBusBuilder
     /// </summary>
     /// <param name="queueUrl">The SQS queue to poll for messages.</param>
     IMessageBusBuilder AddSQSPoller(string queueUrl);
+
+    /// <summary>
+    /// Configures an instance of <see cref="SerializationOptions"/> to control the serialization/de-serialization logic for the application message.
+    /// </summary>
+    IMessageBusBuilder ConfigureSerializationOptions(Action<SerializationOptions> options);
 }

--- a/src/AWS.Messaging/Configuration/IMessageConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/IMessageConfiguration.cs
@@ -36,4 +36,9 @@ public interface IMessageConfiguration
     /// List of configurations for subscriber to poll for messages from an AWS service endpoint.
     /// </summary>
     IList<IMessagePollerConfiguration> MessagePollerConfigurations { get; set; }
+
+    /// <summary>
+    /// Holds an instance of <see cref="SerializationOptions"/> to control the serialization/de-serialization of the application message.
+    /// </summary>
+    SerializationOptions SerializationOptions { get; }
 }

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -1,7 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using AWS.Messaging.Serialization;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace AWS.Messaging.Configuration;
 
@@ -64,9 +66,17 @@ public class MessageBusBuilder : IMessageBusBuilder
         return this;
     }
 
+    /// <inheritdoc/>
+    public IMessageBusBuilder ConfigureSerializationOptions(Action<SerializationOptions> options)
+    {
+        options(_messageConfiguration.SerializationOptions);
+        return this;
+    }
+
     internal void Build(IServiceCollection services)
     {
         services.AddSingleton<IMessageConfiguration>(_messageConfiguration);
+        services.AddSingleton<IMessageSerializer, MessageSerializer>();
 
         if (_messageConfiguration.PublisherMappings.Any())
         {

--- a/src/AWS.Messaging/Configuration/MessageConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/MessageConfiguration.cs
@@ -30,4 +30,7 @@ public class MessageConfiguration : IMessageConfiguration
 
     /// <inheritdoc/>
     public IList<IMessagePollerConfiguration> MessagePollerConfigurations { get; set; } = new List<IMessagePollerConfiguration>();
+
+    /// <inheritdoc/>
+    public SerializationOptions SerializationOptions { get; } = new SerializationOptions();
 }

--- a/src/AWS.Messaging/Configuration/SerializerOptions.cs
+++ b/src/AWS.Messaging/Configuration/SerializerOptions.cs
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace AWS.Messaging.Configuration;
+
+/// <summary>
+/// This class serves as a container to hold various serializer options that can control
+/// the serialization/de-serialization logic of the application message.
+/// </summary>
+public class SerializationOptions
+{
+    /// <summary>
+    /// This is an instance of <see cref="JsonSerializerOptions"/> that controls the serialization/de-serialization logic of the application message.
+    /// </summary>
+    public JsonSerializerOptions? SystemTextJsonOptions { get; set; }
+
+}

--- a/src/AWS.Messaging/Exceptions.cs
+++ b/src/AWS.Messaging/Exceptions.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using AWS.Messaging.Configuration;
+using AWS.Messaging.Serialization;
 
 namespace AWS.Messaging;
 
@@ -91,4 +92,26 @@ public class InvalidSubscriberEndpointException : AWSMessagingException
     /// Creates an instance of <see cref="InvalidSubscriberEndpointException"/>.
     /// </summary>
     public InvalidSubscriberEndpointException(string message, Exception? innerException = null) : base(message, innerException) { }
+}
+
+/// <summary>
+/// Thrown if failed to deserialize the application message while invoking <see cref="IMessageSerializer.Deserialize(string, Type)"/>
+/// </summary>
+public class FailedToDeserializeApplicationMessage : AWSMessagingException
+{
+    /// <summary>
+    /// Creates an instance of <see cref="FailedToDeserializeApplicationMessage"/>.
+    /// </summary>
+    public FailedToDeserializeApplicationMessage(string message, Exception? innerException = null) : base(message, innerException) { }
+}
+
+/// <summary>
+/// Thrown if failed to serialize the application message while invoking <see cref="IMessageSerializer.Serialize(object)"/>
+/// </summary>
+public class FailedToSerializeApplicationMessage : AWSMessagingException
+{
+    /// <summary>
+    /// Creates an instance of <see cref="FailedToSerializeApplicationMessage"/>.
+    /// </summary>
+    public FailedToSerializeApplicationMessage(string message, Exception? innerException = null) : base(message, innerException) { }
 }

--- a/src/AWS.Messaging/Serialization/MessageSerializer.cs
+++ b/src/AWS.Messaging/Serialization/MessageSerializer.cs
@@ -1,0 +1,59 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text.Json;
+using AWS.Messaging.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace AWS.Messaging.Serialization;
+
+/// <summary>
+/// This is the default implementation of <see cref="IMessageSerializer"/> used by the framework.
+/// It uses System.Text.Json to serialize and deserialize messages.
+/// </summary>
+internal class MessageSerializer : IMessageSerializer
+{
+    private readonly ILogger<MessageSerializer> _logger;
+    private readonly IMessageConfiguration _messageConfiguration;
+
+    public MessageSerializer(ILogger<MessageSerializer> logger, IMessageConfiguration messageConfiguration)
+    {
+        _logger = logger;
+        _messageConfiguration= messageConfiguration;
+    }
+
+    /// <inheritdoc/>
+    /// <exception cref="FailedToDeserializeApplicationMessage"></exception>
+    public object Deserialize(string message, Type deserializedType)
+    {
+        try
+        {
+            var jsonSerializerOptions = _messageConfiguration.SerializationOptions.SystemTextJsonOptions;
+            _logger.LogTrace("Deserializing the following message into type '{0}':\n{1}", deserializedType, message);
+            return JsonSerializer.Deserialize(message, deserializedType, jsonSerializerOptions) ?? throw new JsonException("The deserialized application message is null.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to deserialize application message into an instance of {0}.", deserializedType);
+            throw new FailedToDeserializeApplicationMessage($"Failed to deserialize application message into an instance of {deserializedType}.", ex);
+        }
+    }
+
+    /// <inheritdoc/>
+    /// <exception cref="FailedToSerializeApplicationMessage"></exception>
+    public string Serialize(object message)
+    {
+        try
+        {
+            var jsonSerializerOptions = _messageConfiguration.SerializationOptions.SystemTextJsonOptions;
+            var jsonString = JsonSerializer.Serialize(message, jsonSerializerOptions);
+            _logger.LogTrace("Serialized the message object as the following raw string:\n{0}", jsonString);
+            return jsonString;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to serialize application message into a string");
+            throw new FailedToSerializeApplicationMessage("Failed to serialize application message into a string", ex);
+        }
+    }
+}

--- a/test/AWS.Messaging.UnitTests/SerializationTests/MessageSerializerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/MessageSerializerTests.cs
@@ -1,0 +1,95 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text.Json.Serialization;
+using AWS.Messaging.Configuration;
+using AWS.Messaging.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace AWS.Messaging.UnitTests.SerializationTests;
+
+public class MessageSerializerTests
+{
+    [Fact]
+    public void Serialize()
+    {
+        // ARRANGE
+        IMessageSerializer serializer = new MessageSerializer(new NullLogger<MessageSerializer>(), new MessageConfiguration());
+        var person = new PersonInfo
+        {
+            FirstName= "Bob",
+            LastName = "Stone",
+            Age= 30,
+            Gender = Gender.Male,
+            Address= new AddressInfo
+            {
+                Unit = 12,
+                Street = "Prince St",
+                ZipCode = "00001"
+            }
+        };
+
+        // ACT
+        var jsonString = serializer.Serialize(person);
+
+        // ASSERT
+        var expectedString = "{\"FirstName\":\"Bob\",\"LastName\":\"Stone\",\"Age\":30,\"Gender\":\"Male\",\"Address\":{\"Unit\":12,\"Street\":\"Prince St\",\"ZipCode\":\"00001\"}}";
+        Assert.Equal(expectedString, jsonString);
+    }
+
+    [Fact]
+    public void Deserialize()
+    {
+        // ARRANGE
+        IMessageSerializer serializer = new MessageSerializer(new NullLogger<MessageSerializer>(), new MessageConfiguration());
+        var jsonString =
+            @"{
+                   ""FirstName"":""Bob"",
+                   ""LastName"":""Stone"",
+                   ""Age"":30,
+                   ""Gender"":""Male"",
+                   ""Address"":{
+                      ""Unit"":12,
+                      ""Street"":""Prince St"",
+                      ""ZipCode"":""00001""
+                   }
+                }";
+
+        // ACT
+        var message = serializer.Deserialize<PersonInfo>(jsonString);
+
+        // ASSERT
+        Assert.Equal("Bob", message.FirstName);
+        Assert.Equal("Stone", message.LastName);
+        Assert.Equal(30, message.Age);
+        Assert.Equal(Gender.Male, message.Gender);
+        Assert.Equal(12, message.Address?.Unit);
+        Assert.Equal("Prince St", message.Address?.Street);
+        Assert.Equal("00001", message.Address?.ZipCode);
+    }
+}
+
+class PersonInfo
+{
+    public string? FirstName { get; set; }
+    public string? LastName { get; set; }
+    public int Age { get; set; }
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public Gender Gender { get; set; }
+    public AddressInfo? Address { get; set; }
+}
+
+class AddressInfo
+{
+    public int Unit { get; set; }
+    public string? Street { get; set; }
+    public string? ZipCode { get; set; }
+}
+
+enum Gender
+{
+    Male,
+    Female
+}


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6662

*Description of changes:*
* Adds the default message serializer used by the framework
* Adds the ability to inject custom `JsonSerializerOptions` to customize the serialization/de-serialization logic.
* Adds supporting unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
