### PR TITLE
Add MessagePumpService

### DIFF
--- a/sampleapps/SubscriberService/Program.cs
+++ b/sampleapps/SubscriberService/Program.cs
@@ -3,10 +3,16 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using SubscriberService.MessageHandlers;
 using SubscriberService.Models;
 
 await Host.CreateDefaultBuilder(args)
+    .ConfigureLogging(logging =>
+    {
+        logging.ClearProviders();
+        logging.AddConsole().SetMinimumLevel(LogLevel.Debug);
+    })
     .ConfigureServices(services =>
     {
         services.AddAWSMessageBus(builder =>

--- a/src/AWS.Messaging/AWS.Messaging.csproj
+++ b/src/AWS.Messaging/AWS.Messaging.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.5" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.100.69" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
   </ItemGroup>
   

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using AWS.Messaging.Serialization;
+using AWS.Messaging.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -101,6 +102,17 @@ public class MessageBusBuilder : IMessageBusBuilder
             foreach (var subscriberMapping in _messageConfiguration.SubscriberMappings)
             {
                 services.AddSingleton(subscriberMapping.HandlerType);
+            }
+        }
+
+        if (_messageConfiguration.MessagePollerConfigurations.Any())
+        {
+            services.AddHostedService<MessagePumpService>();
+            services.TryAddSingleton<IMessagePollerFactory, DefaultMessagePollerFactory>();
+
+            if (_messageConfiguration.MessagePollerConfigurations.OfType<SQSMessagePollerConfiguration>().Any())
+            {
+                services.TryAddAWSService<Amazon.SQS.IAmazonSQS>();
             }
         }
     }

--- a/src/AWS.Messaging/Services/IMessagePollerFactory.cs
+++ b/src/AWS.Messaging/Services/IMessagePollerFactory.cs
@@ -23,7 +23,7 @@ public interface IMessagePollerFactory
 }
 
 /// <summary>
-/// Implemenation of <see cref="AWS.Messaging.Services.IMessagePollerFactory" /> that is the default registered factory into
+/// Implementation of <see cref="AWS.Messaging.Services.IMessagePollerFactory" /> that is the default registered factory into
 /// the <see cref="Microsoft.Extensions.DependencyInjection.IServiceCollection" /> unless a user has registered their own implementation.
 /// </summary>
 internal class DefaultMessagePollerFactory : IMessagePollerFactory

--- a/src/AWS.Messaging/Services/MessagePumpService.cs
+++ b/src/AWS.Messaging/Services/MessagePumpService.cs
@@ -1,0 +1,65 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Messaging.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace AWS.Messaging.Services;
+
+/// <summary>
+/// Starts an instance of an <see cref="IMessagePoller" /> for each
+/// configured <see cref="IMessagePollerConfiguration" />
+/// </summary>
+internal class MessagePumpService : BackgroundService
+{
+    private readonly ILogger<MessagePumpService> _logger;
+    private readonly IMessageConfiguration _messageConfiguration;
+    private readonly IMessagePollerFactory _messagePollerFactory;
+
+    /// <summary>
+    /// Creates an instance of <see cref="MessagePumpService" />
+    /// </summary>
+    /// <param name="logger">Logger for debugging information</param>
+    /// <param name="messageConfiguration">Configuration containing one or more <see cref="IMessagePollerConfiguration"/> instances to poll</param>
+    /// <param name="messagePollerFactory">Factory for creating a <see cref="IMessagePoller"/> for each configuration</param>
+    public MessagePumpService(ILogger<MessagePumpService> logger, IMessageConfiguration messageConfiguration, IMessagePollerFactory messagePollerFactory)
+    {
+        _logger = logger;
+        _messageConfiguration = messageConfiguration;
+        _messagePollerFactory = messagePollerFactory;
+    }
+
+    /// <summary>
+    /// Starts an instance of an <see cref="IMessagePoller" /> for each
+    /// configured <see cref="IMessagePollerConfiguration" />
+    /// </summary>
+    /// <param name="stoppingToken">Cancellation token that is passed into each poller</param>
+    /// <returns>A task representing all the pollers that were started</returns>
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var tasks = new List<Task>();
+
+        if (_messageConfiguration.MessagePollerConfigurations.Any())
+        {
+            foreach (var pollerConfiguration in _messageConfiguration.MessagePollerConfigurations)
+            {
+                var messagePoller = _messagePollerFactory.CreateMessagePoller(pollerConfiguration);
+
+                _logger.LogInformation("Starting polling: {subscriberEndpoint}", pollerConfiguration.SubscriberEndpoint);
+
+                var task = messagePoller.StartPollingAsync(stoppingToken);
+                task.ContinueWith(completedPollerTask =>
+                {
+                    if (completedPollerTask.IsFaulted && !stoppingToken.IsCancellationRequested )
+                    {
+                        _logger.LogError(completedPollerTask.Exception, "Poller for {subscriberEndpoint} failed for an unexpected reason.", pollerConfiguration.SubscriberEndpoint);
+                    }
+                });
+                tasks.Add(task);
+            }
+        }
+
+        return Task.WhenAll(tasks);
+    }
+}

--- a/test/AWS.Messaging.UnitTests/AWS.Messaging.UnitTests.csproj
+++ b/test/AWS.Messaging.UnitTests/AWS.Messaging.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -11,7 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/AWS.Messaging.UnitTests/MessagePumpServiceTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessagePumpServiceTests.cs
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Threading;
+using AWS.Messaging.Configuration;
+using AWS.Messaging.Services;
+using Moq;
+using Xunit;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AWS.Messaging.UnitTests;
+
+/// <summary>
+/// Unit tests for <see cref="MessagePumpService"/>
+/// </summary>
+public class MessagePumpServiceTests
+{
+    /// <summary>
+    /// Tests that <see cref="MessagePumpService"/> calls CreateMessagePoller
+    /// for each configured <see cref="SQSMessagePollerConfiguration"/>
+    /// </summary>
+    [Fact]
+    public void MessagePumpService_CreatesMessagePollers()
+    {
+        var queueA = new SQSMessagePollerConfiguration("queueA");
+        var queueB = new SQSMessagePollerConfiguration("queueB");
+
+        var configuration = new MessageConfiguration();
+        configuration.MessagePollerConfigurations = new List<IMessagePollerConfiguration>() { queueA, queueB };
+
+        var messagePollerFactoryMock = new Mock<IMessagePollerFactory>();
+        messagePollerFactoryMock.Setup(x => x.CreateMessagePoller(It.IsAny<IMessagePollerConfiguration>()))
+                                .Returns(new Mock<IMessagePoller>().Object);
+
+        var messagePumpService = new MessagePumpService(new NullLogger<MessagePumpService>(), configuration, messagePollerFactoryMock.Object);
+
+        var combinedTask = messagePumpService.StartAsync(new CancellationToken());
+
+        messagePollerFactoryMock.Verify(x => x.CreateMessagePoller(It.IsAny<IMessagePollerConfiguration>()), Times.Exactly(2));
+        messagePollerFactoryMock.Verify(x => x.CreateMessagePoller(queueA), Times.Once());
+        messagePollerFactoryMock.Verify(x => x.CreateMessagePoller(queueB), Times.Once());
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* DOTNET-6667

*Description of changes:*
Adds `MessagePumpService`, which starts an `IMessagePoller` instance for each `IMessagePollerConfiguration`.

Note: The sample `SubscriberService` app does not start up with this change, because `SQSMessagePoller` cannot be started without a `IMessageManagerFactory` instance (will be addressed in DOTNET-6666).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
