### PR TITLE
feat: Add default envelope serializer used by the framework

### DIFF
--- a/src/AWS.Messaging/Configuration/IMessageConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/IMessageConfiguration.cs
@@ -33,6 +33,13 @@ public interface IMessageConfiguration
     SubscriberMapping? GetSubscriberMapping(Type messageType);
 
     /// <summary>
+    /// Returns back the subscriber mapping for the given message type identifier.
+    /// </summary>
+    /// <param name="messageTypeIdentifier">The language agnostic identifier for the application message</param>
+    /// <returns>The <see cref="SubscriberMapping"/> containing routing info for the specified message type.</returns>
+    SubscriberMapping? GetSubscriberMapping(string messageTypeIdentifier);
+
+    /// <summary>
     /// List of configurations for subscriber to poll for messages from an AWS service endpoint.
     /// </summary>
     IList<IMessagePollerConfiguration> MessagePollerConfigurations { get; set; }

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -92,7 +92,10 @@ public class MessageBusBuilder : IMessageBusBuilder
     internal void Build(IServiceCollection services)
     {
         services.AddSingleton<IMessageConfiguration>(_messageConfiguration);
-        services.AddSingleton<IMessageSerializer, MessageSerializer>();
+        services.TryAddSingleton<IMessageSerializer, MessageSerializer>();
+        services.TryAddSingleton<IEnvelopeSerializer, EnvelopeSerializer>();
+        services.TryAddSingleton<IDateTimeHandler, DateTimeHandler>();
+        services.TryAddSingleton<IMessageIdGenerator, MessageIdGenerator>();
 
         if (_messageConfiguration.PublisherMappings.Any())
         {

--- a/src/AWS.Messaging/Configuration/MessageConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/MessageConfiguration.cs
@@ -29,6 +29,13 @@ public class MessageConfiguration : IMessageConfiguration
     }
 
     /// <inheritdoc/>
+    public SubscriberMapping? GetSubscriberMapping(string messageTypeIdentifier)
+    {
+        var subscriberMapping = SubscriberMappings.FirstOrDefault(x => messageTypeIdentifier == x.MessageTypeIdentifier);
+        return subscriberMapping;
+    }
+
+    /// <inheritdoc/>
     public IList<IMessagePollerConfiguration> MessagePollerConfigurations { get; set; } = new List<IMessagePollerConfiguration>();
 
     /// <inheritdoc/>

--- a/src/AWS.Messaging/Configuration/SerializerOptions.cs
+++ b/src/AWS.Messaging/Configuration/SerializerOptions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace AWS.Messaging.Configuration;
@@ -19,6 +20,8 @@ public class SerializationOptions
     /// <summary>
     /// This is an instance of <see cref="JsonSerializerOptions"/> that controls the serialization/de-serialization logic of the application message.
     /// </summary>
-    public JsonSerializerOptions? SystemTextJsonOptions { get; set; }
-
+    public JsonSerializerOptions? SystemTextJsonOptions { get; set; } = new JsonSerializerOptions
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
 }

--- a/src/AWS.Messaging/Exceptions.cs
+++ b/src/AWS.Messaging/Exceptions.cs
@@ -97,23 +97,23 @@ public class InvalidSubscriberEndpointException : AWSMessagingException
 /// <summary>
 /// Thrown if failed to deserialize the application message while invoking <see cref="IMessageSerializer.Deserialize(string, Type)"/>
 /// </summary>
-public class FailedToDeserializeApplicationMessage : AWSMessagingException
+public class FailedToDeserializeApplicationMessageException : AWSMessagingException
 {
     /// <summary>
-    /// Creates an instance of <see cref="FailedToDeserializeApplicationMessage"/>.
+    /// Creates an instance of <see cref="FailedToDeserializeApplicationMessageException"/>.
     /// </summary>
-    public FailedToDeserializeApplicationMessage(string message, Exception? innerException = null) : base(message, innerException) { }
+    public FailedToDeserializeApplicationMessageException(string message, Exception? innerException = null) : base(message, innerException) { }
 }
 
 /// <summary>
 /// Thrown if failed to serialize the application message while invoking <see cref="IMessageSerializer.Serialize(object)"/>
 /// </summary>
-public class FailedToSerializeApplicationMessage : AWSMessagingException
+public class FailedToSerializeApplicationMessageException : AWSMessagingException
 {
     /// <summary>
-    /// Creates an instance of <see cref="FailedToSerializeApplicationMessage"/>.
+    /// Creates an instance of <see cref="FailedToSerializeApplicationMessageException"/>.
     /// </summary>
-    public FailedToSerializeApplicationMessage(string message, Exception? innerException = null) : base(message, innerException) { }
+    public FailedToSerializeApplicationMessageException(string message, Exception? innerException = null) : base(message, innerException) { }
 }
 
 /// <summary>
@@ -125,4 +125,26 @@ public class InvalidMessageException : AWSMessagingException
     /// Creates an instance of <see cref="InvalidMessageException"/>.
     /// </summary>
     public InvalidMessageException(string message, Exception? innerException = null) : base(message, innerException) { }
+}
+
+/// <summary>
+/// Thrown if failed to create a <see cref="MessageEnvelope"/>
+/// </summary>
+public class FailedToCreateMessageEnvelopeException : AWSMessagingException
+{
+    /// <summary>
+    /// Creates an instance of <see cref="FailedToCreateMessageEnvelopeException"/>
+    /// </summary>
+    public FailedToCreateMessageEnvelopeException(string message, Exception? innerException = null) : base(message, innerException) { }
+}
+
+/// <summary>
+/// Thrown if failed to serialize a <see cref="MessageEnvelope"/>
+/// </summary>
+public class FailedToSerializeMessageEnvelopeException : AWSMessagingException
+{
+    /// <summary>
+    /// Creates an instance of <see cref="FailedToSerializeMessageEnvelopeException"/>
+    /// </summary>
+    public FailedToSerializeMessageEnvelopeException(string message, Exception? innerException = null) : base(message, innerException) { }
 }

--- a/src/AWS.Messaging/MessageEnvelope.cs
+++ b/src/AWS.Messaging/MessageEnvelope.cs
@@ -16,38 +16,38 @@ public abstract class MessageEnvelope
     /// Specifies the envelope ID
     /// </summary>
     [JsonPropertyName("id")]
-    public string Id { get; set; }
+    public string Id { get; set; } = null!;
 
     /// <summary>
     /// Specifies the source of the event.
     /// This can be the organization publishing the event or the process that produced the event.
     /// </summary>
     [JsonPropertyName("source")]
-    public Uri Source { get; set; }
+    public Uri Source { get; set; } = null!;
 
     /// <summary>
     /// The version of the CloudEvents specification which the event uses.
     /// </summary>
     [JsonPropertyName("specversion")]
-    public string Version { get; set; }
+    public string Version { get; set; } = null!;
 
     /// <summary>
     /// The type of event that occurred. This represents the language agnostic type that is used to deserialize the envelope message into a .NET type.
     /// </summary>
     [JsonPropertyName("type")]
-    public string Type { get; set; }
+    public string MessageTypeIdentifier { get; set; } = null!;
 
     /// <summary>
     /// The timestamp when the event occurred.
     /// </summary>
     [JsonPropertyName("time")]
-    public DateTime TimeStamp { get; set; }
+    public DateTimeOffset TimeStamp { get; set; } = DateTimeOffset.MinValue;
 
     /// <summary>
     /// This stores different metadata that is not modeled as a top-level property in MessageEnvelope class.
     /// </summary>
     [JsonExtensionData]
-    public Dictionary<string, object>? Metadata { get; set; } = new Dictionary<string, object>();
+    public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 
     /// <summary>
     /// Stores metadata related to Amazon SQS.
@@ -55,20 +55,10 @@ public abstract class MessageEnvelope
     public SQSMetadata? SQSMetadata { get; set; }
 
     /// <summary>
-    /// Creates a MessageEnvelope object that is aligned with CloudEvents specification v1.0
+    /// Attaches the user specified application message to the <see cref="MessageEnvelope"/>
     /// </summary>
-    public MessageEnvelope(string id,
-        Uri source,
-        string version,
-        string type,
-        DateTime timeStamp)
-    {
-        Id = id;
-        Source = source;
-        Version = version;
-        Type = type;
-        TimeStamp = timeStamp;
-    }
+    /// <param name="message">The user specified application message.</param>
+    internal abstract void SetMessage(object message);
 }
 
 /// <summary>
@@ -79,22 +69,17 @@ public abstract class MessageEnvelope
 public class MessageEnvelope<T> : MessageEnvelope
 {
     /// <summary>
-    /// Creates a MessageEnvelope object that is aligned with CloudEvents specification v1.0
-    /// </summary>
-    public MessageEnvelope(string id,
-        Uri source,
-        string version,
-        string type,
-        DateTime timeStamp,
-        T message)
-        : base(id, source, version, type, timeStamp)
-    {
-        Message = message;
-    }
-
-    /// <summary>
     /// The application message that will be processed.
     /// </summary>
     [JsonPropertyName("data")]
-    public T Message { get; set; }
+    public T Message { get; set; } = default!;
+
+    /// <summary>
+    /// Attaches the user specified application message to the <see cref="MessageEnvelope{T}.Message"/> property.
+    /// </summary>
+    /// <param name="message">The user specified application message.</param>
+    internal override void SetMessage(object message)
+    {
+        Message = (T)message;
+    }
 }

--- a/src/AWS.Messaging/Publishers/EventBridgePublisher.cs
+++ b/src/AWS.Messaging/Publishers/EventBridgePublisher.cs
@@ -57,7 +57,7 @@ internal class EventBridgePublisher : IMessagePublisher
         }
 
         _logger.LogDebug("Creating the message envelope for the message of type '{messageType}'.", typeof(T));
-        var messageEnvelope = _envelopeSerializer.ConvertToEnvelope<T>(message);
+        var messageEnvelope = await _envelopeSerializer.CreateEnvelopeAsync<T>(message);
         var messageBody = _envelopeSerializer.Serialize(messageEnvelope);
 
         var request = new PutEventsRequest

--- a/src/AWS.Messaging/Publishers/SNSPublisher.cs
+++ b/src/AWS.Messaging/Publishers/SNSPublisher.cs
@@ -57,7 +57,7 @@ internal class SNSPublisher : IMessagePublisher
         }
 
         _logger.LogDebug("Creating the message envelope for the message of type '{messageType}'.", typeof(T));
-        var messageEnvelope = _envelopeSerializer.ConvertToEnvelope<T>(message);
+        var messageEnvelope = await _envelopeSerializer.CreateEnvelopeAsync(message);
         var messageBody = _envelopeSerializer.Serialize(messageEnvelope);
 
         var request = new PublishRequest

--- a/src/AWS.Messaging/Publishers/SQSPublisher.cs
+++ b/src/AWS.Messaging/Publishers/SQSPublisher.cs
@@ -57,7 +57,7 @@ internal class SQSPublisher : IMessagePublisher
         }
 
         _logger.LogDebug("Creating the message envelope for the message of type '{messageType}'.", typeof(T));
-        var messageEnvelope = _envelopeSerializer.ConvertToEnvelope<T>(message);
+        var messageEnvelope = await _envelopeSerializer.CreateEnvelopeAsync(message);
         var messageBody = _envelopeSerializer.Serialize(messageEnvelope);
 
         var request = new SendMessageRequest

--- a/src/AWS.Messaging/Serialization/ConvertToEnvelopeResult.cs
+++ b/src/AWS.Messaging/Serialization/ConvertToEnvelopeResult.cs
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.SQS.Model;
+using AWS.Messaging.Configuration;
+
+namespace AWS.Messaging.Serialization;
+
+/// <summary>
+/// Indicates the result of <see cref="EnvelopeSerializer.ConvertToEnvelope(Message)"/>
+/// </summary>
+public class ConvertToEnvelopeResult
+{
+    /// <summary>
+    /// The <see cref="MessageEnvelope"/> that is created by deserializing the service response.
+    /// </summary>
+    public MessageEnvelope Envelope { get; init; }
+
+    /// <summary>
+    /// The <see cref="SubscriberMapping"/> that was identified for the service response, and should be used for further processing of <see cref="Envelope"/>.
+    /// </summary>
+    public SubscriberMapping Mapping { get; init; }
+
+    /// <summary>
+    /// Creates an instance of <see cref="ConvertToEnvelopeResult"/>
+    /// </summary>
+    /// <param name="envelope">The <see cref="MessageEnvelope"/> that is created by deserializing the service response.</param>
+    /// <param name="subscriberMapping">The <see cref="SubscriberMapping"/> that was identified for the service response, and should be used for further processing of <see cref="Envelope"/>.</param>
+    public ConvertToEnvelopeResult(MessageEnvelope envelope, SubscriberMapping subscriberMapping)
+    {
+        Envelope = envelope;
+        Mapping = subscriberMapping;
+    }
+}

--- a/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
+++ b/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
@@ -1,0 +1,176 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Amazon.SQS.Model;
+using AWS.Messaging.Configuration;
+using AWS.Messaging.Services;
+using Microsoft.Extensions.Logging;
+
+namespace AWS.Messaging.Serialization;
+
+/// <summary>
+/// The default implementation of <see cref="IEnvelopeSerializer"/> used by the framework.
+/// </summary>
+internal class EnvelopeSerializer : IEnvelopeSerializer
+{
+    private const string CLOUD_EVENT_SPEC_VERSION = "1.0";
+
+    private readonly IMessageConfiguration _messageConfiguration;
+    private readonly IMessageSerializer _messageSerializer;
+    private readonly IDateTimeHandler _dateTimeHandler;
+    private readonly IMessageIdGenerator _messageIdGenerator;
+    private readonly ILogger<EnvelopeSerializer> _logger;
+
+    public EnvelopeSerializer(ILogger<EnvelopeSerializer> logger, IMessageConfiguration messageConfiguration, IMessageSerializer messageSerializer, IDateTimeHandler dateTimeHandler, IMessageIdGenerator messageIdGenerator)
+    {
+        _logger = logger;
+        _messageConfiguration = messageConfiguration;
+        _messageSerializer = messageSerializer;
+        _dateTimeHandler = dateTimeHandler;
+        _messageIdGenerator = messageIdGenerator;
+    }
+
+    // <inheritdoc/>
+    public async ValueTask<MessageEnvelope<T>> CreateEnvelopeAsync<T>(T message)
+    {
+        var messageId = await _messageIdGenerator.GenerateIdAsync();
+        var timeStamp = _dateTimeHandler.GetUtcNow();
+        var source = new Uri("/aws/messaging", UriKind.Relative); // TODO: This is a dummy value. The actual value will come via the publisher configuration (pending implementation).
+
+        var publisherMapping = _messageConfiguration.GetPublisherMapping(typeof(T));
+        if (publisherMapping is null)
+        {
+            _logger.LogError("Failed to create a message envelope because a valid publisher mapping for message type '{0}' does not exist.", typeof(T));
+            throw new FailedToCreateMessageEnvelopeException($"Failed to create a message envelope because a valid publisher mapping for message type '{typeof(T)}' does not exist.");
+        }
+
+        return new MessageEnvelope<T>
+        {
+            Id = messageId,
+            Source = source,
+            Version = CLOUD_EVENT_SPEC_VERSION,
+            MessageTypeIdentifier = publisherMapping.MessageTypeIdentifier,
+            TimeStamp = timeStamp,
+            Message = message
+        };
+    }
+
+    /// <summary>
+    /// Serializes the <see cref="MessageEnvelope{T}"/> into a raw string representing a JSON blob
+    /// </summary>
+    /// <typeparam name="T">The .NET type of the uderlying application message held by <see cref="MessageEnvelope{T}.Message"/></typeparam>
+    /// <param name="envelope">The <see cref="MessageEnvelope{T}"/> instance that will be serialized</param>
+    /// <returns></returns>
+    public string Serialize<T>(MessageEnvelope<T> envelope)
+    {
+        try
+        {
+            var message = envelope.Message ?? throw new ArgumentNullException("The underlying application message cannot be null");
+
+            // This blob serves as an intermediate data container because the underlying application message
+            // must be serialized seperately as the _messageSerializer can have a user injected implementation.
+            var blob = new JsonObject
+            {
+                ["id"] = envelope.Id,
+                ["source"] = envelope.Source?.ToString(),
+                ["specversion"] = envelope.Version,
+                ["type"] = envelope.MessageTypeIdentifier,
+                ["time"] = envelope.TimeStamp,
+                ["data"] = _messageSerializer.Serialize(envelope.Message)
+            };
+
+            var jsonString = blob.ToJsonString();
+            _logger.LogTrace("Serialized the MessageEnvelope object as the following raw string:\n{jsonString}", jsonString);
+            return jsonString;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to serialize the MessageEnvelope into a JSON string");
+            throw new FailedToSerializeMessageEnvelopeException("Failed to serialize the MessageEnvelope into a JSON string", ex);
+        }
+    }
+
+    // <inheritdoc/>
+    public ConvertToEnvelopeResult ConvertToEnvelope(Message sqsMessage)
+    {
+        try
+        {
+            var intermediateEnvelope = JsonSerializer.Deserialize<MessageEnvelope<string>>(sqsMessage.Body)!;
+            ValidateMessageEnvelope(intermediateEnvelope);
+            var messageTypeIdentifier = intermediateEnvelope.MessageTypeIdentifier;
+            var subscriberMapping = _messageConfiguration.GetSubscriberMapping(messageTypeIdentifier);
+            if (subscriberMapping is null)
+            {
+                _logger.LogError("{messageConfiguration} does not have a valid subscriber mapping for message ID '{messageTypeIdentifier}'", nameof(_messageConfiguration), messageTypeIdentifier);
+                throw new InvalidDataException($"{nameof(_messageConfiguration)} does not have a valid subscriber mapping for {nameof(messageTypeIdentifier)} '{messageTypeIdentifier}'");
+            }
+
+            var messageType = subscriberMapping.MessageType;
+            var message = _messageSerializer.Deserialize(intermediateEnvelope.Message, messageType);
+            var messageEnvelopeType = typeof(MessageEnvelope<>).MakeGenericType(messageType);
+
+            if (Activator.CreateInstance(messageEnvelopeType) is not MessageEnvelope finalMessageEnvelope)
+            {
+                _logger.LogError("Failed to create a messageEnvelope of type '{messageEnvelopeType}'", messageEnvelopeType.FullName);
+                throw new InvalidOperationException($"Failed to create a {nameof(MessageEnvelope)} of type '{messageEnvelopeType.FullName}'");
+            }
+
+            finalMessageEnvelope.Id = intermediateEnvelope.Id;
+            finalMessageEnvelope.Source = intermediateEnvelope.Source;
+            finalMessageEnvelope.Version = intermediateEnvelope.Version;
+            finalMessageEnvelope.MessageTypeIdentifier = intermediateEnvelope.MessageTypeIdentifier;
+            finalMessageEnvelope.TimeStamp = intermediateEnvelope.TimeStamp;
+            finalMessageEnvelope.Metadata = intermediateEnvelope.Metadata;
+            finalMessageEnvelope.SetMessage(message);
+
+            var result = new ConvertToEnvelopeResult(finalMessageEnvelope, subscriberMapping);
+
+            _logger.LogTrace("Created a generic {messageEnvelopeName} of type '{messageEnvelopeType}'", nameof(MessageEnvelope), result.Envelope.GetType());
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create a {messageEnvelopeName}", nameof(MessageEnvelope));
+            throw new FailedToCreateMessageEnvelopeException($"Failed to create {nameof(MessageEnvelope)}", ex);
+        }
+    }
+
+    private void ValidateMessageEnvelope<T>(MessageEnvelope<T>? messageEnvelope)
+    {
+        if (messageEnvelope is null)
+        {
+            _logger.LogError("{messageEnvelope} cannot be null", nameof(messageEnvelope));
+            throw new InvalidDataException($"{nameof(messageEnvelope)} cannot be null");
+        }
+
+        var strBuilder = new StringBuilder();
+
+        if (string.IsNullOrEmpty(messageEnvelope.Id))
+            strBuilder.Append($"{nameof(messageEnvelope.Id)} cannot be null or empty.{Environment.NewLine}");
+
+        if (messageEnvelope.Source is null)
+            strBuilder.Append($"{nameof(messageEnvelope.Source)} cannot be null.{Environment.NewLine}");
+
+        if (string.IsNullOrEmpty(messageEnvelope.Version))
+            strBuilder.Append($"{nameof(messageEnvelope.Version)} cannot be null or empty.{Environment.NewLine}");
+
+        if (string.IsNullOrEmpty(messageEnvelope.MessageTypeIdentifier))
+            strBuilder.Append($"{nameof(messageEnvelope.MessageTypeIdentifier)} cannot be null or empty.{Environment.NewLine}");
+
+        if (messageEnvelope.TimeStamp == DateTimeOffset.MinValue)
+            strBuilder.Append($"{nameof(messageEnvelope.TimeStamp)} is not set.");
+
+        if (messageEnvelope.Message is null)
+            strBuilder.Append($"{nameof(messageEnvelope.Message)} cannot be null.{Environment.NewLine}");
+
+        var validationFailures = strBuilder.ToString();
+        if (!string.IsNullOrEmpty(validationFailures))
+        {
+            _logger.LogError("MessageEnvelope instance is not valid{newline}{errorMessage}", Environment.NewLine, validationFailures);
+            throw new InvalidDataException($"MessageEnvelope instance is not valid{Environment.NewLine}{validationFailures}");
+        }
+    }
+}

--- a/src/AWS.Messaging/Serialization/IEnvelopeSerializer.cs
+++ b/src/AWS.Messaging/Serialization/IEnvelopeSerializer.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using Amazon.SQS.Model;
+
 namespace AWS.Messaging.Serialization;
 
 /// <summary>
@@ -15,19 +17,15 @@ public interface IEnvelopeSerializer
     string Serialize<T>(MessageEnvelope<T> envelope);
 
     /// <summary>
-    /// Converts the specified message object into <see cref="MessageEnvelope"/>
-    /// </summary>
-    /// <param name="message">The message object that will be transformed into a <see cref="MessageEnvelope"/></param>
-    /// <param name="messageDataType">The .NET type of the underlying application message.</param>
-    MessageEnvelope ConvertToEnvelope(object message, Type messageDataType);
-
-    /// <summary>
-    /// Converts the specified message object into <see cref="MessageEnvelope"/>
+    /// Creates a <see cref="MessageEnvelope{T}"/>
     /// </summary>
     /// <typeparam name="T">The .NET type of the underlying application message.</typeparam>
-    /// <param name="message">The message object that will be transformed into a <see cref="MessageEnvelope"/></param>
-    MessageEnvelope<T> ConvertToEnvelope<T>(object message)
-    {
-        return (MessageEnvelope<T>)ConvertToEnvelope(message, typeof(T));
-    }
+    /// <param name="message">The application message sent by the user</param>
+    ValueTask<MessageEnvelope<T>> CreateEnvelopeAsync<T>(T message);
+
+    /// <summary>
+    /// Takes an SQS <see cref="Message"/> and converts the <see cref="Message.Body"/> into a <see cref="MessageEnvelope"/>
+    /// </summary>
+    /// <param name="message">The SQS <see cref="Message"/> sent by the user</param>
+    ConvertToEnvelopeResult ConvertToEnvelope(Message message);
 }

--- a/src/AWS.Messaging/Serialization/MessageSerializer.cs
+++ b/src/AWS.Messaging/Serialization/MessageSerializer.cs
@@ -23,7 +23,7 @@ internal class MessageSerializer : IMessageSerializer
     }
 
     /// <inheritdoc/>
-    /// <exception cref="FailedToDeserializeApplicationMessage"></exception>
+    /// <exception cref="FailedToDeserializeApplicationMessageException"></exception>
     public object Deserialize(string message, Type deserializedType)
     {
         try
@@ -35,12 +35,12 @@ internal class MessageSerializer : IMessageSerializer
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to deserialize application message into an instance of {0}.", deserializedType);
-            throw new FailedToDeserializeApplicationMessage($"Failed to deserialize application message into an instance of {deserializedType}.", ex);
+            throw new FailedToDeserializeApplicationMessageException($"Failed to deserialize application message into an instance of {deserializedType}.", ex);
         }
     }
 
     /// <inheritdoc/>
-    /// <exception cref="FailedToSerializeApplicationMessage"></exception>
+    /// <exception cref="FailedToSerializeApplicationMessageException"></exception>
     public string Serialize(object message)
     {
         try
@@ -53,7 +53,7 @@ internal class MessageSerializer : IMessageSerializer
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to serialize application message into a string");
-            throw new FailedToSerializeApplicationMessage("Failed to serialize application message into a string", ex);
+            throw new FailedToSerializeApplicationMessageException("Failed to serialize application message into a string", ex);
         }
     }
 }

--- a/src/AWS.Messaging/Services/DateTimeHandler.cs
+++ b/src/AWS.Messaging/Services/DateTimeHandler.cs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Services;
+
+/// <summary>
+/// This class contains methods that deal with dates and time. It is the default implementation of <see cref="IDateTimeHandler"/>.
+/// </summary>
+internal class DateTimeHandler : IDateTimeHandler
+{
+    /// <summary>
+    /// Returns the current time in UTC as a <see cref="DateTimeOffset"/> object.
+    /// </summary>
+    public DateTimeOffset GetUtcNow()
+    {
+        return DateTimeOffset.UtcNow;
+    }
+}

--- a/src/AWS.Messaging/Services/IDateTimeHandler.cs
+++ b/src/AWS.Messaging/Services/IDateTimeHandler.cs
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Services;
+
+/// <summary>
+/// Interface that exposes methods dealing with DateTime
+/// </summary>
+public interface IDateTimeHandler
+{
+    /// <summary>
+    /// Returns the current DateTime in UTC
+    /// </summary>
+    DateTimeOffset GetUtcNow();
+}

--- a/src/AWS.Messaging/Services/IMessageIdGenerator.cs
+++ b/src/AWS.Messaging/Services/IMessageIdGenerator.cs
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Services;
+
+/// <summary>
+/// This interface provides the functionality to generate a unique message ID.
+/// </summary>
+public interface IMessageIdGenerator
+{
+    /// <summary>
+    /// Returns a unique ID.
+    /// </summary>
+    ValueTask<string> GenerateIdAsync();
+}

--- a/src/AWS.Messaging/Services/MessageIdGenerator.cs
+++ b/src/AWS.Messaging/Services/MessageIdGenerator.cs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Services;
+
+/// <summary>
+/// This is the default implementation of <see cref="IMessageIdGenerator"/> that is used by the framework.
+/// </summary>
+internal class MessageIdGenerator : IMessageIdGenerator
+{
+    /// <summary>
+    /// Returns a new GUID represented as string.
+    /// </summary>
+    public ValueTask<string> GenerateIdAsync()
+    {
+        return ValueTask.FromResult(Guid.NewGuid().ToString());
+    }
+}

--- a/test/AWS.Messaging.UnitTests/MessageEnvelopeTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessageEnvelopeTests.cs
@@ -45,10 +45,10 @@ public class MessageEnvelopeTests
         Assert.NotNull(messageEnvelope);
         Assert.Equal("A1234", messageEnvelope.Id);
         Assert.Equal("1.0", messageEnvelope.Version);
-        Assert.Equal("order-info", messageEnvelope.Type);
-        Assert.Equal("/backend-service/order-placed", messageEnvelope.Source.ToString());
+        Assert.Equal("order-info", messageEnvelope.MessageTypeIdentifier);
+        Assert.Equal("/backend-service/order-placed", messageEnvelope.Source!.ToString());
         Assert.Equal(new DateTime(2018, 4, 5, 17, 31, 0), messageEnvelope.TimeStamp);
-        Assert.Equal("Bob", messageEnvelope.Message.Name);
+        Assert.Equal("Bob", messageEnvelope.Message!.Name);
         Assert.Equal("my-city", messageEnvelope.Message.City);
         Assert.Equal("t-shirt", messageEnvelope.Message.Merchandise);
         Assert.NotNull(messageEnvelope.Metadata);

--- a/test/AWS.Messaging.UnitTests/MessageHandlers/Handlers.cs
+++ b/test/AWS.Messaging.UnitTests/MessageHandlers/Handlers.cs
@@ -14,3 +14,11 @@ public class ChatMessageHandler : IMessageHandler<ChatMessage>
         return Task.FromResult(MessageProcessStatus.Success());
     }
 }
+
+public class AddressInfoHandler : IMessageHandler<AddressInfo>
+{
+    public Task<MessageProcessStatus> HandleAsync(MessageEnvelope<AddressInfo> messageEnvelope, CancellationToken token = default)
+    {
+        return Task.FromResult(MessageProcessStatus.Success());
+    }
+}

--- a/test/AWS.Messaging.UnitTests/Models/ChatMessage.cs
+++ b/test/AWS.Messaging.UnitTests/Models/ChatMessage.cs
@@ -1,9 +1,0 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-
-namespace AWS.Messaging.UnitTests.Models;
-
-public class ChatMessage
-{
-    public string MessageDescription { get; set; } = string.Empty;
-}

--- a/test/AWS.Messaging.UnitTests/Models/Models.cs
+++ b/test/AWS.Messaging.UnitTests/Models/Models.cs
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text.Json.Serialization;
+
+namespace AWS.Messaging.UnitTests.Models;
+
+public class ChatMessage
+{
+    public string MessageDescription { get; set; } = string.Empty;
+}
+
+public class AddressInfo
+{
+    public int Unit { get; set; }
+    public string? Street { get; set; }
+    public string? ZipCode { get; set; }
+}
+
+public class PersonInfo
+{
+    public string? FirstName { get; set; }
+    public string? LastName { get; set; }
+    public int Age { get; set; }
+    public Gender Gender { get; set; }
+    public AddressInfo? Address { get; set; }
+}
+
+public enum Gender
+{
+    Male,
+    Female
+}

--- a/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
@@ -1,0 +1,141 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Threading.Tasks;
+using Amazon.SQS.Model;
+using AWS.Messaging.Serialization;
+using AWS.Messaging.Services;
+using AWS.Messaging.UnitTests.MessageHandlers;
+using AWS.Messaging.UnitTests.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moq;
+using Xunit;
+
+namespace AWS.Messaging.UnitTests.SerializationTests;
+
+public class EnvelopeSerializerTests
+{
+    private readonly IServiceCollection _serviceCollection;
+    private readonly DateTimeOffset _testdate = new DateTime(year: 2000, month: 12, day: 5, hour: 10, minute: 30, second: 55, DateTimeKind.Utc);
+
+    public EnvelopeSerializerTests()
+    {
+        _serviceCollection = new ServiceCollection();
+        _serviceCollection.AddLogging();
+        _serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPublisher<AddressInfo>("sqsQueueUrl", "addressInfo");
+            builder.AddMessageHandler<AddressInfoHandler, AddressInfo>("addressInfo");
+        });
+
+        var mockDateTimeHandler = new Mock<IDateTimeHandler>();
+        mockDateTimeHandler.Setup(x => x.GetUtcNow()).Returns(_testdate);
+        _serviceCollection.Replace(new ServiceDescriptor(typeof(IDateTimeHandler), mockDateTimeHandler.Object));
+    }
+
+    [Fact]
+    public async Task CreateEnvelope()
+    {
+        // ARRANGE
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+        var envelopeSerializer = serviceProvider.GetRequiredService<IEnvelopeSerializer>();
+        var message = new AddressInfo
+        {
+            Street = "Prince St",
+            Unit = 123,
+            ZipCode = "00001"
+        };
+
+        // ACT
+        var envelope = await envelopeSerializer.CreateEnvelopeAsync(message);
+
+        // ASSERT
+        Assert.NotNull(envelope);
+        Assert.Equal(_testdate, envelope.TimeStamp);
+        Assert.Equal("1.0", envelope.Version);
+        Assert.Equal("/aws/messaging", envelope.Source?.ToString());
+        Assert.Equal("addressInfo", envelope.MessageTypeIdentifier);
+
+        var addressInfo = envelope.Message;
+        Assert.Equal("Prince St", addressInfo?.Street);
+        Assert.Equal(123, addressInfo?.Unit);
+        Assert.Equal("00001", addressInfo?.ZipCode);
+    }
+
+    [Fact]
+    public void SerializeEnvelope()
+    {
+        // ARRANGE
+        var message = new AddressInfo
+        {
+            Street = "Prince St",
+            Unit = 123,
+            ZipCode = "00001"
+        };
+
+        var envelope = new MessageEnvelope<AddressInfo>
+        {
+            Id =  "id-123",
+            Source = new Uri("/backend/service", UriKind.Relative),
+            Version = "1.0",
+            MessageTypeIdentifier = "addressInfo",
+            TimeStamp = _testdate,
+            Message = message
+        };
+
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+        var envelopeSerializer = serviceProvider.GetRequiredService<IEnvelopeSerializer>();
+
+        // ACT
+        var jsonBlob = envelopeSerializer.Serialize(envelope);
+
+        // ASSERT
+        // The \u0022 corresponds to quotation mark (")
+        var expectedBlob = "{\"id\":\"id-123\",\"source\":\"/backend/service\",\"specversion\":\"1.0\",\"type\":\"addressInfo\",\"time\":\"2000-12-05T10:30:55+00:00\",\"data\":\"{\\u0022Unit\\u0022:123,\\u0022Street\\u0022:\\u0022Prince St\\u0022,\\u0022ZipCode\\u0022:\\u002200001\\u0022}\"}";
+        Assert.Equal(expectedBlob, jsonBlob);
+    }
+
+    [Fact]
+    public async Task ConvertToEnvelope()
+    {
+        // ARRANGE
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+        var envelopeSerializer = serviceProvider.GetRequiredService<IEnvelopeSerializer>();
+        var message = new AddressInfo
+        {
+            Street = "Prince St",
+            Unit = 123,
+            ZipCode = "00001"
+        };
+
+        var envelope = await envelopeSerializer.CreateEnvelopeAsync(message);
+        var sqsMessage = new Message
+        {
+            Body = envelopeSerializer.Serialize(envelope)
+        };
+
+        // ACT
+        var result = envelopeSerializer.ConvertToEnvelope(sqsMessage);
+
+        // ASSERT
+        envelope = (MessageEnvelope<AddressInfo>)result.Envelope;
+        Assert.NotNull(envelope);
+        Assert.Equal(_testdate, envelope.TimeStamp);
+        Assert.Equal("1.0", envelope.Version);
+        Assert.Equal("/aws/messaging", envelope.Source?.ToString());
+        Assert.Equal("addressInfo", envelope.MessageTypeIdentifier);
+
+        var addressInfo = envelope.Message;
+        Assert.Equal("Prince St", addressInfo?.Street);
+        Assert.Equal(123, addressInfo?.Unit);
+        Assert.Equal("00001", addressInfo?.ZipCode);
+
+        var subscribeMapping = result.Mapping;
+        Assert.NotNull(subscribeMapping);
+        Assert.Equal("addressInfo", subscribeMapping.MessageTypeIdentifier);
+        Assert.Equal(typeof(AddressInfo), subscribeMapping.MessageType);
+        Assert.Equal(typeof(AddressInfoHandler), subscribeMapping.HandlerType);
+    }
+}

--- a/test/AWS.Messaging.UnitTests/SerializationTests/MessageSerializerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/MessageSerializerTests.cs
@@ -4,7 +4,7 @@
 using System.Text.Json.Serialization;
 using AWS.Messaging.Configuration;
 using AWS.Messaging.Serialization;
-using Microsoft.Extensions.Logging;
+using AWS.Messaging.UnitTests.Models;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -69,27 +69,4 @@ public class MessageSerializerTests
         Assert.Equal("Prince St", message.Address?.Street);
         Assert.Equal("00001", message.Address?.ZipCode);
     }
-}
-
-class PersonInfo
-{
-    public string? FirstName { get; set; }
-    public string? LastName { get; set; }
-    public int Age { get; set; }
-    [JsonConverter(typeof(JsonStringEnumConverter))]
-    public Gender Gender { get; set; }
-    public AddressInfo? Address { get; set; }
-}
-
-class AddressInfo
-{
-    public int Unit { get; set; }
-    public string? Street { get; set; }
-    public string? ZipCode { get; set; }
-}
-
-enum Gender
-{
-    Male,
-    Female
 }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6662

*Description of changes:*
* Adds the default implementation of the `IEnvelopeSerializer`.
* Removes the `MessageEnvelope` constructor and makes its properties nullable because the `_envelopeSerializer.ConvertToEnvelope` method needs to create an instance of the `MessageEnvelope<T>` by invoking `Activator.CreateInstance` which requires an empty constructor.
* Adds new unit tests.

**Note** - This PR does not handle message attributes and other service specific metadata that users may want to send along with their application message. This requires a design discussion and this effort is being tracked via `DOTNET-6729`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
