### PR TITLE
Use CreateAsyncScope from HandlerInvoker

### DIFF
--- a/.autover/changes/bcd7916e-93c4-48aa-b480-2f88601c9e67.json
+++ b/.autover/changes/bcd7916e-93c4-48aa-b480-2f88601c9e67.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Support scoped IAsyncDisposable services being disposed after message is processed"
+      ]
+    }
+  ]
+}

--- a/src/AWS.Messaging/Services/HandlerInvoker.cs
+++ b/src/AWS.Messaging/Services/HandlerInvoker.cs
@@ -54,7 +54,7 @@ public class HandlerInvoker : IHandlerInvoker
                     trace.AddMetadata(TelemetryKeys.SqsMessageId, messageEnvelope.SQSMetadata.MessageID);
                 }
 
-                using (var scope = _serviceProvider.CreateScope())
+                await using (var scope = _serviceProvider.CreateAsyncScope())
                 {
                     object handler;
                     try

--- a/test/AWS.Messaging.UnitTests/MessageHandlers/Handlers.cs
+++ b/test/AWS.Messaging.UnitTests/MessageHandlers/Handlers.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Amazon.Lambda.Core;
 using AWS.Messaging.UnitTests.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -41,6 +40,37 @@ public class ChatMessageHandlerWithDependencies : IMessageHandler<ChatMessage>
     {
         _thingDoer.DoThingWithThing();
         return Task.FromResult(MessageProcessStatus.Success());
+    }
+}
+
+public class ChatMessageHandlerWithDisposableServices : IMessageHandler<ChatMessage>
+{
+    public ChatMessageHandlerWithDisposableServices(TestDisposableServiceAsync testDisposableServiceAsync, TestDisposableService testDisposable)
+    {
+    }
+
+    public Task<MessageProcessStatus> HandleAsync(MessageEnvelope<ChatMessage> messageEnvelope, CancellationToken token = default)
+    {
+        return Task.FromResult(MessageProcessStatus.Success());
+    }
+
+    public class TestDisposableServiceAsync : IAsyncDisposable
+    {
+        public static long CallCount { get; set; } = 0;
+        public ValueTask DisposeAsync()
+        {
+            CallCount++;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public class TestDisposableService : IDisposable
+    {
+        public static long CallCount { get; set; } = 0;
+        public void Dispose()
+        {
+            CallCount++;
+        }
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-dotnet-messaging/issues/92

*Description of changes:*
In the handler invoker used to process a message we create a DI scope for services. This PR switches to `CreateAsyncScope` instead of `CreateScope` so that any scoped services created that implement `IAsyncDisposable` get disposed when the scope ends.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
