### PR TITLE
feat: add an implementation for an SNS publisher

### DIFF
--- a/sampleapps/PublisherAPI/Controllers/PublisherController.cs
+++ b/sampleapps/PublisherAPI/Controllers/PublisherController.cs
@@ -34,4 +34,21 @@ public class PublisherController : ControllerBase
 
         return Ok();
     }
+
+    [HttpPost("order", Name = "Order")]
+    public async Task<IActionResult> PublishOrder([FromBody] OrderInfo message)
+    {
+        if (message == null)
+        {
+            return BadRequest("A chat message was not used.");
+        }
+        if (string.IsNullOrEmpty(message.UserId))
+        {
+            return BadRequest("The MessageDescription cannot be null or empty.");
+        }
+
+        await _messagePublisher.PublishAsync(message);
+
+        return Ok();
+    }
 }

--- a/sampleapps/PublisherAPI/Models/OrderInfo.cs
+++ b/sampleapps/PublisherAPI/Models/OrderInfo.cs
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace PublisherAPI.Models;
+
+public class OrderInfo
+{
+    public string OrderId { get; set; } = string.Empty;
+
+    public string UserId { get; set; } = string.Empty;
+}

--- a/sampleapps/PublisherAPI/Program.cs
+++ b/sampleapps/PublisherAPI/Program.cs
@@ -12,6 +12,7 @@ builder.Services.AddControllers();
 builder.Services.AddAWSMessageBus(builder =>
 {
     builder.AddSQSPublisher<ChatMessage>("https://sqs.us-west-2.amazonaws.com/012345678910/MPF");
+    builder.AddSNSPublisher<OrderInfo>("arn:aws:sns:us-west-2:012345678910:MPF");
     builder.ConfigureSerializationOptions(options =>
     {
         options.SystemTextJsonOptions = new JsonSerializerOptions

--- a/src/AWS.Messaging/Publishers/MessageRoutingPublisher.cs
+++ b/src/AWS.Messaging/Publishers/MessageRoutingPublisher.cs
@@ -34,7 +34,8 @@ internal class MessageRoutingPublisher : IMessagePublisher
 
     private readonly Dictionary<string, Type> _publisherTypeMapping = new()
         {
-            { PublisherTargetType.SQS_PUBLISHER, typeof(SQSPublisher) }
+            { PublisherTargetType.SQS_PUBLISHER, typeof(SQSPublisher) },
+            { PublisherTargetType.SNS_PUBLISHER, typeof(SNSPublisher) }
         };
 
     /// <summary>

--- a/src/AWS.Messaging/Publishers/SNSPublisher.cs
+++ b/src/AWS.Messaging/Publishers/SNSPublisher.cs
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.SimpleNotificationService;
+using Amazon.SimpleNotificationService.Model;
+using AWS.Messaging.Configuration;
+using AWS.Messaging.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace AWS.Messaging.Publishers;
+
+/// <summary>
+/// The SNS message publisher allows publishing messages to AWS Simple Notification Service.
+/// </summary>
+internal class SNSPublisher : IMessagePublisher
+{
+    private readonly IAmazonSimpleNotificationService _snsClient;
+    private readonly ILogger<IMessagePublisher> _logger;
+    private readonly IMessageConfiguration _messageConfiguration;
+    private readonly IEnvelopeSerializer _envelopeSerializer;
+
+    /// <summary>
+    /// Creates an instance of <see cref="SNSPublisher"/>.
+    /// </summary>
+    public SNSPublisher(
+        IAmazonSimpleNotificationService snsClient,
+        ILogger<IMessagePublisher> logger,
+        IMessageConfiguration messageConfiguration,
+        IEnvelopeSerializer envelopeSerializer)
+    {
+        _snsClient = snsClient;
+        _logger = logger;
+        _messageConfiguration = messageConfiguration;
+        _envelopeSerializer = envelopeSerializer;
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <exception cref="InvalidMessageException">If the message is null or invalid.</exception>
+    /// <exception cref="MissingMessageTypeConfigurationException">If cannot find the publisher configuration for the message type.</exception>
+    public async Task PublishAsync<T>(T message, CancellationToken token = default)
+    {
+        _logger.LogDebug("Publishing the message of type '{messageType}' using the {publisherType}.", typeof(T), nameof(SQSPublisher));
+
+        if (message == null)
+        {
+            _logger.LogError("A message of type '{messageType}' has a null value.", typeof(T));
+            throw new InvalidMessageException("The message cannot be null.");
+        }
+
+        var mapping = _messageConfiguration.GetPublisherMapping(typeof(T));
+        if (mapping == null)
+        {
+            _logger.LogError("Cannot find a configuration for the message of type '{messageType}'.", typeof(T));
+            throw new MissingMessageTypeConfigurationException($"The framework is not configured to accept messages of type '{typeof(T).FullName}'.");
+        }
+
+        _logger.LogDebug("Creating the message envelope for the message of type '{messageType}'.", typeof(T));
+        var messageEnvelope = _envelopeSerializer.ConvertToEnvelope<T>(message);
+        var messageBody = _envelopeSerializer.Serialize(messageEnvelope);
+
+        var request = new PublishRequest
+        {
+            TopicArn = mapping.PublisherConfiguration.PublisherEndpoint,
+            Message = messageBody
+        };
+
+        _logger.LogDebug("Sending the message of type '{messageType}' to SNS.", typeof(T));
+        await _snsClient.PublishAsync(request);
+        _logger.LogDebug("The message of type '{messageType}' has been pushed to SNS.", typeof(T));
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6670

*Description of changes:*
* Add an SNS implementation for IMessagePublisher.
  Note: We still do not have a functioning publisher pending an implementation of IEnvelopeSerializer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
