### PR TITLE
Adds the initial DefaultMessageManager implementation

### DIFF
--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -85,6 +85,7 @@ public class MessageBusBuilder : IMessageBusBuilder
         {
             MaxNumberOfConcurrentMessages = sqsMessagePollerOptions.MaxNumberOfConcurrentMessages,
             VisibilityTimeout = sqsMessagePollerOptions.VisibilityTimeout,
+            VisibilityTimeoutExtensionInterval = sqsMessagePollerOptions.VisibilityTimeoutExtensionInterval,
             WaitTimeSeconds = sqsMessagePollerOptions.WaitTimeSeconds
         };
 
@@ -146,7 +147,7 @@ public class MessageBusBuilder : IMessageBusBuilder
         if (_messageConfiguration.MessagePollerConfigurations.Any())
         {
             services.AddHostedService<MessagePumpService>();
-            services.TryAddSingleton<HandlerInvoker>();
+            services.TryAddSingleton<IHandlerInvoker, HandlerInvoker>();
             services.TryAddSingleton<IMessagePollerFactory, DefaultMessagePollerFactory>();
             services.TryAddSingleton<IMessageManagerFactory, DefaultMessageManagerFactory>();
 

--- a/src/AWS.Messaging/Configuration/SQSMessagePollerConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/SQSMessagePollerConfiguration.cs
@@ -20,7 +20,13 @@ internal class SQSMessagePollerConfiguration : IMessagePollerConfiguration
     /// Default value for <see cref="VisibilityTimeout"/>
     /// </summary>
     /// <remarks>The default value is 20 seconds.</remarks>
-    public const int DEFAULT_VISBILITY_TIMEOUT_SECONDS = 20;
+    public const int DEFAULT_VISIBILITY_TIMEOUT_SECONDS = 20;
+
+    /// <summary>
+    /// Default value for <see cref="VisibilityTimeoutExtensionInterval"/>
+    /// </summary>
+    /// <remarks>The default value is 18 seconds.</remarks>
+    public const int DEFAULT_VISIBILITY_TIMEOUT_EXTENSION_INTERVAL_SECONDS = 18;
 
     /// <summary>
     /// Default value for <see cref="WaitTimeSeconds"/>
@@ -43,10 +49,19 @@ internal class SQSMessagePollerConfiguration : IMessagePollerConfiguration
     /// <inheritdoc cref="ReceiveMessageRequest.VisibilityTimeout"/>
     /// </summary>
     /// <remarks>
-    /// <inheritdoc cref="DEFAULT_VISBILITY_TIMEOUT_SECONDS" path="//remarks"/>
+    /// <inheritdoc cref="DEFAULT_VISIBILITY_TIMEOUT_SECONDS" path="//remarks"/>
     /// The minimum is 0 seconds. The maximum is 12 hours.
     /// </remarks>
-    public int VisibilityTimeout { get; init; } = DEFAULT_VISBILITY_TIMEOUT_SECONDS;
+    public int VisibilityTimeout { get; init; } = DEFAULT_VISIBILITY_TIMEOUT_SECONDS;
+
+    /// <summary>
+    /// How often in seconds to extend the visibility timeout of messages that have been
+    /// received from SQS but are still being proceessed
+    /// </summary>
+    /// <remarks>
+    /// <inheritdoc cref="DEFAULT_VISIBILITY_TIMEOUT_EXTENSION_INTERVAL_SECONDS" path="//remarks"/>
+    /// </remarks>
+    public int VisibilityTimeoutExtensionInterval { get; init; } = DEFAULT_VISIBILITY_TIMEOUT_EXTENSION_INTERVAL_SECONDS;
 
     /// <summary>
     /// <inheritdoc cref="ReceiveMessageRequest.WaitTimeSeconds"/>

--- a/src/AWS.Messaging/Configuration/SQSMessagePollerOptions.cs
+++ b/src/AWS.Messaging/Configuration/SQSMessagePollerOptions.cs
@@ -14,10 +14,13 @@ public class SQSMessagePollerOptions
     public int MaxNumberOfConcurrentMessages { get; set; } = SQSMessagePollerConfiguration.DEFAULT_MAX_NUMBER_OF_CONCURRENT_MESSAGES;
 
     /// <inheritdoc cref="SQSMessagePollerConfiguration.VisibilityTimeout"/>
-    public int VisibilityTimeout { get; set; } = SQSMessagePollerConfiguration.DEFAULT_VISBILITY_TIMEOUT_SECONDS;
+    public int VisibilityTimeout { get; set; } = SQSMessagePollerConfiguration.DEFAULT_VISIBILITY_TIMEOUT_SECONDS;
 
     /// <inheritdoc cref="SQSMessagePollerConfiguration.WaitTimeSeconds"/>
     public int WaitTimeSeconds { get; set; } = SQSMessagePollerConfiguration.DEFAULT_WAIT_TIME_SECONDS;
+
+    /// <inheritdoc cref="SQSMessagePollerConfiguration.VisibilityTimeoutExtensionInterval"/>
+    public int VisibilityTimeoutExtensionInterval { get; set; } = SQSMessagePollerConfiguration.DEFAULT_VISIBILITY_TIMEOUT_EXTENSION_INTERVAL_SECONDS;
 
     /// <summary>
     /// Validates that the options are valid against the message framework's and/or SQS limits
@@ -42,6 +45,18 @@ public class SQSMessagePollerOptions
         if (WaitTimeSeconds < 0 || WaitTimeSeconds > 20)
         {
             errorMessages.Add($"{nameof(WaitTimeSeconds)} must be between 0 seconds and 20 seconds. Current value: {WaitTimeSeconds}.");
+        }
+
+        if (VisibilityTimeoutExtensionInterval <= 0)
+        {
+            errorMessages.Add($"{nameof(VisibilityTimeoutExtensionInterval)} must be greater than 0. Current value: {VisibilityTimeoutExtensionInterval}.");
+        }
+
+        if (VisibilityTimeoutExtensionInterval >= VisibilityTimeout)
+        {
+            errorMessages.Add($"{nameof(VisibilityTimeoutExtensionInterval)} ({VisibilityTimeoutExtensionInterval} seconds) " +
+                $"must be less than {nameof(VisibilityTimeout)} ({VisibilityTimeout} seconds), " +
+                $"or else other consumers may receive the message while it is still being processed.");
         }
 
         if (errorMessages.Any())

--- a/src/AWS.Messaging/Services/DefaultMessageManager.cs
+++ b/src/AWS.Messaging/Services/DefaultMessageManager.cs
@@ -1,30 +1,180 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Concurrent;
 using AWS.Messaging.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace AWS.Messaging.Services;
 
-/// <inheritdoc/>
+/// <inheritdoc cref="IMessageManager"/>
 public class DefaultMessageManager : IMessageManager
 {
     private readonly IMessagePoller _messagePoller;
-    private readonly HandlerInvoker _handlerInvoker;
-    /// <inheritdoc/>
-    public DefaultMessageManager(IMessagePoller messagePoller, HandlerInvoker handlerInvoker)
+    private readonly IHandlerInvoker _handlerInvoker;
+    private readonly ILogger<DefaultMessageManager> _logger;
+
+    private readonly object _activeMessageCountLock = new object();
+    private int _activeMessageCount;
+    private readonly ManualResetEventSlim _activeMessageCountDecrementedEvent = new ManualResetEventSlim(false);
+
+    private readonly ConcurrentDictionary<Task, MessageEnvelope> _runningHandlerTasks = new();
+    private readonly object _visibilityTimeoutExtensionTaskLock = new object();
+    private Task? _visibilityTimeoutExtensionTask;
+
+    /// <summary>
+    /// Constructs an instance of <see cref="DefaultMessageManager"/>
+    /// </summary>
+    /// <param name="messagePoller">The poller that this manager is managing messages for</param>
+    /// <param name="handlerInvoker">Used to look up and invoke the correct handler for each message</param>
+    /// <param name="logger">Logger for debugging information</param>
+    public DefaultMessageManager(IMessagePoller messagePoller, IHandlerInvoker handlerInvoker, ILogger<DefaultMessageManager> logger)
     {
         _messagePoller = messagePoller;
         _handlerInvoker = handlerInvoker;
+        _logger = logger;
     }
 
     /// <inheritdoc/>
-    public int ActiveMessageCount { get; set; }
+    public int ActiveMessageCount {
+        get
+        {
+            lock (_activeMessageCountLock)
+            {
+                return _activeMessageCount;
+            }
+        }
+        set
+        {
+            lock (_activeMessageCountLock)
+            {
+                _logger.LogTrace("Updating {activeMessageCount} from {before} to {after}", nameof(ActiveMessageCount), ActiveMessageCount, value);
+
+                var isDecrementing = value < _activeMessageCount;
+                _activeMessageCount = value;
+
+                // If we just decremented the active message count, signal to the poller
+                // that there may be more capacity available again.
+                if (isDecrementing)
+                {
+                    _activeMessageCountDecrementedEvent.Set();
+                }
+            }
+        }
+    }
 
     /// <inheritdoc/>
-    public void StartProcessMessage(MessageEnvelope messageEnvelope, SubscriberMapping subscriberMapping)
+    public Task WaitAsync(TimeSpan timeout)
     {
-        // TODO: a follow-up PR will handle managing this task, updating ActiveMessageCount, deleting the message when done.
-        // This commit is just getting the HandlerInvoker in place
-        var task = _handlerInvoker.InvokeAsync(messageEnvelope, subscriberMapping);
+        _logger.LogTrace("Beginning wait for {name} for a maximum of {timeout} seconds", nameof(_activeMessageCountDecrementedEvent), timeout.TotalSeconds);
+
+        // TODO: Rework to avoid this synchronous wait.
+        // See https://github.com/dotnet/runtime/issues/35962 for potential workarounds
+        var wasSet = _activeMessageCountDecrementedEvent.Wait(timeout);
+
+        // Don't reset if we hit the timeout
+        if (wasSet)
+        {
+            _logger.LogTrace("{name} was set, resetting the event", nameof(_activeMessageCountDecrementedEvent));
+            _activeMessageCountDecrementedEvent.Reset();
+        }
+        else
+        {
+            _logger.LogTrace("Timed out at {timeout} seconds while waiting for {name}, returning.", timeout.TotalSeconds, nameof(_activeMessageCountDecrementedEvent));
+        }
+
+        return Task.CompletedTask;
+    }
+
+
+    /// <inheritdoc/>
+    public async Task ProcessMessageAsync(MessageEnvelope messageEnvelope, SubscriberMapping subscriberMapping, CancellationToken token = default)
+    {
+        ActiveMessageCount++;
+
+        var handlerTask = _handlerInvoker.InvokeAsync(messageEnvelope, subscriberMapping, token);
+
+        // Add it to the dictionary of running task, used to extend the visibility timeout if necessary
+        _runningHandlerTasks.TryAdd(handlerTask, messageEnvelope);
+
+        StartMessageVisibilityExtensionTaskIfNotRunning(token);
+
+        // Wait for the handler to finish processing the message
+        try
+        {
+            await handlerTask;
+        }
+        catch (AWSMessagingException)
+        {
+            // Swallow exceptions thrown by the framework, and rely on the thrower to log
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An unknown exception occurred while processing message ID {subscriberEndpoint}", messageEnvelope.Id);
+        }
+
+        _runningHandlerTasks.Remove(handlerTask, out _);
+
+        if (handlerTask.IsCompletedSuccessfully)
+        {
+            if (handlerTask.Result.IsSuccess)
+            {
+                // Delete the message from the queue if it was processed successfully
+                await _messagePoller.DeleteMessagesAsync(new MessageEnvelope[] { messageEnvelope });
+            }
+            else // the handler still finished, but returned MessageProcessStatus.Failed
+            {
+                _logger.LogError("Message handling completed unsuccessfully for message ID {messageId}", messageEnvelope.Id);
+            }
+        }
+        else if (handlerTask.IsFaulted)
+        {
+            _logger.LogError(handlerTask.Exception, "Message handling failed unexpectedly for message ID {messageId}", messageEnvelope.Id);
+        }
+
+        ActiveMessageCount--;
+    }
+
+    /// <summary>
+    /// Starts the task that extends the visibility timeout of in-flight messages
+    /// </summary>
+    /// <param name="token">Cancellation token to stop the visibility timeout extension task</param>
+    private void StartMessageVisibilityExtensionTaskIfNotRunning(CancellationToken token)
+    {
+        // It may either have been never started, or previously started and completed because there were no more in flight messages
+        if (_visibilityTimeoutExtensionTask == null || _visibilityTimeoutExtensionTask.IsCompleted)
+        {
+            lock(_visibilityTimeoutExtensionTaskLock)
+            {
+                if (_visibilityTimeoutExtensionTask == null || _visibilityTimeoutExtensionTask.IsCompleted)
+                {
+                    _visibilityTimeoutExtensionTask = ExtendUnfinishedMessageVisibilityTimeoutBatch(token);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Extends the visibility timeout periodically for messages whose corresponding handler task is not yet complete
+    /// </summary>
+    /// <param name="token">Cancellation token to stop the visibility timeout extension loop</param>
+    private async Task ExtendUnfinishedMessageVisibilityTimeoutBatch(CancellationToken token)
+    {
+        IEnumerable<MessageEnvelope> unfinishedMessages;
+
+        do
+        {
+            // Wait for the configured interval before extending visibility
+            await Task.Delay(_messagePoller.VisibilityTimeoutExtensionInterval * 1000, token);
+
+            // Select the message envelopes whose corresponding handler task is not yet complete
+             unfinishedMessages = _runningHandlerTasks.Values;
+
+            // TODO: The envelopes in _runningHandlerTasks may have been received at different times, we could track + extend visibility separately
+            // TODO: The underlying ChangeMessageVisibilityBatch only takes up to 10 messages, we may need to slice and make multiple calls
+            // TODO: Handle the race condition where a message could have finished handling and be deleted concurrently
+            await _messagePoller.ExtendMessageVisibilityTimeoutAsync(unfinishedMessages);
+
+        } while (unfinishedMessages.Count() > 0 && !token.IsCancellationRequested);
     }
 }

--- a/src/AWS.Messaging/Services/HandlerInvoker.cs
+++ b/src/AWS.Messaging/Services/HandlerInvoker.cs
@@ -8,10 +8,8 @@ using Microsoft.Extensions.Logging;
 
 namespace AWS.Messaging.Services;
 
-/// <summary>
-/// Identifies and invokes the correct method on a registered <see cref="IMessageHandler{T}"/> for received messages
-/// </summary>
-public class HandlerInvoker
+/// <inheritdoc cref="IHandlerInvoker"/>
+public class HandlerInvoker : IHandlerInvoker
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<HandlerInvoker> _logger;
@@ -33,13 +31,7 @@ public class HandlerInvoker
         _logger = logger;
     }
 
-    /// <summary>
-    /// Identifies and invokes the correct method to invoke on a registered <see cref="IMessageHandler{T}"/> for the given message
-    /// </summary>
-    /// <param name="messageEnvelope">Envelope of the message that is being handled</param>
-    /// <param name="subscriberMapping">Subscriber mapping of the message that is being handled</param>
-    /// <param name="token">Cancellation token which will be passed to the message handler</param>
-    /// <returns>Task representing the outcome of the message handler</returns>
+    /// <inheritdoc/>
     public async Task<MessageProcessStatus> InvokeAsync(MessageEnvelope messageEnvelope, SubscriberMapping subscriberMapping, CancellationToken token = default)
     {
         var handler = _serviceProvider.GetService(subscriberMapping.HandlerType);

--- a/src/AWS.Messaging/Services/IHandlerInvoker.cs
+++ b/src/AWS.Messaging/Services/IHandlerInvoker.cs
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Messaging.Configuration;
+
+namespace AWS.Messaging.Services;
+
+/// <summary>
+/// Identifies and invokes the correct method on a registered <see cref="IMessageHandler{T}"/> for received messages
+/// </summary>
+public interface IHandlerInvoker
+{
+    /// <summary>
+    /// Identifies and calls the correct method on a registered <see cref="IMessageHandler{T}"/> for the given message
+    /// </summary>
+    /// <param name="messageEnvelope">Envelope of the message that is being handled</param>
+    /// <param name="subscriberMapping">Subscriber mapping of the message that is being handled</param>
+    /// <param name="token">Cancellation token which will be passed to the message handler</param>
+    /// <returns>Task representing the outcome of the message handler</returns>
+    Task<MessageProcessStatus> InvokeAsync(MessageEnvelope messageEnvelope, SubscriberMapping subscriberMapping, CancellationToken token = default);
+}

--- a/src/AWS.Messaging/Services/IMessageManager.cs
+++ b/src/AWS.Messaging/Services/IMessageManager.cs
@@ -7,13 +7,16 @@ namespace AWS.Messaging.Services;
 
 /// <summary>
 /// Instances of <see cref="AWS.Messaging.Services.IMessageManager" /> manage the lifecycle of a message being processed.
-///
-/// Responsibilities:
-/// * Start the async work of processing messages and add the task to collection of active tasks
-/// * Monitor the active processing message's task
-/// * If a task completes with success status code delete message
-/// * While the message tasks are working periodically inform the source the message is still being processed.
 /// </summary>
+/// <remarks>
+/// Responsibilities:
+/// <list type="bullet">
+/// <item><description>Start the async work of processing messages and add the task to collection of active tasks</description></item>
+/// <item><description>Monitor the active processing message's task</description></item>
+/// <item><description>If a task completes with success status code delete message</description></item>
+/// <item><description>While the message tasks are working periodically inform the source the message is still being processed.</description></item>
+/// </list>
+/// </remarks>
 public interface IMessageManager
 {
     /// <summary>
@@ -22,9 +25,16 @@ public interface IMessageManager
     int ActiveMessageCount { get; }
 
     /// <summary>
+    /// Allows a poller to wait for when <see cref="ActiveMessageCount"/> is next decremented or when the timeout elapses
+    /// </summary>
+    /// <param name="timeout">Maximum amount of time to wait</param>
+    Task WaitAsync(TimeSpan timeout);
+
+    /// <summary>
     /// Start the async processing of a message.
     /// </summary>
     /// <param name="messageEnvelope">The message to start processing</param>
     /// <param name="subscriberMapping">The mapping between the message's type and its handler</param>
-    void StartProcessMessage(MessageEnvelope messageEnvelope, SubscriberMapping subscriberMapping);
+    /// <param name="token">Optional token to cancel the message processing</param>
+    Task ProcessMessageAsync(MessageEnvelope messageEnvelope, SubscriberMapping subscriberMapping, CancellationToken token = default);
 }

--- a/src/AWS.Messaging/Services/IMessagePoller.cs
+++ b/src/AWS.Messaging/Services/IMessagePoller.cs
@@ -14,23 +14,28 @@ namespace AWS.Messaging.Services;
 public interface IMessagePoller
 {
     /// <summary>
+    /// How frequently message visibility should be extended in seconds
+    /// via <see cref="ExtendMessageVisibilityTimeoutAsync"/> while the message is still being processed
+    /// </summary>
+    int VisibilityTimeoutExtensionInterval { get; }
+
+    /// <summary>
     /// Start polling the underlying service. Polling will run indefinitely till the CancellationToken is cancelled.
     /// </summary>
     /// <param name="token">Optional cancellation token to shutdown the poller.</param>
-    /// <returns></returns>
-    Task StartPollingAsync(CancellationToken token = default(CancellationToken));
+    Task StartPollingAsync(CancellationToken token = default);
 
     /// <summary>
     /// Delete the message in the underlying service.
     /// </summary>
     /// <param name="messages">The messages to delete.</param>
-    /// <returns></returns>
-    Task DeleteMessagesAsync(IEnumerable<MessageEnvelope> messages);
+    /// <param name="token">Optional token to cancel the deletion.</param>
+    Task DeleteMessagesAsync(IEnumerable<MessageEnvelope> messages, CancellationToken token = default);
 
     /// <summary>
     /// Inform the underlying service to extend the message's visibility timeout because the message is still being processed.
     /// </summary>
     /// <param name="messages">The messages to extend their visibility timeout.</param>
-    /// <returns></returns>
-    Task ExtendMessageVisiblityTimeoutAsync(IEnumerable<MessageEnvelope> messages);
+    /// <param name="token">Optional token to cancel the visibility timeout extension.</param>
+    Task ExtendMessageVisibilityTimeoutAsync(IEnumerable<MessageEnvelope> messages, CancellationToken token = default);
 }

--- a/test/AWS.Messaging.UnitTests/DefaultMessageManagerTests.cs
+++ b/test/AWS.Messaging.UnitTests/DefaultMessageManagerTests.cs
@@ -1,0 +1,188 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AWS.Messaging.Configuration;
+using AWS.Messaging.Services;
+using AWS.Messaging.UnitTests.MessageHandlers;
+using AWS.Messaging.UnitTests.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace AWS.Messaging.UnitTests
+{
+    public class DefaultMessageManagerTests
+    {
+        /// <summary>
+        /// Happy path test for a successful message handling, that it is deleted at at the end
+        /// </summary>
+        [Fact]
+        public async Task DefaultMessageManager_ManagesMessageSuccess()
+        {
+            var mockPoller = CreateMockPoller(messageVisibilityRefreshInterval: 10);
+            var mockHandlerInvoker = CreateMockHandlerInvoker(MessageProcessStatus.Success());
+
+            var manager = new DefaultMessageManager(mockPoller.Object, mockHandlerInvoker.Object, new NullLogger<DefaultMessageManager>());
+
+            var messsageEnvelope = new MessageEnvelope<ChatMessage>();
+            var subscriberMapping = new SubscriberMapping(typeof(ChatMessageHandler), typeof(ChatMessage));
+
+            await manager.ProcessMessageAsync(messsageEnvelope, subscriberMapping);
+
+            // Verify that the handler was invoked once with the expected message and mapping
+            mockHandlerInvoker.Verify(x => x.InvokeAsync(
+                    It.Is<MessageEnvelope>(actualEnvelope => actualEnvelope == messsageEnvelope),
+                    It.Is<SubscriberMapping>(actualMapping => actualMapping == subscriberMapping),
+                    It.IsAny<CancellationToken>()),
+                Times.Once());
+
+            // Since the mock handler invoker returns success, verify that delete was called
+            mockPoller.Verify(poller => poller.DeleteMessagesAsync(
+                    It.Is<IEnumerable<MessageEnvelope>>(x => x.Count() == 1 && x.First() == messsageEnvelope),
+                    It.IsAny<CancellationToken>()),
+                Times.Once());
+
+            // Since the handler succeeds right away, verify the visiblity was never extended
+            mockPoller.Verify(poller => poller.ExtendMessageVisibilityTimeoutAsync(
+                    It.IsAny<IEnumerable<MessageEnvelope>>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never());
+
+            // Verify that the active message count was deprecated back to 0
+            Assert.Equal(0, manager.ActiveMessageCount);
+        }
+
+        [Fact]
+        public async Task DefaultMessageManager_ManagesMessageFailed()
+        {
+            var mockPoller = CreateMockPoller(messageVisibilityRefreshInterval: 10);
+            var mockHandlerInvoker = CreateMockHandlerInvoker(MessageProcessStatus.Failed());
+
+            var manager = new DefaultMessageManager(mockPoller.Object, mockHandlerInvoker.Object, new NullLogger<DefaultMessageManager>());
+
+            var messsageEnvelope = new MessageEnvelope<ChatMessage>();
+            var subscriberMapping = new SubscriberMapping(typeof(ChatMessageHandler), typeof(ChatMessage));
+
+            await manager.ProcessMessageAsync(messsageEnvelope, subscriberMapping);
+
+            // Verify that the handler was invoked once with the expected message and mapping
+            mockHandlerInvoker.Verify(x => x.InvokeAsync(
+                    It.Is<MessageEnvelope>(actualEnvelope => actualEnvelope == messsageEnvelope),
+                    It.Is<SubscriberMapping>(actualMapping => actualMapping == subscriberMapping),
+                    It.IsAny<CancellationToken>()),
+                Times.Once());
+
+            // Since the message handling failed, verify that delete was never called
+            mockPoller.Verify(poller => poller.DeleteMessagesAsync(
+                    It.IsAny<IEnumerable<MessageEnvelope>>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never());
+
+            // Since the handler fails right away, verify the visiblity was never extended
+            mockPoller.Verify(poller => poller.ExtendMessageVisibilityTimeoutAsync(
+                    It.IsAny<IEnumerable<MessageEnvelope>>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never());
+
+            // Verify that the active message count was deprecated back to 0
+            Assert.Equal(0, manager.ActiveMessageCount);
+        }
+
+        [Fact]
+        public async Task DefaultMessageManager_RefreshesLongHandler()
+        {
+            var mockPoller = CreateMockPoller(messageVisibilityRefreshInterval: 1);
+            var mockHandlerInvoker = CreateMockHandlerInvoker(MessageProcessStatus.Success(), messageHandlingDelay: TimeSpan.FromSeconds(3));
+
+            var manager = new DefaultMessageManager(mockPoller.Object, mockHandlerInvoker.Object, new NullLogger<DefaultMessageManager>());
+
+            var messsageEnvelope = new MessageEnvelope<ChatMessage>();
+            var subscriberMapping = new SubscriberMapping(typeof(ChatMessageHandler), typeof(ChatMessage));
+
+            // Don't await the task, but start it so we can assert ActiveMessageCount was incremented while the handler is still processing
+            var task = manager.ProcessMessageAsync(messsageEnvelope, subscriberMapping);
+            Assert.Equal(1, manager.ActiveMessageCount);
+
+            // Now finish awaiting the handler
+            await task;
+
+            // Verify that the handler was invoked once with the expected message and mapping
+            mockHandlerInvoker.Verify(x => x.InvokeAsync(
+                        It.Is<MessageEnvelope>(actualEnvelope => actualEnvelope == messsageEnvelope),
+                        It.Is<SubscriberMapping>(actualMapping => actualMapping == subscriberMapping),
+                        It.IsAny<CancellationToken>()),
+                Times.Once());
+
+            // Since the mock handler invoker returns success, verify that delete was called
+            mockPoller.Verify(poller => poller.DeleteMessagesAsync(
+                    It.Is<IEnumerable<MessageEnvelope>>(x => x.Count() == 1 && x.First() == messsageEnvelope),
+                    It.IsAny<CancellationToken>()),
+                Times.Once());
+
+            // Since the message handler takes 3 seconds, verify the the visibility was extended
+            // TODO: the 2 to 3 allows for some instability
+            mockPoller.Verify(poller => poller.ExtendMessageVisibilityTimeoutAsync(
+                    It.Is<IEnumerable<MessageEnvelope>>(x => x.Count() == 1 && x.First() == messsageEnvelope),
+                    It.IsAny<CancellationToken>()),
+                Times.Between(2, 3, Moq.Range.Inclusive));
+
+            // Verify that the active message count was deprecated back to 0
+            Assert.Equal(0, manager.ActiveMessageCount);
+        }
+
+        /// <summary>
+        /// Mocks a message poller with the given visibility refresh interval
+        /// </summary>
+        /// <param name="messageVisibilityRefreshInterval">How frequently the manager should extend message visibility in seconds</param>
+        /// <returns>Mock poller</returns>
+        private Mock<IMessagePoller> CreateMockPoller(int messageVisibilityRefreshInterval)
+        {
+            var mockPoller = new Mock<IMessagePoller>();
+
+            mockPoller.Setup(x => x.ExtendMessageVisibilityTimeoutAsync(
+                    It.IsAny<IEnumerable<MessageEnvelope>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            mockPoller.Setup(x => x.VisibilityTimeoutExtensionInterval).Returns(messageVisibilityRefreshInterval);
+
+            return mockPoller;
+        }
+
+        /// <summary>
+        /// Mocks a handler invoker that will always return the given status with an optional delay
+        /// </summary>
+        /// <param name="messageProcessStatus">Message status the handler should always return</param>
+        /// <param name="messageHandlingDelay">Optional delay during handling, leave null to return immediately</param>
+        /// <returns>Mock handler invoker</returns>
+        private Mock<IHandlerInvoker> CreateMockHandlerInvoker(MessageProcessStatus messageProcessStatus, TimeSpan? messageHandlingDelay = null)
+        {
+            var mockHandlerInvoker = new Mock<IHandlerInvoker>();
+
+            // Moq doesn't support passing in null or TimeSpan.Zero (the default value) for the delay, so branch
+            if (messageHandlingDelay != null)
+            {
+                mockHandlerInvoker.Setup(x => x.InvokeAsync(
+                    It.IsAny<MessageEnvelope>(),
+                    It.IsAny<SubscriberMapping>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(messageProcessStatus, (TimeSpan)messageHandlingDelay);
+            }
+            else // return the status immediately
+            {
+                mockHandlerInvoker.Setup(x => x.InvokeAsync(
+                    It.IsAny<MessageEnvelope>(),
+                    It.IsAny<SubscriberMapping>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(messageProcessStatus);
+            }
+
+            return mockHandlerInvoker;
+        }
+    }
+}

--- a/test/AWS.Messaging.UnitTests/SQSMessagePollerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SQSMessagePollerTests.cs
@@ -85,13 +85,13 @@ public class SQSMessagePollerTests
             It.Is<DeleteMessageBatchRequest>(request =>
                 request.QueueUrl == TEST_QUEUE_URL &&
                 request.Entries.Count == 2 &&
-                request.Entries.Any(x => x.ReceiptHandle == "rh1") &&
-                request.Entries.Any(x => x.ReceiptHandle == "rh2")),
+                request.Entries.Any(entry => entry.Id == "1" && entry.ReceiptHandle == "rh1") &&
+                request.Entries.Any(entry => entry.Id == "2" && entry.ReceiptHandle == "rh2")),
             It.IsAny<CancellationToken>()));
     }
 
     /// <summary>
-    /// Tests that calling <see cref="IMessagePoller.ExtendMessageVisiblityTimeoutAsync"/> calls
+    /// Tests that calling <see cref="IMessagePoller.ExtendMessageVisibilityTimeoutAsync"/> calls
     /// SQS's ChangeMessageVisibilityBatch with an expected request.
     /// </summary>
     [Fact]
@@ -110,14 +110,14 @@ public class SQSMessagePollerTests
             new MessageEnvelope<ChatMessage> { Id = "2", SQSMetadata = new SQSMetadata { ReceiptHandle ="rh2"} }
         };
 
-        await messagePoller.ExtendMessageVisiblityTimeoutAsync(messageEnvelopes);
+        await messagePoller.ExtendMessageVisibilityTimeoutAsync(messageEnvelopes);
 
         client.Verify(x => x.ChangeMessageVisibilityBatchAsync(
             It.Is<ChangeMessageVisibilityBatchRequest>(request =>
                 request.QueueUrl == TEST_QUEUE_URL &&
                 request.Entries.Count == 2 &&
-                request.Entries.Any(x => x.ReceiptHandle == "rh1") &&
-                request.Entries.Any(x => x.ReceiptHandle == "rh2")),
+                request.Entries.Any(entry => entry.Id == "1" && entry.ReceiptHandle == "rh1") &&
+                request.Entries.Any(entry => entry.Id == "2" && entry.ReceiptHandle == "rh2")),
             It.IsAny<CancellationToken>()));
     }
 


### PR DESCRIPTION
*Issue #, if available:* DOTNET-6664

*Description of changes:* Adds the message manager, which was the last missing component for the subscriber workflow!

Some loose ends since I'm rushing to get this out before vacation:
* We're now able to write integration tests more easily, though none are included here. We might want to break into a separate task. I've done some manual testing of single message workflows.
* There's a TODO in the code, I'm unsure if we want to plumb the `CancellationToken` for the entire poller down into a single message's handling (and therefore its delete or visibility extension calls). 
* The unit test that a 3 second message handling with a 1 second visibility window will call extend either 2 or 3 times. I used `Between` so it always passes for now, but might need to tighten it up.
* I haven't done any unit or manual/integration testing for more then one message in the queue at a time, so the synchronization around `ActiveMessageCount` hasn't been exercised much.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
