### PR TITLE
Add initial HandlerInvoker implementation to identify and invoke the appropriate message handler for a given message

### DIFF
--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -136,6 +136,7 @@ public class MessageBusBuilder : IMessageBusBuilder
         if (_messageConfiguration.MessagePollerConfigurations.Any())
         {
             services.AddHostedService<MessagePumpService>();
+            services.TryAddSingleton<HandlerInvoker>();
             services.TryAddSingleton<IMessagePollerFactory, DefaultMessagePollerFactory>();
             services.TryAddSingleton<IMessageManagerFactory, DefaultMessageManagerFactory>();
 

--- a/src/AWS.Messaging/Exceptions.cs
+++ b/src/AWS.Messaging/Exceptions.cs
@@ -181,3 +181,15 @@ public class InvalidSQSMessagePollerOptionsException : AWSMessagingException
     /// </summary>
     public InvalidSQSMessagePollerOptionsException(string message, Exception? innerException = null) : base(message, innerException) { }
 }
+
+/// <summary>
+/// Thrown during message handling if unable to find an <see cref="IMessageHandler{T}.HandleAsync(MessageEnvelope{T}, CancellationToken)"/>
+/// method on the handler type for a given message
+/// </summary>
+public class InvalidMessageHandlerSignatureException : AWSMessagingException
+{
+    /// <summary>
+    /// Creates an instance of <see cref="InvalidMessageHandlerSignatureException"/>.
+    /// </summary>
+    public InvalidMessageHandlerSignatureException(string message, Exception? innerException = null) : base(message, innerException) { }
+}

--- a/src/AWS.Messaging/SQS/SQSMessagePoller.cs
+++ b/src/AWS.Messaging/SQS/SQSMessagePoller.cs
@@ -108,7 +108,7 @@ internal class SQSMessagePoller : IMessagePoller
                 foreach (var message in receiveMessageResponse.Messages)
                 {
                     var messageEnvelopeResult = _envelopeSerializer.ConvertToEnvelope(message);
-                    _messageManager.StartProcessMessage(messageEnvelopeResult.Envelope);
+                    _messageManager.StartProcessMessage(messageEnvelopeResult.Envelope, messageEnvelopeResult.Mapping);
                 }
             }
             catch (AWSMessagingException)

--- a/src/AWS.Messaging/Services/DefaultMessageManager.cs
+++ b/src/AWS.Messaging/Services/DefaultMessageManager.cs
@@ -1,11 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using AWS.Messaging.Configuration;
 
 namespace AWS.Messaging.Services;
 
@@ -13,15 +9,22 @@ namespace AWS.Messaging.Services;
 public class DefaultMessageManager : IMessageManager
 {
     private readonly IMessagePoller _messagePoller;
+    private readonly HandlerInvoker _handlerInvoker;
     /// <inheritdoc/>
-    public DefaultMessageManager(IMessagePoller messagePoller)
+    public DefaultMessageManager(IMessagePoller messagePoller, HandlerInvoker handlerInvoker)
     {
         _messagePoller = messagePoller;
+        _handlerInvoker = handlerInvoker;
     }
 
     /// <inheritdoc/>
     public int ActiveMessageCount { get; set; }
 
     /// <inheritdoc/>
-    public void StartProcessMessage(MessageEnvelope messageEnvelope) => throw new NotImplementedException();
+    public void StartProcessMessage(MessageEnvelope messageEnvelope, SubscriberMapping subscriberMapping)
+    {
+        // TODO: a follow-up PR will handle managing this task, updating ActiveMessageCount, deleting the message when done.
+        // This commit is just getting the HandlerInvoker in place
+        var task = _handlerInvoker.InvokeAsync(messageEnvelope, subscriberMapping);
+    }
 }

--- a/src/AWS.Messaging/Services/HandlerInvoker.cs
+++ b/src/AWS.Messaging/Services/HandlerInvoker.cs
@@ -1,0 +1,105 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Concurrent;
+using System.Reflection;
+using AWS.Messaging.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace AWS.Messaging.Services;
+
+/// <summary>
+/// Identifies and invokes the correct method on a registered <see cref="IMessageHandler{T}"/> for received messages
+/// </summary>
+public class HandlerInvoker
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<HandlerInvoker> _logger;
+
+    /// <summary>
+    /// Caches the <see cref="MethodInfo"/> of the <see cref="IMessageHandler{T}.HandleAsync(MessageEnvelope{T}, CancellationToken)"/>
+    /// method that will be invoked with the message envelope for each handler
+    /// </summary>
+    private readonly ConcurrentDictionary<Type, MethodInfo?> _handlerMethods = new();
+
+    /// <summary>
+    /// Constructs an instance of HandlerInvoker
+    /// </summary>
+    /// <param name="serviceProvider">Service provider used to resolve handler objects</param>
+    /// <param name="logger">Logger for debugging information</param>
+    public HandlerInvoker(IServiceProvider serviceProvider, ILogger<HandlerInvoker> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Identifies and invokes the correct method to invoke on a registered <see cref="IMessageHandler{T}"/> for the given message
+    /// </summary>
+    /// <param name="messageEnvelope">Envelope of the message that is being handled</param>
+    /// <param name="subscriberMapping">Subscriber mapping of the message that is being handled</param>
+    /// <param name="token">Cancellation token which will be passed to the message handler</param>
+    /// <returns>Task representing the outcome of the message handler</returns>
+    public async Task<MessageProcessStatus> InvokeAsync(MessageEnvelope messageEnvelope, SubscriberMapping subscriberMapping, CancellationToken token = default)
+    {
+        var handler = _serviceProvider.GetService(subscriberMapping.HandlerType);
+
+        if (handler == null)
+        {
+            var message = $"Unable to resolve a handler for {subscriberMapping.HandlerType} " +
+                $"while handling message ID {messageEnvelope.Id}.";
+            _logger.LogError(message);
+            throw new InvalidMessageHandlerSignatureException(message);
+        }
+
+        var method = _handlerMethods.GetOrAdd(subscriberMapping.MessageType, x =>
+        {
+            return subscriberMapping.HandlerType.GetMethod(    // Look up the method on the handler type with:
+                nameof(IMessageHandler<MessageProcessStatus>.HandleAsync),              // name "HandleAsync"
+                new Type[] { messageEnvelope.GetType(), typeof(CancellationToken) });   // parameters (MessageEnvelope<MessageType>, CancellationToken)
+        });
+
+        if (method == null)
+        {
+            var message = $"Unable to resolve a compatible HandleAsync method for {subscriberMapping.HandlerType} " +
+                $"while handling message ID {messageEnvelope.Id}.";
+            _logger.LogError(message);
+            throw new InvalidMessageHandlerSignatureException(message);
+        }
+
+        try
+        {
+            var task = method.Invoke(handler, new object[] { messageEnvelope, token }) as Task<MessageProcessStatus>;
+
+            if (task == null)
+            {
+                var message = $"Unexpected return type for the HandleAsync method on {subscriberMapping.HandlerType} " +
+                    $"while handling message ID {messageEnvelope.Id}. Expected {nameof(Task<MessageProcessStatus>)}";
+                _logger.LogError(message);
+                throw new InvalidMessageHandlerSignatureException(message);
+            }
+
+            return await task;
+        }
+        // Since we are invoking HandleAsync via reflection, we need to unwrap the TargetInvocationException
+        // containing application exceptions that happened inside the IMessageHandler
+        catch (TargetInvocationException ex)
+        {
+            if (ex.InnerException != null)
+            {
+                _logger.LogError(ex.InnerException, "A handler exception occurred while handling message ID {messageId}.", messageEnvelope.Id);
+                return MessageProcessStatus.Failed();
+            }
+            else
+            {
+                _logger.LogError(ex, "An unexpected exception occurred while handling message ID {messageId}.", messageEnvelope.Id);
+                return MessageProcessStatus.Failed();
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An unexpected exception occurred while handling message ID {messageId}.", messageEnvelope.Id);
+            return MessageProcessStatus.Failed();
+        }
+    }
+}

--- a/src/AWS.Messaging/Services/IMessageManager.cs
+++ b/src/AWS.Messaging/Services/IMessageManager.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using AWS.Messaging.Configuration;
+
 namespace AWS.Messaging.Services;
 
 /// <summary>
@@ -22,6 +24,7 @@ public interface IMessageManager
     /// <summary>
     /// Start the async processing of a message.
     /// </summary>
-    /// <param name="messageEnvelope">The message to start processing.</param>
-    void StartProcessMessage(MessageEnvelope messageEnvelope);
+    /// <param name="messageEnvelope">The message to start processing</param>
+    /// <param name="subscriberMapping">The mapping between the message's type and its handler</param>
+    void StartProcessMessage(MessageEnvelope messageEnvelope, SubscriberMapping subscriberMapping);
 }

--- a/test/AWS.Messaging.UnitTests/HandlerInvokerTests.cs
+++ b/test/AWS.Messaging.UnitTests/HandlerInvokerTests.cs
@@ -1,0 +1,108 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Threading.Tasks;
+using AWS.Messaging.Configuration;
+using AWS.Messaging.Services;
+using AWS.Messaging.UnitTests.MessageHandlers;
+using AWS.Messaging.UnitTests.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace AWS.Messaging.UnitTests;
+
+/// <summary>
+/// Tests for <see cref="HandlerInvoker"/>
+/// </summary>
+public class HandlerInvokerTests
+{
+    /// <summary>
+    /// Tests that a single handler can be invoked successfully
+    /// </summary>
+    [Fact]
+    public async Task HandlerInvoker_HappyPath()
+    {
+        var serviceCollection = new ServiceCollection()
+            .AddAWSMessageBus(builder =>
+            {
+                builder.AddMessageHandler<ChatMessageHandler, ChatMessage>("sqsQueueUrl");
+            });
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var handlerInvoker = new HandlerInvoker(serviceProvider, new NullLogger<HandlerInvoker>());
+
+        var envelope = new MessageEnvelope<ChatMessage>();
+        var subscriberMapping = new SubscriberMapping(typeof(ChatMessageHandler), typeof(ChatMessage));
+        var messageProcessStatus = await handlerInvoker.InvokeAsync(envelope, subscriberMapping);
+
+        Assert.Equal(MessageProcessStatus.Success(), messageProcessStatus);
+    }
+
+    /// <summary>
+    /// Tests that the correct methods are invoked on a single type that
+    /// implements the handler for multiple message types
+    /// </summary>
+    [Fact]
+    public async Task HandlerInvoker_DualHandler_InvokesCorrectMethod()
+    {
+        var serviceCollection = new ServiceCollection()
+            .AddAWSMessageBus(builder =>
+            {
+                builder.AddMessageHandler<DualHandler, ChatMessage>("sqsQueueUrl");
+                builder.AddMessageHandler<DualHandler, AddressInfo>("sqsQueueUrl");
+            });
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var handlerInvoker = new HandlerInvoker(serviceProvider, new NullLogger<HandlerInvoker>());
+
+        // Assert that ChatMessage is routed to the right handler method, which always succeeds
+        var chatEnvelope = new MessageEnvelope<ChatMessage>();
+        var chatSubscriberMapping = new SubscriberMapping(typeof(DualHandler), typeof(ChatMessage));
+        var chatMessageProcessStatus = await handlerInvoker.InvokeAsync(chatEnvelope, chatSubscriberMapping);
+
+        Assert.True(chatMessageProcessStatus.IsSuccess);
+
+        // Assert that AddressInfo is routed to the right handler method, which always fails
+        var addressEnvelope = new MessageEnvelope<AddressInfo>();
+        var addressSubscriberMapping = new SubscriberMapping(typeof(DualHandler), typeof(AddressInfo));
+        var addressMessageProcessStatus = await handlerInvoker.InvokeAsync(addressEnvelope, addressSubscriberMapping);
+
+        Assert.True(addressMessageProcessStatus.IsFailed);
+    }
+
+    /// <summary>
+    /// Tests that a exception thrown by a handler is logged correctly, since
+    /// the handler is invoked via reflection we want to log the inner exception and
+    /// not the TargetInvocationException
+    /// </summary>
+    [Fact]
+    public async Task HandlerInvoker_UnwrapsTargetInvocationException()
+    {
+        var mockLogger = new Mock<ILogger<HandlerInvoker>>();
+
+        var serviceCollection = new ServiceCollection()
+            .AddAWSMessageBus(builder =>
+            {
+                builder.AddMessageHandler<ChatExceptionHandler, ChatMessage>("sqsQueueUrl");
+            });
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var handlerInvoker = new HandlerInvoker(serviceProvider, mockLogger.Object);
+        var envelope = new MessageEnvelope<ChatMessage>()
+        {
+            Id = "123"
+        };
+        var subscriberMapping = new SubscriberMapping(typeof(ChatExceptionHandler), typeof(ChatMessage));
+
+        await handlerInvoker.InvokeAsync(envelope, subscriberMapping);
+
+        mockLogger.VerifyLogError(typeof(CustomHandlerException), "A handler exception occurred while handling message ID 123.");
+
+    }
+}

--- a/test/AWS.Messaging.UnitTests/MessageBusBuilderTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessageBusBuilderTests.cs
@@ -221,6 +221,11 @@ public class MessageBusBuilderTests
         Assert.NotNull(messagePollerFactory);
         Assert.IsType<DefaultMessagePollerFactory>(messagePollerFactory);
 
+        // Verify that the helper to invoke message handlers was added
+        var handlerInvoker = serviceProvider.GetService<HandlerInvoker>();
+        Assert.NotNull(handlerInvoker);
+        Assert.IsType<HandlerInvoker>(handlerInvoker);
+
         // Verify that the message framework configuration object exists
         var messageConfiguration = serviceProvider.GetService<IMessageConfiguration>();
         Assert.NotNull(messageConfiguration);

--- a/test/AWS.Messaging.UnitTests/MessageHandlers/Handlers.cs
+++ b/test/AWS.Messaging.UnitTests/MessageHandlers/Handlers.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using AWS.Messaging.UnitTests.Models;
@@ -20,5 +21,40 @@ public class AddressInfoHandler : IMessageHandler<AddressInfo>
     public Task<MessageProcessStatus> HandleAsync(MessageEnvelope<AddressInfo> messageEnvelope, CancellationToken token = default)
     {
         return Task.FromResult(MessageProcessStatus.Success());
+    }
+}
+
+/// <summary>
+/// Implements handling for mutiple message types
+/// </summary>
+public class DualHandler : IMessageHandler<ChatMessage>, IMessageHandler<AddressInfo>
+{
+    public Task<MessageProcessStatus> HandleAsync(MessageEnvelope<ChatMessage> messageEnvelope, CancellationToken token = default)
+    {
+        return Task.FromResult(MessageProcessStatus.Success());
+    }
+
+    public Task<MessageProcessStatus> HandleAsync(MessageEnvelope<AddressInfo> messageEnvelope, CancellationToken token = default)
+    {
+        return Task.FromResult(MessageProcessStatus.Failed());
+    }
+}
+
+/// <summary>
+/// Custom exception to throw from a handler
+/// </summary>
+public class CustomHandlerException : Exception
+{
+    public CustomHandlerException(string message, Exception? innerException = null) : base(message, innerException) { }
+}
+
+/// <summary>
+/// Always throws a custom exception, useful for testing error handling
+/// </summary>
+public class ChatExceptionHandler : IMessageHandler<ChatMessage>
+{
+    public Task<MessageProcessStatus> HandleAsync(MessageEnvelope<ChatMessage> messageEnvelope, CancellationToken token = default)
+    {
+        throw new CustomHandlerException($"Unable to process message {messageEnvelope.Id}");
     }
 }

--- a/test/AWS.Messaging.UnitTests/MockExtensions.cs
+++ b/test/AWS.Messaging.UnitTests/MockExtensions.cs
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace AWS.Messaging.UnitTests;
+
+/// <summary>
+/// Extensions for <see cref="Mock"/>
+/// </summary>
+public static class MockExtensions
+{
+    /// <summary>
+    /// Verifies that Log was called on a mocked <see cref="ILogger"/> with given parameters
+    /// </summary>
+    /// <typeparam name="T">Generic type for the logger (which type you expect to log the message)</typeparam>
+    /// <param name="mock">Mocked Logger</param>
+    /// <param name="logLevel">Expected log level</param>
+    /// <param name="exceptionType">Expected type of the exception that's being logged</param>
+    /// <param name="message">Expected log message</param>
+    public static void VerifyLog<T>(this Mock<ILogger<T>> mock, LogLevel logLevel, Type exceptionType, string message)
+    {
+        mock.Verify(x => x.Log(
+            It.Is<LogLevel>(level => level == logLevel),
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((@object, @type) => @object.ToString() == message && @type.Name == "FormattedLogValues"),
+            It.Is<Exception>(exception => exception.GetType() == exceptionType),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that LogError was called on a mocked <see cref="ILogger"/> with given parameters
+    /// </summary>
+    /// <typeparam name="T">Generic type for the logger (which type you expect to log the message)</typeparam>
+    /// <param name="mock">Mocked Logger</param>
+    /// <param name="exceptionType">Expected type of the exception that's being logged</param>
+    /// <param name="message">Expected log message</param>
+    public static void VerifyLogError<T>(this Mock<ILogger<T>> mock, Type exceptionType, string message)
+    {
+        // We can't verify LogError directly because it's an extension method
+        // see https://stackoverflow.com/a/66307704/557448
+        mock.VerifyLog(LogLevel.Error, exceptionType, message);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* Part of DOTNET-6664

*Description of changes:* Introduces `HandlerInvoker`, which is responsible for identifying and invoking the handler method for a given message that we're receiving. This is just a part of the initial message manager implementation, but fairly standalone so submitting this smaller PR for review initially.

This is akin to `MessageRoutingPublisher` on the publishing side.

I didn't think this is something a user would want to provide their own implementation so only added a single concrete class without an interface, but open to feedback.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
