### PR TITLE
feat: Handle EventBridge message envelope

### DIFF
--- a/src/AWS.Messaging/EventBridgeMetadata.cs
+++ b/src/AWS.Messaging/EventBridgeMetadata.cs
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AWS.Messaging
+{
+    /// <summary>
+    /// Contains Metadata related to Amazon EventBridge.
+    /// </summary>
+    public class EventBridgeMetadata
+    {
+        /// <summary>
+        /// The unique event identifier
+        /// </summary>
+        public string? EventId { get; set; }
+
+        /// <summary>
+        /// The type of the event that was sent.
+        /// </summary>
+        public string? DetailType { get; set; }
+
+        /// <summary>
+        /// Identifies the source of the event
+        /// </summary>
+        public string? Source { get; set; }
+
+        /// <summary>
+        /// The time the event occurred.
+        /// </summary>
+        public DateTimeOffset Time { get; set; }
+
+        /// <summary>
+        /// The 12-digit number identifying an AWS account that published the event.
+        /// </summary>
+        public string? AWSAccount { get; set; }
+
+        /// <summary>
+        /// Identifies the AWS Region where the event originated.
+        /// </summary>
+        public string? AWSRegion { get; set; }
+
+        /// <summary>
+        /// Contains a list of Amazon Resource Names that the event primarily concerns.
+        /// </summary>
+        public List<string>? Resources { get; set; }
+    }
+}

--- a/src/AWS.Messaging/MessageEnvelope.cs
+++ b/src/AWS.Messaging/MessageEnvelope.cs
@@ -60,6 +60,11 @@ public abstract class MessageEnvelope
     public SNSMetadata? SNSMetadata { get; set; }
 
     /// <summary>
+    /// Stores metadata related to Amazon EventBridge.
+    /// </summary>
+    public EventBridgeMetadata? EventBridgeMetadata { get; set; }
+
+    /// <summary>
     /// Attaches the user specified application message to the <see cref="MessageEnvelope"/>
     /// </summary>
     /// <param name="message">The user specified application message.</param>

--- a/src/AWS.Messaging/MessageEnvelopeConfiguration.cs
+++ b/src/AWS.Messaging/MessageEnvelopeConfiguration.cs
@@ -22,4 +22,9 @@ internal class MessageEnvelopeConfiguration
     /// Stores metadata related to Amazon SNS.
     /// </summary>
     public SNSMetadata? SNSMetadata { get; set; }
+
+    /// <summary>
+    /// Stores metadata related to Amazon EventBridge.
+    /// </summary>
+    public EventBridgeMetadata? EventBridgeMetadata { get; set; }
 }

--- a/src/AWS.Messaging/Publishers/EventBridge/EventBridgeOptions.cs
+++ b/src/AWS.Messaging/Publishers/EventBridge/EventBridgeOptions.cs
@@ -23,5 +23,15 @@ namespace AWS.Messaging.Publishers.EventBridge
         /// To learn more about X-Ray trace headers, see <see href="https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader">Tracing header</see> in the X-Ray Developer Guide.
         /// </summary>
         public string? TraceHeader { get; set; }
+
+        /// <summary>
+        /// Specifies the type of event being sent.
+        /// </summary>
+        public string? DetailType { get; set; }
+
+        /// <summary>
+        /// Contains a list of Amazon Resource Names that the event primarily concerns.
+        /// </summary>
+        public List<string>? Resources { get; set; }
     }
 }

--- a/src/AWS.Messaging/Publishers/EventBridge/EventBridgePublisher.cs
+++ b/src/AWS.Messaging/Publishers/EventBridge/EventBridgePublisher.cs
@@ -79,7 +79,7 @@ internal class EventBridgePublisher : IMessagePublisher, IEventBridgePublisher
         var requestEntry = new PutEventsRequestEntry
         {
             EventBusName = eventBusName,
-            Detail = messageBody,
+            Detail = messageBody
         };
 
         var putEventsRequest = new PutEventsRequest
@@ -98,6 +98,12 @@ internal class EventBridgePublisher : IMessagePublisher, IEventBridgePublisher
 
         if (eventBridgeOptions.Time != DateTimeOffset.MinValue)
             requestEntry.Time = eventBridgeOptions.Time.DateTime;
+
+        if (!string.IsNullOrEmpty(eventBridgeOptions.DetailType))
+            requestEntry.DetailType = eventBridgeOptions.DetailType;
+
+        if (eventBridgeOptions.Resources?.Any() ?? false)
+            requestEntry.Resources = eventBridgeOptions.Resources;
 
         return putEventsRequest;
     }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6832

*Description of changes:*
This PR is similar to https://github.com/awslabs/aws-dotnet-messaging/pull/18

When a message is published to EventBridge, the SQS message retrieved by the subscribing queue will contain an outer message envelope that is injected by EventBridge.

**Sample SQS message body when retrieving messages from EventBridge**
```
{
   "version":"0",
   "id":"17793124-05d4-b198-2fde-7ededc63b103",
   "detail-type":"order-placed",
   "source":"order-manager-backend-service",
   "account":"111122223333",
   "time":"2021-11-12T00:00:00Z",
   "region":"us-west-2",
   "resources":[
      "SOME-ARN-1",
      "SOME-ARN-2"
   ],
   "detail":"<SERIALIZED-MESSAGE-ENVELOPE-POCO-FROM-MPF>"
}
```

This PR detects and strips down the outer envelope and stores the EventBridge metadata as part of `EventBridgeMetadata` inside the MessageEnvelope.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
