### PR TITLE
Add MaxNumberOfConcurrentMessages to the SQS poller configuration

### DIFF
--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -44,7 +44,8 @@ public interface IMessageBusBuilder
     /// Adds an SQS queue to poll for messages.
     /// </summary>
     /// <param name="queueUrl">The SQS queue to poll for messages.</param>
-    IMessageBusBuilder AddSQSPoller(string queueUrl);
+    /// <param name="options">Optional configuration for polling message from SQS.</param>
+    IMessageBusBuilder AddSQSPoller(string queueUrl, Action<SQSMessagePollerOptions>? options = null);
 
     /// <summary>
     /// Configures an instance of <see cref="SerializationOptions"/> to control the serialization/de-serialization logic for the application message.

--- a/src/AWS.Messaging/Configuration/SQSMessagePollerConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/SQSMessagePollerConfiguration.cs
@@ -4,14 +4,26 @@
 namespace AWS.Messaging.Configuration;
 
 /// <summary>
-/// Configuration for polling messages from SQS
+/// Internal configuration for polling messages from SQS
 /// </summary>
-public class SQSMessagePollerConfiguration : IMessagePollerConfiguration
+internal class SQSMessagePollerConfiguration : IMessagePollerConfiguration
 {
+    /// <summary>
+    /// Default value for <see cref="MaxNumberOfConcurrentMessages"/>
+    /// </summary>
+    /// <remarks>The default value is 10 messages.</remarks>
+    public const int DefaultMaxNumberOfConcurrentMessages = 10;
+
     /// <summary>
     /// The SQS QueueUrl to poll messages from.
     /// </summary>
     public string SubscriberEndpoint { get; }
+
+    /// <summary>
+    /// The maximum number of messages from this queue to process concurrently.
+    /// </summary>
+    /// <remarks><inheritdoc cref="DefaultMaxNumberOfConcurrentMessages" path="//remarks"/></remarks>
+    public int MaxNumberOfConcurrentMessages { get; init; } = DefaultMaxNumberOfConcurrentMessages;
 
     /// <summary>
     /// Construct an instance of <see cref="SQSMessagePollerConfiguration" />

--- a/src/AWS.Messaging/Configuration/SQSMessagePollerOptions.cs
+++ b/src/AWS.Messaging/Configuration/SQSMessagePollerOptions.cs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Configuration;
+
+/// <summary>
+/// Configuration for polling messages from SQS
+/// </summary>
+public class SQSMessagePollerOptions
+{
+    /// <inheritdoc cref="SQSMessagePollerConfiguration.MaxNumberOfConcurrentMessages"/>
+    public int MaxNumberOfConcurrentMessages { get; set; } = SQSMessagePollerConfiguration.DefaultMaxNumberOfConcurrentMessages;
+}
+

--- a/src/AWS.Messaging/SQS/SQSMessagePoller.cs
+++ b/src/AWS.Messaging/SQS/SQSMessagePoller.cs
@@ -12,7 +12,7 @@ namespace AWS.Messaging.SQS;
 /// <summary>
 /// SQS implementation of the <see cref="AWS.Messaging.Services.IMessagePoller" />
 /// </summary>
-public class SQSMessagePoller : IMessagePoller
+internal class SQSMessagePoller : IMessagePoller
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly IAmazonSQS _sqsClient;


### PR DESCRIPTION
*Issue #, if available:* DOTNET-6666

*Description of changes:*
 * Adds `MaxNumberOfConcurrentMessages` to `SQSMessagePollerConfiguration`
     * Note: I considered adding to `IMessagePollerConfiguration`, but I believe for the other concrete `IMessagePollerConfiguration` we'll have at launch (Lambda) that the concurrency will be controlled by Lambda configuration: https://aws.amazon.com/about-aws/whats-new/2023/01/aws-lambda-maximum-concurrency-amazon-sqs-event-source/. So I don't believe `MaxNumberOfConcurrentMessages` is common across all possible message pollers.
 * Adds `DefaultMessageManagerFactory` to the DI container when configuring one or more SQSMessagePollers, which will be required by the message pump(s).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
