### PR TITLE
chore: add happy path integration tests

### DIFF
--- a/src/AWS.Messaging/Properties/AssemblyInfo.cs
+++ b/src/AWS.Messaging/Properties/AssemblyInfo.cs
@@ -4,3 +4,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("AWS.Messaging.UnitTests")]
+[assembly: InternalsVisibleTo("AWS.Messaging.IntegrationTests")]

--- a/test/AWS.Messaging.IntegrationTests/AWS.Messaging.IntegrationTests.csproj
+++ b/test/AWS.Messaging.IntegrationTests/AWS.Messaging.IntegrationTests.csproj
@@ -7,6 +7,25 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.101.47" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.5" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.110" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\AWS.Messaging\AWS.Messaging.csproj" />
   </ItemGroup>
 

--- a/test/AWS.Messaging.IntegrationTests/EventBridgePublisherTests.cs
+++ b/test/AWS.Messaging.IntegrationTests/EventBridgePublisherTests.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Amazon.SQS;
+using Microsoft.Extensions.DependencyInjection;
+using AWS.Messaging.IntegrationTests.Models;
+using System.Text.Json;
+using Amazon.EventBridge;
+using Amazon.EventBridge.Model;
+using System.Collections.Generic;
+using Amazon.SQS.Model;
+using Amazon.SecurityToken;
+using Amazon.SecurityToken.Model;
+
+namespace AWS.Messaging.IntegrationTests;
+
+public class EventBridgePublisherTests : IAsyncLifetime
+{
+    private readonly IAmazonEventBridge _eventBridgeClient;
+    private readonly IAmazonSQS _sqsClient;
+    private readonly IAmazonSecurityTokenService _stsClient;
+    private ServiceProvider _serviceProvider;
+    private string _eventBusArn;
+    private string _resourceName;
+    private string _sqsQueueUrl;
+
+    public EventBridgePublisherTests()
+    {
+        _sqsClient = new AmazonSQSClient();
+        _eventBridgeClient = new AmazonEventBridgeClient();
+        _stsClient = new AmazonSecurityTokenServiceClient();
+        _serviceProvider = default!;
+        _eventBusArn = string.Empty;
+        _resourceName = string.Empty;
+        _sqsQueueUrl = string.Empty;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _resourceName = $"MPFTest-{Guid.NewGuid().ToString().Split('-').Last()}";
+        var createQueueResponse = await _sqsClient.CreateQueueAsync(_resourceName);
+        _sqsQueueUrl = createQueueResponse.QueueUrl;
+        var getQueueAttributesResponse = await _sqsClient.GetQueueAttributesAsync(_sqsQueueUrl, new List<string> { "QueueArn" });
+        var sqsQueueArn = getQueueAttributesResponse.QueueARN;
+        await _sqsClient.SetQueueAttributesAsync(new SetQueueAttributesRequest
+        {
+            QueueUrl = _sqsQueueUrl,
+            Attributes = new Dictionary<string, string>
+            {
+                { "Policy",
+                    @$"{{
+                        ""Version"": ""2008-10-17"",
+                        ""Statement"": [
+                            {{
+                                ""Effect"": ""Allow"",
+                                ""Principal"": {{
+                                    ""Service"": ""events.amazonaws.com""
+                                }},
+                                ""Action"": ""SQS:SendMessage"",
+                                ""Resource"": ""{sqsQueueArn}""
+                            }}
+                        ]
+                    }}"
+                }
+            }
+        });
+
+        var createEventBusResponse = await _eventBridgeClient.CreateEventBusAsync(
+            new CreateEventBusRequest
+            {
+                Name = _resourceName
+            });
+        _eventBusArn = createEventBusResponse.EventBusArn;
+
+        var getCallerIdentityResponse = await _stsClient.GetCallerIdentityAsync(new GetCallerIdentityRequest());
+        await _eventBridgeClient.PutRuleAsync(new PutRuleRequest
+        {
+            Name = _resourceName,
+            EventBusName = _resourceName,
+            EventPattern =
+            @$"{{
+              ""account"": [""{getCallerIdentityResponse.Account}""],
+              ""source"": [""/aws/messaging""]
+            }}"
+        });
+
+        await _eventBridgeClient.PutTargetsAsync(new PutTargetsRequest
+        {
+            EventBusName = _resourceName,
+            Targets = new List<Target>
+            {
+                new Target
+                {
+                    Arn = sqsQueueArn,
+                    Id = _resourceName
+                }
+            },
+            Rule = _resourceName
+        });
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging();
+        serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddEventBridgePublisher<ChatMessage>(_eventBusArn);
+        });
+        _serviceProvider = serviceCollection.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task PublishMessage()
+    {
+        var publishStartTime = DateTime.UtcNow;
+        var publisher = _serviceProvider.GetRequiredService<IMessagePublisher>();
+        await publisher.PublishAsync(new ChatMessage
+        {
+            MessageDescription = "Test1"
+        });
+        var publishEndTime = DateTime.UtcNow;
+
+        // Wait to allow the published message to propagate through the system
+        await Task.Delay(5000);
+
+        var receiveMessageResponse = await _sqsClient.ReceiveMessageAsync(_sqsQueueUrl);
+        var message = Assert.Single(receiveMessageResponse.Messages);
+
+        // EventBridge adds an external envelope which we need to strip away
+        var eventBridgeEnvelope = JsonSerializer.Deserialize<EventBridgeEnvelope>(message.Body);
+        Assert.NotNull(eventBridgeEnvelope);
+
+        Assert.NotNull(eventBridgeEnvelope.Detail);
+        var envelope = eventBridgeEnvelope.Detail;
+        Assert.False(string.IsNullOrEmpty(envelope.Id));
+        Assert.Equal("/aws/messaging", envelope.Source.ToString());
+        Assert.True(envelope.TimeStamp > publishStartTime);
+        Assert.True(envelope.TimeStamp < publishEndTime);
+
+        var messageType = Type.GetType(eventBridgeEnvelope.Detail.MessageTypeIdentifier);
+        Assert.NotNull(messageType);
+
+        var chatMessageObject = JsonSerializer.Deserialize(eventBridgeEnvelope.Detail.Message, messageType);
+        var chatMessage = Assert.IsType<ChatMessage>(chatMessageObject);
+        Assert.Equal("Test1", chatMessage.MessageDescription);
+    }
+
+    public async Task DisposeAsync()
+    {
+        try
+        {
+            await _eventBridgeClient.RemoveTargetsAsync(new RemoveTargetsRequest
+            {
+                EventBusName = _resourceName,
+                Force = true,
+                Ids = new List<string> { _resourceName },
+                Rule = _resourceName
+            });
+        } catch { }
+        try
+        {
+            await _eventBridgeClient.DeleteRuleAsync(new DeleteRuleRequest
+            {
+                EventBusName = _resourceName,
+                Name = _resourceName
+            });
+        }
+        catch { }
+        try
+        {
+            await _eventBridgeClient.DeleteEventBusAsync(new DeleteEventBusRequest
+            {
+                Name = _resourceName
+            });
+        }
+        catch { }
+        try
+        {
+            await _sqsClient.DeleteQueueAsync(_sqsQueueUrl);
+        }
+        catch { }
+    }
+}

--- a/test/AWS.Messaging.IntegrationTests/Handlers/ChatMessageHandler.cs
+++ b/test/AWS.Messaging.IntegrationTests/Handlers/ChatMessageHandler.cs
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Threading;
+using System.Threading.Tasks;
+using AWS.Messaging.IntegrationTests.Models;
+
+namespace AWS.Messaging.IntegrationTests.Handlers;
+
+public class ChatMessageHandler : IMessageHandler<ChatMessage>
+{
+    private readonly TempStorage<ChatMessage> _tempStorage;
+
+    public ChatMessageHandler(TempStorage<ChatMessage> tempStorage)
+    {
+        _tempStorage = tempStorage;
+    }
+
+    public Task<MessageProcessStatus> HandleAsync(MessageEnvelope<ChatMessage> messageEnvelope, CancellationToken token = default)
+    {
+        _tempStorage.Messages.Add(messageEnvelope);
+
+        return Task.FromResult(MessageProcessStatus.Success());
+    }
+}

--- a/test/AWS.Messaging.IntegrationTests/Models/ChatMessage.cs
+++ b/test/AWS.Messaging.IntegrationTests/Models/ChatMessage.cs
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.IntegrationTests.Models;
+
+public class ChatMessage
+{
+    public string MessageDescription { get; set; } = string.Empty;
+}

--- a/test/AWS.Messaging.IntegrationTests/Models/EventBridgeEnvelope.cs
+++ b/test/AWS.Messaging.IntegrationTests/Models/EventBridgeEnvelope.cs
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text.Json.Serialization;
+
+namespace AWS.Messaging.IntegrationTests.Models;
+
+public class EventBridgeEnvelope
+{
+    [JsonPropertyName("detail")]
+    public MessageEnvelope<string> Detail { get; set; } = default!;
+}

--- a/test/AWS.Messaging.IntegrationTests/Models/SNSEnvelope.cs
+++ b/test/AWS.Messaging.IntegrationTests/Models/SNSEnvelope.cs
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.IntegrationTests.Models;
+
+public class SNSEnvelope
+{
+    public string Type { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+}

--- a/test/AWS.Messaging.IntegrationTests/Models/TempStorage.cs
+++ b/test/AWS.Messaging.IntegrationTests/Models/TempStorage.cs
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace AWS.Messaging.IntegrationTests.Models;
+
+public class TempStorage<T>
+{
+    public List<MessageEnvelope<T>> Messages { get; set; } = new List<MessageEnvelope<T>>();
+}

--- a/test/AWS.Messaging.IntegrationTests/SNSPublisherTests.cs
+++ b/test/AWS.Messaging.IntegrationTests/SNSPublisherTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Amazon.SQS;
+using Microsoft.Extensions.DependencyInjection;
+using AWS.Messaging.IntegrationTests.Models;
+using System.Text.Json;
+using Amazon.SimpleNotificationService;
+using Amazon.SimpleNotificationService.Model;
+
+namespace AWS.Messaging.IntegrationTests;
+
+public class SNSPublisherTests : IAsyncLifetime
+{
+    private readonly IAmazonSimpleNotificationService _snsClient;
+    private readonly IAmazonSQS _sqsClient;
+    private ServiceProvider _serviceProvider;
+    private string _snsTopicArn;
+    private string _sqsQueueUrl;
+
+    public SNSPublisherTests()
+    {
+        _sqsClient = new AmazonSQSClient();
+        _snsClient = new AmazonSimpleNotificationServiceClient();
+        _serviceProvider = default!;
+        _snsTopicArn = string.Empty;
+        _sqsQueueUrl = string.Empty;
+    }
+
+    public async Task InitializeAsync()
+    {
+        var resourceName = $"MPFTest-{Guid.NewGuid().ToString().Split('-').Last()}";
+        var createQueueResponse = await _sqsClient.CreateQueueAsync(resourceName);
+        _sqsQueueUrl = createQueueResponse.QueueUrl;
+
+        var createTopicResponse = await _snsClient.CreateTopicAsync(resourceName);
+        _snsTopicArn = createTopicResponse.TopicArn;
+
+        await _snsClient.SubscribeQueueAsync(_snsTopicArn, _sqsClient, _sqsQueueUrl);
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging();
+        serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSNSPublisher<ChatMessage>(_snsTopicArn);
+        });
+        _serviceProvider = serviceCollection.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task PublishMessage()
+    {
+        var publishStartTime = DateTime.UtcNow;
+        var publisher = _serviceProvider.GetRequiredService<IMessagePublisher>();
+        await publisher.PublishAsync(new ChatMessage
+        {
+            MessageDescription = "Test1"
+        });
+        var publishEndTime = DateTime.UtcNow;
+
+        // Wait to allow the published message to propagate through the system
+        await Task.Delay(5000);
+
+        var receiveMessageResponse = await _sqsClient.ReceiveMessageAsync(_sqsQueueUrl);
+        var message = Assert.Single(receiveMessageResponse.Messages);
+
+        // SNS adds an external envelope which we need to strip away
+        var snsEnvelope = JsonSerializer.Deserialize<SNSEnvelope>(message.Body);
+        Assert.NotNull(snsEnvelope);
+
+        var envelope = JsonSerializer.Deserialize<MessageEnvelope<string>>(snsEnvelope.Message);
+        Assert.NotNull(envelope);
+        Assert.False(string.IsNullOrEmpty(envelope.Id));
+        Assert.Equal("/aws/messaging", envelope.Source.ToString());
+        Assert.True(envelope.TimeStamp > publishStartTime);
+        Assert.True(envelope.TimeStamp < publishEndTime);
+
+        var messageType = Type.GetType(envelope.MessageTypeIdentifier);
+        Assert.NotNull(messageType);
+
+        var chatMessageObject = JsonSerializer.Deserialize(envelope.Message, messageType);
+        var chatMessage = Assert.IsType<ChatMessage>(chatMessageObject);
+        Assert.Equal("Test1", chatMessage.MessageDescription);
+    }
+
+    public async Task DisposeAsync()
+    {
+        try
+        {
+            await _snsClient.DeleteTopicAsync(new DeleteTopicRequest { TopicArn = _snsTopicArn });
+        }
+        catch { }
+        try
+        {
+            await _sqsClient.DeleteQueueAsync(_sqsQueueUrl);
+        }
+        catch { }
+    }
+}

--- a/test/AWS.Messaging.IntegrationTests/SQSPublisherTests.cs
+++ b/test/AWS.Messaging.IntegrationTests/SQSPublisherTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Amazon.SQS;
+using Microsoft.Extensions.DependencyInjection;
+using AWS.Messaging.IntegrationTests.Models;
+using System.Text.Json;
+
+namespace AWS.Messaging.IntegrationTests;
+
+public class SQSPublisherTests : IAsyncLifetime
+{
+    private readonly IAmazonSQS _sqsClient;
+    private ServiceProvider _serviceProvider;
+    private string _sqsQueueUrl;
+
+    public SQSPublisherTests()
+    {
+        _sqsClient = new AmazonSQSClient();
+        _serviceProvider = default!;
+        _sqsQueueUrl = string.Empty;
+    }
+
+    public async Task InitializeAsync()
+    {
+        var createQueueResponse = await _sqsClient.CreateQueueAsync($"MPFTest-{Guid.NewGuid().ToString().Split('-').Last()}");
+        _sqsQueueUrl = createQueueResponse.QueueUrl;
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging();
+        serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPublisher<ChatMessage>(_sqsQueueUrl);
+        });
+        _serviceProvider = serviceCollection.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task PublishMessage()
+    {
+        var publishStartTime = DateTime.UtcNow;
+        var publisher = _serviceProvider.GetRequiredService<IMessagePublisher>();
+        await publisher.PublishAsync(new ChatMessage
+        {
+            MessageDescription = "Test1"
+        });
+        var publishEndTime = DateTime.UtcNow;
+
+        // Wait to allow the published message to propagate through the system
+        await Task.Delay(5000);
+
+        var receiveMessageResponse = await _sqsClient.ReceiveMessageAsync(_sqsQueueUrl);
+        var message = Assert.Single(receiveMessageResponse.Messages);
+
+        var envelope = JsonSerializer.Deserialize<MessageEnvelope<string>>(message.Body);
+        Assert.NotNull(envelope);
+        Assert.False(string.IsNullOrEmpty(envelope.Id));
+        Assert.Equal("/aws/messaging", envelope.Source.ToString());
+        Assert.True(envelope.TimeStamp >  publishStartTime);
+        Assert.True(envelope.TimeStamp < publishEndTime);
+        var messageType = Type.GetType(envelope.MessageTypeIdentifier);
+        Assert.NotNull(messageType);
+        var chatMessageObject = JsonSerializer.Deserialize(envelope.Message, messageType);
+        var chatMessage = Assert.IsType<ChatMessage>(chatMessageObject);
+        Assert.Equal("Test1", chatMessage.MessageDescription);
+    }
+
+    public async Task DisposeAsync()
+    {
+        try
+        {
+            await _sqsClient.DeleteQueueAsync(_sqsQueueUrl);
+        }
+        catch { }
+    }
+}

--- a/test/AWS.Messaging.IntegrationTests/SubscriberTests.cs
+++ b/test/AWS.Messaging.IntegrationTests/SubscriberTests.cs
@@ -1,0 +1,92 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.SQS;
+using AWS.Messaging.IntegrationTests.Handlers;
+using AWS.Messaging.IntegrationTests.Models;
+using AWS.Messaging.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace AWS.Messaging.IntegrationTests;
+
+public class SubscriberTests : IAsyncLifetime
+{
+    private readonly IAmazonSQS _sqsClient;
+    private ServiceProvider _serviceProvider;
+    private string _sqsQueueUrl;
+
+    public SubscriberTests()
+    {
+        _sqsClient = new AmazonSQSClient();
+        _serviceProvider = default!;
+        _sqsQueueUrl = string.Empty;
+    }
+
+    public async Task InitializeAsync()
+    {
+        var createQueueResponse = await _sqsClient.CreateQueueAsync($"MPFTest-{Guid.NewGuid().ToString().Split('-').Last()}");
+        _sqsQueueUrl = createQueueResponse.QueueUrl;
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddSingleton<TempStorage<ChatMessage>>();
+        serviceCollection.AddLogging();
+        serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPublisher<ChatMessage>(_sqsQueueUrl);
+            builder.AddSQSPoller(_sqsQueueUrl);
+            builder.AddMessageHandler<ChatMessageHandler, ChatMessage>();
+        });
+        _serviceProvider = serviceCollection.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task SendAndReceive1Message()
+    {
+        var publishStartTime = DateTime.UtcNow;
+        var publisher = _serviceProvider.GetRequiredService<IMessagePublisher>();
+        await publisher.PublishAsync(new ChatMessage
+        {
+            MessageDescription = "Test1"
+        });
+        var publishEndTime = DateTime.UtcNow;
+
+        var pump = _serviceProvider.GetRequiredService<IHostedService>() as MessagePumpService;
+        Assert.NotNull(pump);
+        var source = new CancellationTokenSource();
+
+        await pump.StartAsync(source.Token);
+
+        var tempStorage = _serviceProvider.GetRequiredService<TempStorage<ChatMessage>>();
+        source.CancelAfter(60000);
+        while (!source.IsCancellationRequested)
+        {
+            if (tempStorage.Messages.Count > 0)
+            {
+                source.Cancel();
+                break;
+            }
+        }
+
+        var message = Assert.Single(tempStorage.Messages);
+        Assert.False(string.IsNullOrEmpty(message.Id));
+        Assert.Equal("/aws/messaging", message.Source.ToString());
+        Assert.True(message.TimeStamp > publishStartTime);
+        Assert.True(message.TimeStamp < publishEndTime);
+        Assert.Equal("Test1", message.Message.MessageDescription);
+    }
+
+    public async Task DisposeAsync()
+    {
+        try
+        {
+            await _sqsClient.DeleteQueueAsync(_sqsQueueUrl);
+        }
+        catch { }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6878

*Description of changes:*
Add tests for the following cases:
* Publishing to SQS
* Publishing to SNS
* Publishing to EventBridge
* End-to-end Publishing and polling for 1 message
Note: We can't add tests for more than 1 message published since the framework doesn't yet delete the handled messages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
