### PR TITLE
feat: Add support for EventBridge global endpoints

### DIFF
--- a/src/AWS.Messaging/Configuration/EventBridgePublishOptions.cs
+++ b/src/AWS.Messaging/Configuration/EventBridgePublishOptions.cs
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Configuration;
+
+/// <summary>
+/// Contains additional properties that can be set while configuring a EventBridge publisher.
+/// </summary>
+public class EventBridgePublishOptions
+{
+    /// <summary>
+    /// The ID of the global EventBridge endpoint.
+    /// </summary>
+    public string? EndpointID { get; set; }
+}

--- a/src/AWS.Messaging/Configuration/EventBridgePublisherConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/EventBridgePublisherConfiguration.cs
@@ -9,19 +9,24 @@ namespace AWS.Messaging.Configuration;
 public class EventBridgePublisherConfiguration : IMessagePublisherConfiguration
 {
     /// <summary>
-    /// Retrieves the EventBridge Event Bus URL which the publisher will use to route the message.
+    /// Retrieves the EventBridge Event Bus name or ARN which the publisher will use to route the message.
     /// </summary>
     public string PublisherEndpoint { get; set; }
 
     /// <summary>
+    /// The ID of the global EventBridge endpoint.
+    /// </summary>
+    public string? EndpointID { get; set; }
+
+    /// <summary>
     /// Creates an instance of <see cref="EventBridgePublisherConfiguration"/>.
     /// </summary>
-    /// <param name="eventBusUrl">The EventBus URL</param>
-    public EventBridgePublisherConfiguration(string eventBusUrl)
+    /// <param name="eventBusName">The name or the ARN of the event bus where the mesasge is published</param>
+    public EventBridgePublisherConfiguration(string eventBusName)
     {
-        if (string.IsNullOrEmpty(eventBusUrl))
-            throw new InvalidPublisherEndpointException("The Event Bus URL cannot be empty.");
+        if (string.IsNullOrEmpty(eventBusName))
+            throw new InvalidPublisherEndpointException("The event bus name cannot be empty.");
 
-        PublisherEndpoint = eventBusUrl;
+        PublisherEndpoint = eventBusName;
     }
 }

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -25,12 +25,13 @@ public interface IMessageBusBuilder
     IMessageBusBuilder AddSNSPublisher<TMessage>(string topicUrl, string? messageTypeIdentifier = null);
 
     /// <summary>
-    /// Adds an EventBridge Publisher to the framework which will handle publishing
-    /// the defined message type to the specified EventBridge event bus URL.
+    /// Adds an EventBridge Publisher to the framework which will handle publishing the defined message type to the specified EventBridge event bus name.
+    /// If you are specifying a global endpoint ID via <see cref="EventBridgePublishOptions"/>, then you must also include the <see href="https://www.nuget.org/packages/AWSSDK.Extensions.CrtIntegration">AWSSDK.Extensions.CrtIntegration</see> package in your application.
     /// </summary>
-    /// <param name="eventBusUrl">The EventBridge event bus URL to publish the message to.</param>
+    /// <param name="eventBusName">The EventBridge event bus name or ARN where the message will be published.</param>
     /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
-    IMessageBusBuilder AddEventBridgePublisher<TMessage>(string eventBusUrl, string? messageTypeIdentifier = null);
+    /// <param name="options">Contains additional properties that can be set while configuring an EventBridge publisher</param>
+    IMessageBusBuilder AddEventBridgePublisher<TMessage>(string eventBusName, string? messageTypeIdentifier = null, EventBridgePublishOptions? options = null);
 
     /// <summary>
     /// Add a message handler for a given message type.

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -42,9 +42,12 @@ public class MessageBusBuilder : IMessageBusBuilder
     }
 
     /// <inheritdoc/>
-    public IMessageBusBuilder AddEventBridgePublisher<TMessage>(string eventBusUrl, string? messageTypeIdentifier = null)
+    public IMessageBusBuilder AddEventBridgePublisher<TMessage>(string eventBusName, string? messageTypeIdentifier = null, EventBridgePublishOptions? options = null)
     {
-        var eventBridgePublisherConfiguration = new EventBridgePublisherConfiguration(eventBusUrl);
+        var eventBridgePublisherConfiguration = new EventBridgePublisherConfiguration(eventBusName)
+        {
+            EndpointID = options?.EndpointID
+        };
         return AddPublisher<TMessage>(eventBridgePublisherConfiguration, PublisherTargetType.EVENTBRIDGE_PUBLISHER, messageTypeIdentifier);
     }
 


### PR DESCRIPTION
**Issue #, if available:**
DOTNET-6818

**What is an EventBridge global endpoint?**
Read this blog for a detailed understanding - https://aws.amazon.com/blogs/compute/introducing-global-endpoints-for-amazon-eventbridge/

**tl;dr:**
Global endpoints aim to improve availability and fault tolerence. Each global endpoint must be backed by exactly 2 event buses (primary and secondary) in different AWS regions. These event buses need to have the same name. Under normal operating conditions, any message published to a global endpoint is routed to the primary event bus. When the the primary event bus experiences a failure, the messages are routed to the secondary event bus.

**While invoking the `PutEvents` operation against a global endpoint, its corresponding event bus name must also be passed to the request object.**

***Description of changes:***
This PR adds support for publishing messages to EventBridge global endpoints.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
