### PR TITLE
Add initial SQSMessagePoller implementation

### DIFF
--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -72,10 +72,14 @@ public class MessageBusBuilder : IMessageBusBuilder
             options.Invoke(sqsMessagePollerOptions);
         }
 
+        sqsMessagePollerOptions.Validate();
+
         // Copy that to our internal options class
         var sqsMessagePollerConfiguration = new SQSMessagePollerConfiguration(queueUrl)
         {
-            MaxNumberOfConcurrentMessages = sqsMessagePollerOptions.MaxNumberOfConcurrentMessages
+            MaxNumberOfConcurrentMessages = sqsMessagePollerOptions.MaxNumberOfConcurrentMessages,
+            VisibilityTimeout = sqsMessagePollerOptions.VisibilityTimeout,
+            WaitTimeSeconds = sqsMessagePollerOptions.WaitTimeSeconds
         };
 
         _messageConfiguration.MessagePollerConfigurations.Add(sqsMessagePollerConfiguration);

--- a/src/AWS.Messaging/Configuration/SQSMessagePollerConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/SQSMessagePollerConfiguration.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using Amazon.SQS.Model;
+
 namespace AWS.Messaging.Configuration;
 
 /// <summary>
@@ -12,7 +14,19 @@ internal class SQSMessagePollerConfiguration : IMessagePollerConfiguration
     /// Default value for <see cref="MaxNumberOfConcurrentMessages"/>
     /// </summary>
     /// <remarks>The default value is 10 messages.</remarks>
-    public const int DefaultMaxNumberOfConcurrentMessages = 10;
+    public const int DEFAULT_MAX_NUMBER_OF_CONCURRENT_MESSAGES = 10;
+
+    /// <summary>
+    /// Default value for <see cref="VisibilityTimeout"/>
+    /// </summary>
+    /// <remarks>The default value is 20 seconds.</remarks>
+    public const int DEFAULT_VISBILITY_TIMEOUT_SECONDS = 20;
+
+    /// <summary>
+    /// Default value for <see cref="WaitTimeSeconds"/>
+    /// </summary>
+    /// <remarks>The default value is 20 seconds.</remarks>
+    public const int DEFAULT_WAIT_TIME_SECONDS = 20;
 
     /// <summary>
     /// The SQS QueueUrl to poll messages from.
@@ -22,8 +36,26 @@ internal class SQSMessagePollerConfiguration : IMessagePollerConfiguration
     /// <summary>
     /// The maximum number of messages from this queue to process concurrently.
     /// </summary>
-    /// <remarks><inheritdoc cref="DefaultMaxNumberOfConcurrentMessages" path="//remarks"/></remarks>
-    public int MaxNumberOfConcurrentMessages { get; init; } = DefaultMaxNumberOfConcurrentMessages;
+    /// <remarks><inheritdoc cref="DEFAULT_MAX_NUMBER_OF_CONCURRENT_MESSAGES" path="//remarks"/></remarks>
+    public int MaxNumberOfConcurrentMessages { get; init; } = DEFAULT_MAX_NUMBER_OF_CONCURRENT_MESSAGES;
+
+    /// <summary>
+    /// <inheritdoc cref="ReceiveMessageRequest.VisibilityTimeout"/>
+    /// </summary>
+    /// <remarks>
+    /// <inheritdoc cref="DEFAULT_VISBILITY_TIMEOUT_SECONDS" path="//remarks"/>
+    /// The minimum is 0 seconds. The maximum is 12 hours.
+    /// </remarks>
+    public int VisibilityTimeout { get; init; } = DEFAULT_VISBILITY_TIMEOUT_SECONDS;
+
+    /// <summary>
+    /// <inheritdoc cref="ReceiveMessageRequest.WaitTimeSeconds"/>
+    /// </summary>
+    /// <remarks>
+    /// <inheritdoc cref="DEFAULT_WAIT_TIME_SECONDS" path="//remarks"/>
+    /// The minimum is 0 seconds. The maximum is 20 seconds.
+    /// </remarks>
+    public int WaitTimeSeconds { get; init; } = DEFAULT_WAIT_TIME_SECONDS;
 
     /// <summary>
     /// Construct an instance of <see cref="SQSMessagePollerConfiguration" />

--- a/src/AWS.Messaging/Configuration/SQSMessagePollerOptions.cs
+++ b/src/AWS.Messaging/Configuration/SQSMessagePollerOptions.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Text;
+
 namespace AWS.Messaging.Configuration;
 
 /// <summary>
@@ -9,6 +11,43 @@ namespace AWS.Messaging.Configuration;
 public class SQSMessagePollerOptions
 {
     /// <inheritdoc cref="SQSMessagePollerConfiguration.MaxNumberOfConcurrentMessages"/>
-    public int MaxNumberOfConcurrentMessages { get; set; } = SQSMessagePollerConfiguration.DefaultMaxNumberOfConcurrentMessages;
+    public int MaxNumberOfConcurrentMessages { get; set; } = SQSMessagePollerConfiguration.DEFAULT_MAX_NUMBER_OF_CONCURRENT_MESSAGES;
+
+    /// <inheritdoc cref="SQSMessagePollerConfiguration.VisibilityTimeout"/>
+    public int VisibilityTimeout { get; set; } = SQSMessagePollerConfiguration.DEFAULT_VISBILITY_TIMEOUT_SECONDS;
+
+    /// <inheritdoc cref="SQSMessagePollerConfiguration.WaitTimeSeconds"/>
+    public int WaitTimeSeconds { get; set; } = SQSMessagePollerConfiguration.DEFAULT_WAIT_TIME_SECONDS;
+
+    /// <summary>
+    /// Validates that the options are valid against the message framework's and/or SQS limits
+    /// </summary>
+    /// <exception cref="InvalidSQSMessagePollerOptionsException">Thrown when one or more invalid options are found</exception>
+    internal void Validate()
+    {
+        var errorMessages = new List<string>();
+       
+        if (MaxNumberOfConcurrentMessages <= 0)
+        {
+            errorMessages.Add($"{nameof(MaxNumberOfConcurrentMessages)} must be greater than 0. Current value: {MaxNumberOfConcurrentMessages}.");
+        }
+
+        // https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html
+        if (VisibilityTimeout < 0 || VisibilityTimeout > TimeSpan.FromHours(12).TotalSeconds)
+        {
+            errorMessages.Add($"{nameof(VisibilityTimeout)} must be between 0 seconds and 12 hours. Current value: {VisibilityTimeout}.");
+        }
+
+        // https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html#sqs-long-polling
+        if (WaitTimeSeconds < 0 || WaitTimeSeconds > 20)
+        {
+            errorMessages.Add($"{nameof(WaitTimeSeconds)} must be between 0 seconds and 20 seconds. Current value: {WaitTimeSeconds}.");
+        }
+
+        if (errorMessages.Any())
+        {
+            throw new InvalidSQSMessagePollerOptionsException(string.Join(Environment.NewLine, errorMessages));
+        }
+    }
 }
 

--- a/src/AWS.Messaging/Exceptions.cs
+++ b/src/AWS.Messaging/Exceptions.cs
@@ -159,3 +159,25 @@ public class FailedToCreateMessageEnvelopeConfigurationException : AWSMessagingE
     /// </summary>
     public FailedToCreateMessageEnvelopeConfigurationException(string message, Exception? innerException = null) : base(message, innerException) { }
 }
+
+/// <summary>
+/// Thrown when attempting to perform an SQS operation on a message without a valid receipt handle in the <see cref="MessageEnvelope.SQSMetadata"/>
+/// </summary>
+public class MissingSQSReceiptHandleException : AWSMessagingException
+{
+    /// <summary>
+    /// Creates an instance of <see cref="MissingSQSReceiptHandleException"/>.
+    /// </summary>
+    public MissingSQSReceiptHandleException(string message, Exception? innerException = null) : base(message, innerException) { }
+}
+
+/// <summary>
+/// Thrown when an <see cref="SQSMessagePollerOptions" /> is configured with one or more invalid values
+/// </summary>
+public class InvalidSQSMessagePollerOptionsException : AWSMessagingException
+{
+    /// <summary>
+    /// Creates an instance of <see cref="InvalidSQSMessagePollerOptionsException"/>.
+    /// </summary>
+    public InvalidSQSMessagePollerOptionsException(string message, Exception? innerException = null) : base(message, innerException) { }
+}

--- a/src/AWS.Messaging/SQS/SQSMessagePoller.cs
+++ b/src/AWS.Messaging/SQS/SQSMessagePoller.cs
@@ -4,6 +4,7 @@
 using Amazon.SQS;
 using Amazon.SQS.Model;
 using AWS.Messaging.Configuration;
+using AWS.Messaging.Serialization;
 using AWS.Messaging.Services;
 using Microsoft.Extensions.Logging;
 
@@ -14,37 +15,271 @@ namespace AWS.Messaging.SQS;
 /// </summary>
 internal class SQSMessagePoller : IMessagePoller
 {
-    private readonly IServiceProvider _serviceProvider;
     private readonly IAmazonSQS _sqsClient;
     private readonly ILogger<SQSMessagePoller> _logger;
     private readonly IMessageManager _messageManager;
     private readonly SQSMessagePollerConfiguration _configuration;
+    private readonly IEnvelopeSerializer _envelopeSerializer;
+
+    /// <summary>
+    /// The number of milliseconds to pause if already processing the configured maximum number of messages
+    /// </summary>
+    private const int CONCURRENCY_LIMIT_PAUSE_MILLIS = 50;
+
+    /// <summary>
+    /// Maximum valid value for <see cref="ReceiveMessageRequest.MaxNumberOfMessages"/>
+    /// </summary>
+    private const int SQS_MAX_NUMBER_MESSAGES_TO_READ = 10;
 
     /// <summary>
     /// Creates instance of <see cref="AWS.Messaging.SQS.SQSMessagePoller" />
     /// </summary>
-    /// <param name="serviceProvider"><see cref="System.IServiceProvider" /> container used for acquiring and creating dependent services.</param>
     /// <param name="logger">Logger for debugging information.</param>
     /// <param name="messageManagerFactory">The factory to create the message manager for processing messages.</param>
     /// <param name="sqsClient">SQS service client to use for service API calls.</param>
     /// <param name="configuration">The SQS message poller configuration.</param>
-    public SQSMessagePoller(IServiceProvider serviceProvider, ILogger<SQSMessagePoller> logger, IMessageManagerFactory messageManagerFactory, IAmazonSQS sqsClient, SQSMessagePollerConfiguration configuration)
+    /// <param name="envelopeSerializer">Serializer used to deserialize the SQS messages</param>
+    public SQSMessagePoller(
+        ILogger<SQSMessagePoller> logger,
+        IMessageManagerFactory messageManagerFactory,
+        IAmazonSQS sqsClient,
+        SQSMessagePollerConfiguration configuration,
+        IEnvelopeSerializer envelopeSerializer)
     {
-        _serviceProvider = serviceProvider;
         _logger = logger;
         _sqsClient = sqsClient;
         _configuration = configuration;
+        _envelopeSerializer = envelopeSerializer;
 
         _messageManager = messageManagerFactory.CreateMessageManager(this);
     }
 
     /// <inheritdoc/>
-    public Task StartPollingAsync(CancellationToken token = default) => throw new NotImplementedException();
+    public async Task StartPollingAsync(CancellationToken token = default)
+    {
+        await PollQueue(token);
+    }
+
+    /// <summary>
+    /// Polls SQS indefinitely until cancelled
+    /// </summary>
+    /// <param name="token">Cancellation token to shutdown the poller.</param>
+    private async Task PollQueue(CancellationToken token)
+    {
+        while (!token.IsCancellationRequested)
+        {
+            var numberOfMessagesToRead = _configuration.MaxNumberOfConcurrentMessages - _messageManager.ActiveMessageCount;
+
+            // If already processing the maximum number of messages, block and then try again
+            // TODO: change this to a signal once DefaultMessageManager is implemented
+            if (numberOfMessagesToRead <= 0)
+            {
+                await Task.Delay(CONCURRENCY_LIMIT_PAUSE_MILLIS);
+                continue;
+            }
+
+            // Only read SQS's maximum numer of messages. If configured for
+            // higher concurrency, then the next interation could read more
+            if (numberOfMessagesToRead > SQS_MAX_NUMBER_MESSAGES_TO_READ)
+            {
+                numberOfMessagesToRead = SQS_MAX_NUMBER_MESSAGES_TO_READ;
+            }
+
+            var receiveMessageRequest = new ReceiveMessageRequest
+            {
+                QueueUrl = _configuration.SubscriberEndpoint,
+                VisibilityTimeout = _configuration.VisibilityTimeout,
+                WaitTimeSeconds = _configuration.WaitTimeSeconds,
+                MaxNumberOfMessages = numberOfMessagesToRead,
+                AttributeNames = new List<string> { "All" },
+                MessageAttributeNames = new List<string> { "All" }
+            };
+
+            try
+            {
+                _logger.LogTrace("Retrieving up to {numberOfMesagesToRead} messages from {queueUrl}",
+                    receiveMessageRequest.MaxNumberOfMessages, receiveMessageRequest.QueueUrl);
+
+                var receiveMessageResponse = await _sqsClient.ReceiveMessageAsync(receiveMessageRequest, token);
+
+                _logger.LogTrace("Retrieved {messagesCount} messages from {queueUrl} via request ID {requestId}",
+                    receiveMessageResponse.Messages.Count, receiveMessageRequest.QueueUrl, receiveMessageResponse.ResponseMetadata.RequestId);
+
+                foreach (var message in receiveMessageResponse.Messages)
+                {
+                    var messageEnvelopeResult = _envelopeSerializer.ConvertToEnvelope(message);
+                    _messageManager.StartProcessMessage(messageEnvelopeResult.Envelope);
+                }
+            }
+            catch (AWSMessagingException)
+            {
+                // Swallow exceptions thrown by the framework, and rely on the thrower to log
+            }
+            catch (AmazonSQSException ex)
+            {
+                _logger.LogError(ex, "An {exceptionName} occurred while polling", nameof(AmazonSQSException));
+
+                // Rethrow the exception to fail fast for invalid configuration, permissioning, etc.
+                // TODO: explore a "cool down mode" for repeated exceptions
+                if (IsSQSExceptionFatal(ex))
+                {
+                    throw ex;
+                }
+            }
+            catch (Exception ex)
+            {
+                // TODO: explore a "cool down mode" for repeated exceptions
+                _logger.LogError(ex, "An unknown exception occurred while polling {subscriberEndpoint}", _configuration.SubscriberEndpoint);
+            }
+        }
+    }
 
     /// <inheritdoc/>
-    public Task DeleteMessagesAsync(IEnumerable<MessageEnvelope> messages) => throw new NotImplementedException();
+    public async Task DeleteMessagesAsync(IEnumerable<MessageEnvelope> messages)
+    {
+        if (messages.Count() == 0)
+        {
+            return;
+        }
+
+        var request = new DeleteMessageBatchRequest
+        {
+            QueueUrl = _configuration.SubscriberEndpoint
+        };
+
+        foreach (var message in messages)
+        {
+            if (!string.IsNullOrEmpty(message.SQSMetadata?.ReceiptHandle))
+            {
+                _logger.LogTrace("Preparing to delete message {messageId} with SQS receipt handle {receiptHandle} from queue {subscriberEndpoint}",
+                    message.Id, message.SQSMetadata.ReceiptHandle, _configuration.SubscriberEndpoint);
+                request.Entries.Add(new DeleteMessageBatchRequestEntry()
+                {
+                    ReceiptHandle = message.SQSMetadata.ReceiptHandle
+                });
+            }
+            else
+            {
+                var errorMessage = $"Attempted to delete message {message.Id} from {_configuration.SubscriberEndpoint} without an SQS receipt handle.";
+
+                _logger.LogError(errorMessage);
+                throw new MissingSQSReceiptHandleException(errorMessage);
+            }
+        }
+
+        try
+        {
+            var response = await _sqsClient.DeleteMessageBatchAsync(request);
+
+            foreach (var successMessage in response.Successful)
+            {
+                _logger.LogTrace("Deleted message {messageId} from queue {subscriberEndpoint} successfully", successMessage.Id, _configuration.SubscriberEndpoint);
+            }
+
+            foreach (var failedMessage in response.Failed)
+            {
+                _logger.LogError("Failed to delete message {failedMessageId} from queue {subscriberEndpoint}: {failedMessage}", 
+                    failedMessage.Id, _configuration.SubscriberEndpoint, failedMessage.Message);
+            }
+        }
+        catch (AmazonSQSException ex)
+        {
+            _logger.LogError(ex, "Failed to delete message(s) [{messageIds}] from queue {subscriberEndpoint}",
+                string.Join(", ", messages.Select(x => x.Id)), _configuration.SubscriberEndpoint);
+
+            // Rethrow the exception to fail fast for invalid configuration, permissioning, etc.
+            if (IsSQSExceptionFatal(ex))
+            {
+                throw ex;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An unexpected exception occurred while deleting messages from queue {subscriberEndpoint}", _configuration.SubscriberEndpoint);
+        }
+    }
 
     /// <inheritdoc/>
-    public Task ExtendMessageVisiblityTimeoutAsync(IEnumerable<MessageEnvelope> messages) => throw new NotImplementedException();
+    public async Task ExtendMessageVisiblityTimeoutAsync(IEnumerable<MessageEnvelope> messages)
+    {
+        if (messages.Count() == 0)
+        {
+            return;
+        }
 
+        var request = new ChangeMessageVisibilityBatchRequest
+        {
+            QueueUrl = _configuration.SubscriberEndpoint
+        };
+
+        foreach (var message in messages)
+        {
+            if (!string.IsNullOrEmpty(message.SQSMetadata?.ReceiptHandle))
+            {
+                _logger.LogTrace("Preparing to extend the visibility of {messageId} with SQS receipt handle {receiptHandle} by {visibilityTimeout} seconds",
+                    message.Id, message.SQSMetadata.ReceiptHandle, _configuration.VisibilityTimeout);
+                request.Entries.Add(new ChangeMessageVisibilityBatchRequestEntry
+                {
+                    ReceiptHandle = message.SQSMetadata.ReceiptHandle,
+                    VisibilityTimeout = _configuration.VisibilityTimeout
+                });
+            }
+            else
+            {
+                var errorMessage = $"Attempted to change the visibility of message {message.Id} from {_configuration.SubscriberEndpoint} without an SQS receipt handle.";
+
+                _logger.LogError(errorMessage);
+                throw new MissingSQSReceiptHandleException(errorMessage);
+            }
+        }
+
+        try
+        {
+            var response = await _sqsClient.ChangeMessageVisibilityBatchAsync(request);
+
+            foreach (var successMessage in response.Successful)
+            {
+                _logger.LogTrace("Extended the visibility of message {messageId} on queue {subscriberEndpoint} successfully", successMessage.Id, _configuration.SubscriberEndpoint);
+            }
+
+            foreach (var failedMessage in response.Failed)
+            {
+                _logger.LogError("Failed to extend the visibility of message {failedMessageId} on queue {subscriberEndpoint}: {failedMessage}",
+                    failedMessage.Id, _configuration.SubscriberEndpoint, failedMessage.Message);
+            }
+        }
+        catch (AmazonSQSException ex)
+        {
+            _logger.LogError(ex, "Failed to extend the visibility of message(s) [{messageIds}] on queue {subscriberEndpoint}",
+               string.Join(", ", messages.Select(x => x.Id)), _configuration.SubscriberEndpoint);
+
+            // Rethrow the exception to fail fast for invalid configuration, permissioning, etc.
+            if (IsSQSExceptionFatal(ex))
+            {
+                throw ex;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An unexpected exception occurred while extending message visibility on queue {subscriberEndpoint}", _configuration.SubscriberEndpoint);
+        }
+    }
+
+    /// <summary>
+    /// <see cref="AmazonSQSException"/> error codes that should be treated as fatal and stop the poller
+    /// </summary>
+    private static readonly HashSet<string> _fatalSQSErrorCodes = new HashSet<string>
+    {
+        "InvalidAddress",   // Returned for an invalid queue URL
+        "AccessDenied"      // Returned with insufficient IAM permissions to read from the configured queue
+    };
+
+    /// <summary>
+    /// Determines if a given SQS exception should be treated as fatal and rethrown to stop the poller
+    /// </summary>
+    /// <param name="sqsException">SQS Exception</param>
+    private bool IsSQSExceptionFatal(AmazonSQSException sqsException)
+    {
+        return _fatalSQSErrorCodes.Contains(sqsException.ErrorCode);
+    }
 }

--- a/src/AWS.Messaging/Services/DefaultMessageManager.cs
+++ b/src/AWS.Messaging/Services/DefaultMessageManager.cs
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AWS.Messaging.Services;
+
+/// <inheritdoc/>
+public class DefaultMessageManager : IMessageManager
+{
+    private readonly IMessagePoller _messagePoller;
+    /// <inheritdoc/>
+    public DefaultMessageManager(IMessagePoller messagePoller)
+    {
+        _messagePoller = messagePoller;
+    }
+
+    /// <inheritdoc/>
+    public int ActiveMessageCount { get; set; }
+
+    /// <inheritdoc/>
+    public void StartProcessMessage(MessageEnvelope messageEnvelope) => throw new NotImplementedException();
+}

--- a/src/AWS.Messaging/Services/IMessageManagerFactory.cs
+++ b/src/AWS.Messaging/Services/IMessageManagerFactory.cs
@@ -21,7 +21,7 @@ public interface IMessageManagerFactory
 }
 
 /// <summary>
-/// Implemenation of <see cref="AWS.Messaging.Services.IMessageManagerFactory" /> that is the default registered factory into
+/// Implementation of <see cref="AWS.Messaging.Services.IMessageManagerFactory" /> that is the default registered factory into
 /// the IServiceCollection unless a user has registered their own implementation.
 /// </summary>
 internal class DefaultMessageManagerFactory : IMessageManagerFactory
@@ -37,6 +37,6 @@ internal class DefaultMessageManagerFactory : IMessageManagerFactory
     /// <inheritdoc/>
     public IMessageManager CreateMessageManager(IMessagePoller poller)
     {
-        return ActivatorUtilities.CreateInstance<IMessageManager>(_serviceProvider, poller);
+        return ActivatorUtilities.CreateInstance<DefaultMessageManager>(_serviceProvider, poller);
     }
 }

--- a/test/AWS.Messaging.UnitTests/SQSMessagePollerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SQSMessagePollerTests.cs
@@ -1,0 +1,185 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using AWS.Messaging.Configuration;
+using AWS.Messaging.Services;
+using AWS.Messaging.UnitTests.MessageHandlers;
+using AWS.Messaging.UnitTests.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using Xunit;
+
+namespace AWS.Messaging.UnitTests;
+
+public class SQSMessagePollerTests
+{
+    private const string TEST_QUEUE_URL = "queueUrl";
+
+    /// <summary>
+    /// Tests that starting an SQS poller with default settings begins polling SQS
+    /// </summary>
+    [Fact]
+    public async Task SQSMessagePoller_Defaults_PollsSQS()
+    {
+        var client = new Mock<IAmazonSQS>();
+        client.Setup(x => x.ReceiveMessageAsync(It.IsAny<ReceiveMessageRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ReceiveMessageResponse(), TimeSpan.FromMilliseconds(50));
+
+        await RunSQSMessagePollerTest(client);
+
+        client.Verify(x => x.ReceiveMessageAsync(It.IsAny<ReceiveMessageRequest>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce());
+    }
+
+    /// <summary>
+    /// Tests that configuring a poller with <see cref="SQSMessagePollerConfiguration.MaxNumberOfConcurrentMessages"/>
+    /// set to a value greater than SQS's current limit of 10 will only recieve 10 messages at a time.
+    /// </summary>
+    [Fact]
+    public async Task SQSMessagePoller_ManyConcurrentMessages_DoesNotExceedSQSMax()
+    {
+        var client = new Mock<IAmazonSQS>();
+
+        client.Setup(x => x.ReceiveMessageAsync(It.IsAny<ReceiveMessageRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ReceiveMessageResponse(), TimeSpan.FromMilliseconds(50));
+
+        await RunSQSMessagePollerTest(client, options => options.MaxNumberOfConcurrentMessages = 50);
+
+        client.Verify(x => x.ReceiveMessageAsync(
+            It.Is<ReceiveMessageRequest>(request => request.MaxNumberOfMessages == 10), It.IsAny<CancellationToken>()), Times.AtLeastOnce());
+
+        client.Verify(x => x.ReceiveMessageAsync(
+            It.Is<ReceiveMessageRequest>(request => request.MaxNumberOfMessages != 10), It.IsAny<CancellationToken>()), Times.Never());
+    }
+
+    /// <summary>
+    /// Tests that calling <see cref="IMessagePoller.DeleteMessagesAsync"/> calls
+    /// SQS's DeleteMessageBatch with an expected request.
+    /// </summary>
+    [Fact]
+    public async Task SQSMessagePoller_DeleteMessages_Success()
+    {
+        var client = new Mock<IAmazonSQS>();
+
+        client.Setup(x => x.DeleteMessageBatchAsync(It.IsAny<DeleteMessageBatchRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeleteMessageBatchResponse { Failed = new List<BatchResultErrorEntry>() });
+
+        var messagePoller = CreateSQSMessagePoller(client);
+
+        var messageEnvelopes = new List<MessageEnvelope>()
+        {
+            new MessageEnvelope<ChatMessage> { Id = "1", SQSMetadata = new SQSMetadata { ReceiptHandle ="rh1"} },
+            new MessageEnvelope<ChatMessage> { Id = "2", SQSMetadata = new SQSMetadata { ReceiptHandle ="rh2"} }
+        };
+
+        await messagePoller.DeleteMessagesAsync(messageEnvelopes);
+
+        client.Verify(x => x.DeleteMessageBatchAsync(
+            It.Is<DeleteMessageBatchRequest>(request =>
+                request.QueueUrl == TEST_QUEUE_URL &&
+                request.Entries.Count == 2 &&
+                request.Entries.Any(x => x.ReceiptHandle == "rh1") &&
+                request.Entries.Any(x => x.ReceiptHandle == "rh2")),
+            It.IsAny<CancellationToken>()));
+    }
+
+    /// <summary>
+    /// Tests that calling <see cref="IMessagePoller.ExtendMessageVisiblityTimeoutAsync"/> calls
+    /// SQS's ChangeMessageVisibilityBatch with an expected request.
+    /// </summary>
+    [Fact]
+    public async Task SQSMessagePoller_ExtendMessageVisibility_Success()
+    {
+        var client = new Mock<IAmazonSQS>();
+
+        client.Setup(x => x.ChangeMessageVisibilityBatchAsync(It.IsAny<ChangeMessageVisibilityBatchRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChangeMessageVisibilityBatchResponse { Failed = new List<BatchResultErrorEntry>() }, TimeSpan.FromMilliseconds(50));
+
+        var messagePoller = CreateSQSMessagePoller(client);
+
+        var messageEnvelopes = new List<MessageEnvelope>()
+        {
+            new MessageEnvelope<ChatMessage> { Id = "1", SQSMetadata = new SQSMetadata { ReceiptHandle ="rh1"} },
+            new MessageEnvelope<ChatMessage> { Id = "2", SQSMetadata = new SQSMetadata { ReceiptHandle ="rh2"} }
+        };
+
+        await messagePoller.ExtendMessageVisiblityTimeoutAsync(messageEnvelopes);
+
+        client.Verify(x => x.ChangeMessageVisibilityBatchAsync(
+            It.Is<ChangeMessageVisibilityBatchRequest>(request =>
+                request.QueueUrl == TEST_QUEUE_URL &&
+                request.Entries.Count == 2 &&
+                request.Entries.Any(x => x.ReceiptHandle == "rh1") &&
+                request.Entries.Any(x => x.ReceiptHandle == "rh2")),
+            It.IsAny<CancellationToken>()));
+    }
+
+    /// <summary>
+    /// Helper function that initializes and starts a <see cref="MessagePumpService"/> with
+    /// a mocked SQS client, then cancels after 500ms
+    /// </summary>
+    /// <param name="mockSqsClient">Mocked SQS client</param>
+    /// <param name="options">SQS MessagePoller options</param>
+    private async Task RunSQSMessagePollerTest(Mock<IAmazonSQS> mockSqsClient, Action<SQSMessagePollerOptions>? options = null)
+    {
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging();
+
+        serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPoller(TEST_QUEUE_URL, options);
+            builder.AddMessageHandler<ChatMessageHandler, ChatMessage>();
+        });
+
+        serviceCollection.AddSingleton(mockSqsClient.Object);
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var pump = serviceProvider.GetService<IHostedService>() as MessagePumpService;
+
+        if (pump == null)
+        {
+            Assert.Fail($"Unable to get the {nameof(MessagePumpService)} from the service provider.");
+        }
+
+        var source = new CancellationTokenSource();
+        source.CancelAfter(500);
+
+        await pump.StartAsync(source.Token);
+    }
+
+    /// <summary>
+    /// Helper function that initializes an SQSMessagePoller
+    /// </summary>
+    /// <param name="mockSqsClient">Mocked SQS client</param>
+    private IMessagePoller CreateSQSMessagePoller(Mock<IAmazonSQS> mockSqsClient)
+    {
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging();
+
+        serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPoller(TEST_QUEUE_URL);
+            builder.AddMessageHandler<ChatMessageHandler, ChatMessage>();
+        });
+
+        serviceCollection.AddSingleton(mockSqsClient.Object);
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var messagePollerFactory = serviceProvider.GetService<IMessagePollerFactory>();
+        Assert.NotNull(messagePollerFactory);
+
+        var messagePoller = messagePollerFactory.CreateMessagePoller(new SQSMessagePollerConfiguration(TEST_QUEUE_URL));
+        Assert.NotNull(messagePoller);
+
+        return messagePoller;
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* DOTNET-6665

*Description of changes:*  Adds an initial implementation of the SQS message poller with unit tests.

Tracing and error handling could be improved. I think once we implement the message manager (DOTNET-6664) we'll be able to fully run the poller and start adding integration tests, so can look at logging and errors more holistically. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
