### PR TITLE
chore: modify SDK User-Agent header for metrics tracking

### DIFF
--- a/src/AWS.Messaging/Configuration/AWSClientProvider.cs
+++ b/src/AWS.Messaging/Configuration/AWSClientProvider.cs
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Reflection;
+using Amazon.Runtime;
+
+namespace AWS.Messaging.Configuration;
+
+/// <summary>
+/// Provides an AWS service client from the DI container
+/// </summary>
+internal class AWSClientProvider : IAWSClientProvider
+{
+    private const string _userAgentHeader = "User-Agent";
+    private static readonly string _assemblyVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? string.Empty;
+    private static readonly string _userAgentString = $"lib/aws-dotnet-messaging_{_assemblyVersion}";
+
+    private readonly IServiceProvider _serviceProvider;
+
+    /// <summary>
+    /// Creates an instance of <see cref="AWSClientProvider"/>
+    /// </summary>
+    public AWSClientProvider(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    /// <inheritdoc/>
+    public T GetServiceClient<T>() where T : IAmazonService
+    {
+        var serviceClient =  _serviceProvider.GetService(typeof(T)) ?? throw new FailedToFindAWSServiceClientException($"Failed to find AWS service client of type {typeof(T)}");
+        if (serviceClient is AmazonServiceClient)
+        {
+            ((AmazonServiceClient)serviceClient).BeforeRequestEvent += AWSServiceClient_BeforeServiceRequest;
+        }
+        return (T)serviceClient;
+    }
+
+    private static void AWSServiceClient_BeforeServiceRequest(object sender, RequestEventArgs e)
+    {
+        if (e is not WebServiceRequestEventArgs args || !args.Headers.ContainsKey(_userAgentHeader) || args.Headers[_userAgentHeader].Contains(_userAgentString))
+            return;
+
+        args.Headers[_userAgentHeader] = args.Headers[_userAgentHeader] + " " + _userAgentString;
+    }
+}

--- a/src/AWS.Messaging/Configuration/IAWSClientProvider.cs
+++ b/src/AWS.Messaging/Configuration/IAWSClientProvider.cs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Runtime;
+
+namespace AWS.Messaging.Configuration;
+
+/// <summary>
+/// Provides an AWS service client from the DI container
+/// </summary>
+public interface IAWSClientProvider
+{
+    /// <summary>
+    /// Returns the AWS service client that was injected into the DI container
+    /// </summary>
+    /// <typeparam name="T">This type must implement <see cref="IAmazonService"/></typeparam>
+    T GetServiceClient<T>() where T : IAmazonService;
+}

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -113,6 +113,7 @@ public class MessageBusBuilder : IMessageBusBuilder
         services.TryAddSingleton<IEnvelopeSerializer, EnvelopeSerializer>();
         services.TryAddSingleton<IDateTimeHandler, DateTimeHandler>();
         services.TryAddSingleton<IMessageIdGenerator, MessageIdGenerator>();
+        services.TryAddSingleton<IAWSClientProvider, AWSClientProvider>();
 
         if (_messageConfiguration.PublisherMappings.Any())
         {

--- a/src/AWS.Messaging/Exceptions.cs
+++ b/src/AWS.Messaging/Exceptions.cs
@@ -193,3 +193,14 @@ public class InvalidMessageHandlerSignatureException : AWSMessagingException
     /// </summary>
     public InvalidMessageHandlerSignatureException(string message, Exception? innerException = null) : base(message, innerException) { }
 }
+
+/// <summary>
+/// Thrown if could not retrieve the AWS service client from the DI container.
+/// </summary>
+public class FailedToFindAWSServiceClientException : AWSMessagingException
+{
+    /// <summary>
+    /// Creates an instance of <see cref="InvalidMessageHandlerSignatureException"/>.
+    /// </summary>
+    public FailedToFindAWSServiceClientException(string message, Exception? innerException = null) : base(message, innerException) { }
+}

--- a/src/AWS.Messaging/Publishers/EventBridge/EventBridgePublisher.cs
+++ b/src/AWS.Messaging/Publishers/EventBridge/EventBridgePublisher.cs
@@ -23,12 +23,12 @@ internal class EventBridgePublisher : IMessagePublisher, IEventBridgePublisher
     /// Creates an instance of <see cref="EventBridgePublisher"/>.
     /// </summary>
     public EventBridgePublisher(
-        IAmazonEventBridge eventBridgeClient,
+        IAWSClientProvider awsClientProvider,
         ILogger<IMessagePublisher> logger,
         IMessageConfiguration messageConfiguration,
         IEnvelopeSerializer envelopeSerializer)
     {
-        _eventBridgeClient = eventBridgeClient;
+        _eventBridgeClient = awsClientProvider.GetServiceClient<IAmazonEventBridge>();
         _logger = logger;
         _messageConfiguration = messageConfiguration;
         _envelopeSerializer = envelopeSerializer;

--- a/src/AWS.Messaging/Publishers/SNS/SNSPublisher.cs
+++ b/src/AWS.Messaging/Publishers/SNS/SNSPublisher.cs
@@ -23,12 +23,12 @@ internal class SNSPublisher : IMessagePublisher, ISNSPublisher
     /// Creates an instance of <see cref="SNSPublisher"/>.
     /// </summary>
     public SNSPublisher(
-        IAmazonSimpleNotificationService snsClient,
+        IAWSClientProvider awsClientProvider,
         ILogger<IMessagePublisher> logger,
         IMessageConfiguration messageConfiguration,
         IEnvelopeSerializer envelopeSerializer)
     {
-        _snsClient = snsClient;
+        _snsClient = awsClientProvider.GetServiceClient<IAmazonSimpleNotificationService>();
         _logger = logger;
         _messageConfiguration = messageConfiguration;
         _envelopeSerializer = envelopeSerializer;

--- a/src/AWS.Messaging/Publishers/SQS/SQSPublisher.cs
+++ b/src/AWS.Messaging/Publishers/SQS/SQSPublisher.cs
@@ -23,12 +23,12 @@ internal class SQSPublisher : IMessagePublisher, ISQSPublisher
     /// Creates an instance of <see cref="SQSPublisher"/>.
     /// </summary>
     public SQSPublisher(
-        IAmazonSQS sqsClient,
+        IAWSClientProvider awsClientProvider,
         ILogger<IMessagePublisher> logger,
         IMessageConfiguration messageConfiguration,
         IEnvelopeSerializer envelopeSerializer)
     {
-        _sqsClient = sqsClient;
+        _sqsClient = awsClientProvider.GetServiceClient<IAmazonSQS>();
         _logger = logger;
         _messageConfiguration = messageConfiguration;
         _envelopeSerializer = envelopeSerializer;

--- a/src/AWS.Messaging/SQS/SQSMessagePoller.cs
+++ b/src/AWS.Messaging/SQS/SQSMessagePoller.cs
@@ -36,18 +36,18 @@ internal class SQSMessagePoller : IMessagePoller
     /// </summary>
     /// <param name="logger">Logger for debugging information.</param>
     /// <param name="messageManagerFactory">The factory to create the message manager for processing messages.</param>
-    /// <param name="sqsClient">SQS service client to use for service API calls.</param>
+    /// <param name="awsClientProvider">Provides the AWS service client from the DI container.</param>
     /// <param name="configuration">The SQS message poller configuration.</param>
     /// <param name="envelopeSerializer">Serializer used to deserialize the SQS messages</param>
     public SQSMessagePoller(
         ILogger<SQSMessagePoller> logger,
         IMessageManagerFactory messageManagerFactory,
-        IAmazonSQS sqsClient,
+        IAWSClientProvider awsClientProvider,
         SQSMessagePollerConfiguration configuration,
         IEnvelopeSerializer envelopeSerializer)
     {
         _logger = logger;
-        _sqsClient = sqsClient;
+        _sqsClient = awsClientProvider.GetServiceClient<IAmazonSQS>();
         _configuration = configuration;
         _envelopeSerializer = envelopeSerializer;
 

--- a/test/AWS.Messaging.UnitTests/MessagePublisherTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessagePublisherTests.cs
@@ -104,12 +104,14 @@ public class MessagePublisherTests
     {
         var publisherConfiguration = new SQSPublisherConfiguration("endpoint");
         var publisherMapping = new PublisherMapping(typeof(ChatMessage), publisherConfiguration, PublisherTargetType.SQS_PUBLISHER);
+        var awsClientProvider = new AWSClientProvider(_serviceProvider.Object);
 
         _serviceProvider.Setup(x => x.GetService(typeof(IAmazonSQS))).Returns(_sqsClient.Object);
         _serviceProvider.Setup(x => x.GetService(typeof(ILogger<IMessagePublisher>))).Returns(_logger.Object);
         _serviceProvider.Setup(x => x.GetService(typeof(IMessageConfiguration))).Returns(_messageConfiguration.Object);
         _serviceProvider.Setup(x => x.GetService(typeof(IEnvelopeSerializer))).Returns(_envelopeSerializer.Object);
         _messageConfiguration.Setup(x => x.GetPublisherMapping(typeof(ChatMessage))).Returns(publisherMapping);
+        _serviceProvider.Setup(x => x.GetService(typeof(IAWSClientProvider))).Returns(awsClientProvider);
     }
 
     [Fact]
@@ -131,12 +133,14 @@ public class MessagePublisherTests
     {
         var publisherConfiguration = new SNSPublisherConfiguration("endpoint");
         var publisherMapping = new PublisherMapping(typeof(ChatMessage), publisherConfiguration, PublisherTargetType.SNS_PUBLISHER);
+        var awsClientProvider = new AWSClientProvider(_serviceProvider.Object);
 
         _serviceProvider.Setup(x => x.GetService(typeof(IAmazonSimpleNotificationService))).Returns(_snsClient.Object);
         _serviceProvider.Setup(x => x.GetService(typeof(ILogger<IMessagePublisher>))).Returns(_logger.Object);
         _serviceProvider.Setup(x => x.GetService(typeof(IMessageConfiguration))).Returns(_messageConfiguration.Object);
         _serviceProvider.Setup(x => x.GetService(typeof(IEnvelopeSerializer))).Returns(_envelopeSerializer.Object);
         _messageConfiguration.Setup(x => x.GetPublisherMapping(typeof(ChatMessage))).Returns(publisherMapping);
+        _serviceProvider.Setup(x => x.GetService(typeof(IAWSClientProvider))).Returns(awsClientProvider);
     }
 
     [Fact]
@@ -183,12 +187,14 @@ public class MessagePublisherTests
         };
 
         var publisherMapping = new PublisherMapping(typeof(ChatMessage), publisherConfiguration, PublisherTargetType.EVENTBRIDGE_PUBLISHER);
+        var awsClientProvider = new AWSClientProvider(_serviceProvider.Object);
 
         _serviceProvider.Setup(x => x.GetService(typeof(IAmazonEventBridge))).Returns(_eventBridgeClient.Object);
         _serviceProvider.Setup(x => x.GetService(typeof(ILogger<IMessagePublisher>))).Returns(_logger.Object);
         _serviceProvider.Setup(x => x.GetService(typeof(IMessageConfiguration))).Returns(_messageConfiguration.Object);
         _serviceProvider.Setup(x => x.GetService(typeof(IEnvelopeSerializer))).Returns(_envelopeSerializer.Object);
         _messageConfiguration.Setup(x => x.GetPublisherMapping(typeof(ChatMessage))).Returns(publisherMapping);
+        _serviceProvider.Setup(x => x.GetService(typeof(IAWSClientProvider))).Returns(awsClientProvider);
     }
     
     [Fact]
@@ -245,7 +251,7 @@ public class MessagePublisherTests
         _eventBridgeClient.Setup(x => x.PutEventsAsync(It.IsAny<PutEventsRequest>(), It.IsAny<CancellationToken>()));
 
         var messagePublisher = new EventBridgePublisher(
-            _eventBridgeClient.Object,
+            (IAWSClientProvider)_serviceProvider.Object.GetService(typeof(IAWSClientProvider))!,
             _logger.Object,
             _messageConfiguration.Object,
             _envelopeSerializer.Object
@@ -272,7 +278,7 @@ public class MessagePublisherTests
         _eventBridgeClient.Setup(x => x.PutEventsAsync(It.IsAny<PutEventsRequest>(), It.IsAny<CancellationToken>()));
 
         var messagePublisher = new EventBridgePublisher(
-            _eventBridgeClient.Object,
+            (IAWSClientProvider)_serviceProvider.Object.GetService(typeof(IAWSClientProvider))!,
             _logger.Object,
             _messageConfiguration.Object,
             _envelopeSerializer.Object


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6790

*Description of changes:*
This PR modifies the SDK User-Agent header for metrics tracking. It append the `lib/aws-dotnet-messaging_{ASSEMBLY-VERSION}` to the UA string.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
