### PR TITLE
Subscriber middleware

### DIFF
--- a/.autover/changes/5bdfbea6-1f68-4d45-b380-4b705ed18fe2.json
+++ b/.autover/changes/5bdfbea6-1f68-4d45-b380-4b705ed18fe2.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Added subscriber middleware"
+      ]
+    }
+  ]
+}

--- a/.autover/changes/5bdfbea6-1f68-4d45-b380-4b705ed18fe2.json
+++ b/.autover/changes/5bdfbea6-1f68-4d45-b380-4b705ed18fe2.json
@@ -4,7 +4,7 @@
       "Name": "AWS.Messaging",
       "Type": "Minor",
       "ChangelogMessages": [
-        "Added subscriber middleware"
+        "Added subscriber middleware with optional error handler to override result or retry execution."
       ]
     }
   ]

--- a/AWS.Messaging.lutconfig
+++ b/AWS.Messaging.lutconfig
@@ -1,0 +1,6 @@
+<LUTConfig Version="1.0">
+  <Repository />
+  <ParallelBuilds>true</ParallelBuilds>
+  <ParallelTestRuns>true</ParallelTestRuns>
+  <TestCaseTimeout>180000</TestCaseTimeout>
+</LUTConfig>

--- a/README.md
+++ b/README.md
@@ -311,6 +311,112 @@ The outer `MessageEnvelope` contains metadata used by the framework. Its `messag
 
 You can return `MessageProcessStatus.Success()` to indicate that the message was processed successfully and the framework will delete the message from the SQS queue. When returning `MessageProcessStatus.Failed()` the message will remain in the queue, where it can be processed again or moved to a [dead-letter queue](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html) if configured.
 
+## Subscriber Middleware
+
+You can add middleware to the subscriber message processing pipeline. Middleware executes in the order it is registered, wrapping around the message handler. This is useful for cross-cutting concerns such as logging, metrics, message enrichment, or custom retry logic.
+
+To create middleware, implement the `IMiddleware` interface:
+
+```csharp
+public class LoggingMiddleware : IMiddleware
+{
+    private readonly ILogger<LoggingMiddleware> _logger;
+
+    public LoggingMiddleware(ILogger<LoggingMiddleware> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<MessageProcessStatus> InvokeAsync<T>(
+        MessageEnvelope<T> messageEnvelope,
+        RequestDelegate next,
+        CancellationToken token = default)
+    {
+        _logger.LogInformation("Processing message {MessageId}", messageEnvelope.Id);
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+        var result = await next();
+
+        stopwatch.Stop();
+        _logger.LogInformation("Processed message {MessageId} in {Elapsed}ms", messageEnvelope.Id, stopwatch.ElapsedMilliseconds);
+
+        return result;
+    }
+}
+```
+
+Register middleware during startup using `AddMiddleware`. Middleware is registered as a singleton by default, but you can configure its service lifetime:
+
+```csharp
+services.AddAWSMessageBus(builder =>
+{
+    builder.AddSQSPoller("https://sqs.us-west-2.amazonaws.com/012345678910/MyAppProd");
+    builder.AddMessageHandler<ChatMessageHandler, ChatMessage>();
+
+    // Add middleware - executes in registration order
+    builder.AddMiddleware<LoggingMiddleware>();
+    builder.AddMiddleware<MetricsMiddleware>();
+
+    // Optionally specify a different service lifetime
+    builder.AddMiddleware<ScopedMiddleware>(ServiceLifetime.Scoped);
+});
+```
+
+## Message Error Handling
+
+You can register a message error handler to control what happens when an exception occurs during message processing (in the handler or middleware). The error handler can choose to retry, fail, or mark the message as successful.
+
+Implement the `IMessageErrorHandler` interface:
+```csharp
+public class TransientErrorHandler : IMessageErrorHandler
+{
+    private readonly ILogger<TransientErrorHandler> _logger;
+
+    public TransientErrorHandler(ILogger<TransientErrorHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public ValueTask<MessageErrorHandlerResponse> OnHandleError<T>(
+        MessageEnvelope<T> messageEnvelope,
+        Exception exception,
+        int attempts,
+        CancellationToken token)
+    {
+        // Retry up to 3 times for transient errors
+        if (attempts <= 3 && IsTransient(exception))
+        {
+            _logger.LogWarning(exception, "Transient error on attempt {Attempt} for message {MessageId}, retrying.", attempts, messageEnvelope.Id);
+            return ValueTask.FromResult(MessageErrorHandlerResponse.Retry);
+        }
+
+        // Give up after max retries
+        _logger.LogError(exception, "Failed to process message {MessageId} after {Attempt} attempts.", messageEnvelope.Id, attempts);
+        return ValueTask.FromResult(MessageErrorHandlerResponse.Failed);
+    }
+
+    private static bool IsTransient(Exception ex) =>
+        ex is TimeoutException or HttpRequestException;
+}
+```
+
+Register the error handler during startup:
+```csharp
+services.AddAWSMessageBus(builder =>
+{
+    builder.AddSQSPoller("https://sqs.us-west-2.amazonaws.com/012345678910/MyAppProd");
+    builder.AddMessageHandler<ChatMessageHandler, ChatMessage>();
+
+    // Register an error handler for retry/failure control
+    builder.AddMessageErrorHandler<TransientErrorHandler>();
+});
+```
+
+The `MessageErrorHandlerResponse` enum supports three responses:
+* `Retry` - Re-execute the entire processing pipeline (middleware + handler) in a new DI scope. This is useful for transient errors since scoped services like `DbContext` will be recreated.
+* `Failed` - Return a failed status. The message will remain in the queue for reprocessing or dead-letter queue routing.
+* `Success` - Treat the message as successfully processed. The framework will delete it from the queue. This is useful for routing poison messages to a dead-letter queue.
+
 ## Handling Messages in a Long-Running Process
 You can call `AddSQSPoller` with an SQS queue URL to start a long-running [`BackgroundService`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.backgroundservice) that will continuously poll the queue and process messages.
 

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ public class LoggingMiddleware : IHandlerMiddleware
 }
 ```
 
-Register middleware during startup using `AddMiddleware`. Middleware is registered as a singleton by default, but you can configure its service lifetime:
+Register middleware during startup using `AddHandlerMiddleware`. Middleware is registered as a singleton by default, but you can configure its service lifetime:
 
 ```csharp
 services.AddAWSMessageBus(builder =>
@@ -354,11 +354,11 @@ services.AddAWSMessageBus(builder =>
     builder.AddMessageHandler<ChatMessageHandler, ChatMessage>();
 
     // Add middleware - executes in registration order
-    builder.AddMiddleware<LoggingMiddleware>();
-    builder.AddMiddleware<MetricsMiddleware>();
+    builder.AddHandlerMiddleware<LoggingMiddleware>();
+    builder.AddHandlerMiddleware<MetricsMiddleware>();
 
     // Optionally specify a different service lifetime
-    builder.AddMiddleware<ScopedMiddleware>(ServiceLifetime.Scoped);
+    builder.AddHandlerMiddleware<ScopedMiddleware>(ServiceLifetime.Scoped);
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -315,10 +315,10 @@ You can return `MessageProcessStatus.Success()` to indicate that the message was
 
 You can add middleware to the subscriber message processing pipeline. Middleware executes in the order it is registered, wrapping around the message handler. This is useful for cross-cutting concerns such as logging, metrics, message enrichment, or custom retry logic.
 
-To create middleware, implement the `IMiddleware` interface:
+To create middleware, implement the `IHandlerMiddleware` interface:
 
 ```csharp
-public class LoggingMiddleware : IMiddleware
+public class LoggingMiddleware : IHandlerMiddleware
 {
     private readonly ILogger<LoggingMiddleware> _logger;
 

--- a/sampleapps/SubscriberService/Middleware/SampleMiddleware.cs
+++ b/sampleapps/SubscriberService/Middleware/SampleMiddleware.cs
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Messaging;
+
+namespace SubscriberService.Middleware;
+
+public class SampleMiddleware : IMiddleware
+{
+    public Task<MessageProcessStatus> InvokeAsync<T>(MessageEnvelope<T> messageEnvelope, RequestDelegate next, CancellationToken token = default)
+    {
+        // This middleware does not do anything, but exists to demonstrate how to implement a middleware
+
+        return next();
+    }
+}

--- a/sampleapps/SubscriberService/Middleware/SampleMiddleware.cs
+++ b/sampleapps/SubscriberService/Middleware/SampleMiddleware.cs
@@ -5,7 +5,7 @@ using AWS.Messaging;
 
 namespace SubscriberService.Middleware;
 
-public class SampleMiddleware : IMiddleware
+public class SampleMiddleware : IHandlerMiddleware
 {
     public Task<MessageProcessStatus> InvokeAsync<T>(MessageEnvelope<T> messageEnvelope, RequestDelegate next, CancellationToken token = default)
     {

--- a/sampleapps/SubscriberService/Program.cs
+++ b/sampleapps/SubscriberService/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using SubscriberService.MessageHandlers;
+using SubscriberService.Middleware;
 using SubscriberService.Models;
 
 await Host.CreateDefaultBuilder(args)
@@ -33,6 +34,8 @@ await Host.CreateDefaultBuilder(args)
             var mpfQueueUrl = context.Configuration["AWS:Resources:MPFQueueUrl"];
             if (string.IsNullOrEmpty(mpfQueueUrl))
                 throw new InvalidOperationException("Missing required configuration parameter 'AWS:Resources:MPFQueueUrl'.");
+
+            builder.AddMiddleware<SampleMiddleware>();
 
             builder.AddSQSPoller(mpfQueueUrl);
             builder.AddMessageHandler<ChatMessageHandler, ChatMessage>("chatMessage");

--- a/sampleapps/SubscriberService/Program.cs
+++ b/sampleapps/SubscriberService/Program.cs
@@ -35,7 +35,7 @@ await Host.CreateDefaultBuilder(args)
             if (string.IsNullOrEmpty(mpfQueueUrl))
                 throw new InvalidOperationException("Missing required configuration parameter 'AWS:Resources:MPFQueueUrl'.");
 
-            builder.AddMiddleware<SampleMiddleware>();
+            builder.AddHandlerMiddleware<SampleMiddleware>();
 
             builder.AddSQSPoller(mpfQueueUrl);
             builder.AddMessageHandler<ChatMessageHandler, ChatMessage>("chatMessage");

--- a/sampleapps/SubscriberService/README.md
+++ b/sampleapps/SubscriberService/README.md
@@ -33,7 +33,7 @@ SubscriberService/
 
 ## Middleware
 
-This sample includes `SampleMiddleware` to demonstrate the subscriber middleware feature. Middleware implements the `IHandlerMiddleware` interface and is registered using `builder.AddMiddleware<SampleMiddleware>()` in `Program.cs`. Middleware executes in registration order, wrapping around the message handler, and is useful for cross-cutting concerns such as logging, metrics, or message enrichment. See the main [README](../../README.md#subscriber-middleware) for more details.
+This sample includes `SampleMiddleware` to demonstrate the subscriber middleware feature. Middleware implements the `IHandlerMiddleware` interface and is registered using `builder.AddHandlerMiddleware<SampleMiddleware>()` in `Program.cs`. Middleware executes in registration order, wrapping around the message handler, and is useful for cross-cutting concerns such as logging, metrics, or message enrichment. See the main [README](../../README.md#subscriber-middleware) for more details.
 
 ## Testing
 

--- a/sampleapps/SubscriberService/README.md
+++ b/sampleapps/SubscriberService/README.md
@@ -1,4 +1,4 @@
-﻿# AWS Message Processing Framework Subscriber Service Sample
+# AWS Message Processing Framework Subscriber Service Sample
 
 This sample application demonstrates how to use the AWS Message Processing Framework for .NET to process messages from SQS queues with configurable polling and message handling.
 
@@ -33,7 +33,7 @@ SubscriberService/
 
 ## Middleware
 
-This sample includes `SampleMiddleware` to demonstrate the subscriber middleware feature. Middleware implements the `IMiddleware` interface and is registered using `builder.AddMiddleware<SampleMiddleware>()` in `Program.cs`. Middleware executes in registration order, wrapping around the message handler, and is useful for cross-cutting concerns such as logging, metrics, or message enrichment. See the main [README](../../README.md#subscriber-middleware) for more details.
+This sample includes `SampleMiddleware` to demonstrate the subscriber middleware feature. Middleware implements the `IHandlerMiddleware` interface and is registered using `builder.AddMiddleware<SampleMiddleware>()` in `Program.cs`. Middleware executes in registration order, wrapping around the message handler, and is useful for cross-cutting concerns such as logging, metrics, or message enrichment. See the main [README](../../README.md#subscriber-middleware) for more details.
 
 ## Testing
 

--- a/sampleapps/SubscriberService/README.md
+++ b/sampleapps/SubscriberService/README.md
@@ -7,6 +7,7 @@ This sample application demonstrates how to use the AWS Message Processing Frame
 This sample demonstrates:
 - Configuring and using SQS message pollers
 - Implementing typed message handlers
+- Adding subscriber middleware to the processing pipeline
 - Configuration-based setup using .NET Aspire
 - Configurable backoff policies for message processing
 - Proper message handling patterns
@@ -17,16 +18,22 @@ This sample demonstrates:
 - Follow the setup instructions in the AppHost README to ensure all AWS resources and .NET Aspire components are properly configured
 
 
-## Project Structure
+## Project Structure
 ```
 SubscriberService/
 ├── MessageHandlers/
 │   └── ChatMessageHandler.cs    # Message handler implementation
+├── Middleware/
+│   └── SampleMiddleware.cs      # Sample middleware implementation
 ├── Models/
 │   └── ChatMessage.cs          # Message type definition
 ├── Program.cs                  # Application entry point
 └── appsettings.json           # Application configuration
 ```
+
+## Middleware
+
+This sample includes `SampleMiddleware` to demonstrate the subscriber middleware feature. Middleware implements the `IMiddleware` interface and is registered using `builder.AddMiddleware<SampleMiddleware>()` in `Program.cs`. Middleware executes in registration order, wrapping around the message handler, and is useful for cross-cutting concerns such as logging, metrics, or message enrichment. See the main [README](../../README.md#subscriber-middleware) for more details.
 
 ## Testing
 
@@ -47,7 +54,7 @@ $messageBody = '{"type":"chatMessage","id":"123","source":"test","specversion":"
 aws sqs send-message --queue-url YOUR_QUEUE_URL --message-body $messageBody
 ```
 
-## Configuration Options
+## Configuration Options
 ```
 {
     "MaxNumberOfConcurrentMessages": 10,    // Maximum number of messages to process concurrently
@@ -57,7 +64,7 @@ aws sqs send-message --queue-url YOUR_QUEUE_URL --message-body $messageBody
     "VisibilityTimeoutExtensionThreshold": 5   // When to extend visibility timeout
 }
 ```
-### Backoff Policy Options
+### Backoff Policy Options
 ```
 {
     "BackoffPolicy": "CappedExponential",  // Available options: Linear, Exponential, CappedExponential
@@ -66,4 +73,3 @@ aws sqs send-message --queue-url YOUR_QUEUE_URL --message-body $messageBody
     }
 }
 ```
-

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -54,6 +54,17 @@ public interface IMessageBusBuilder
         where THandler : IMessageHandler<TMessage>;
 
     /// <summary>
+    /// Adds a middleware to the subscriber message bus pipeline.
+    /// </summary>
+    /// <remarks>
+    /// Middleware will be executed in the order in which it is added.
+    /// </remarks>
+    /// <typeparam name="TMiddleware">The type that implements <see cref="IMiddleware"/></typeparam>
+    /// <param name="serviceLifetime">The lifetime of the middleware.</param>
+    IMessageBusBuilder AddMiddleware<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMiddleware>(ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
+        where TMiddleware : class, IMiddleware;
+
+    /// <summary>
     /// Adds an SQS queue to poll for messages.
     /// </summary>
     /// <param name="queueUrl">The SQS queue to poll for messages.</param>

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -59,10 +59,10 @@ public interface IMessageBusBuilder
     /// <remarks>
     /// Middleware will be executed in the order in which it is added.
     /// </remarks>
-    /// <typeparam name="TMiddleware">The type that implements <see cref="IMiddleware"/></typeparam>
+    /// <typeparam name="TMiddleware">The type that implements <see cref="IHandlerMiddleware"/></typeparam>
     /// <param name="serviceLifetime">The lifetime of the middleware.</param>
     IMessageBusBuilder AddMiddleware<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMiddleware>(ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
-        where TMiddleware : class, IMiddleware;
+        where TMiddleware : class, IHandlerMiddleware;
 
     /// <summary>
     /// Adds a message error handler to the subscriber pipeline.

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -65,6 +65,16 @@ public interface IMessageBusBuilder
         where TMiddleware : class, IMiddleware;
 
     /// <summary>
+    /// Adds a message error handler to the subscriber pipeline.
+    /// The error handler is invoked when an exception occurs during message processing
+    /// and can control retry behavior, override results, or handle exceptions.
+    /// </summary>
+    /// <typeparam name="T">The type that implements <see cref="IMessageErrorHandler"/></typeparam>
+    /// <param name="serviceLifetime">The lifetime of the error handler.</param>
+    IMessageBusBuilder AddMessageErrorHandler<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
+        where T : IMessageErrorHandler;
+
+    /// <summary>
     /// Adds an SQS queue to poll for messages.
     /// </summary>
     /// <param name="queueUrl">The SQS queue to poll for messages.</param>

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -61,7 +61,7 @@ public interface IMessageBusBuilder
     /// </remarks>
     /// <typeparam name="TMiddleware">The type that implements <see cref="IHandlerMiddleware"/></typeparam>
     /// <param name="serviceLifetime">The lifetime of the middleware.</param>
-    IMessageBusBuilder AddMiddleware<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMiddleware>(ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
+    IMessageBusBuilder AddHandlerMiddleware<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMiddleware>(ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
         where TMiddleware : class, IHandlerMiddleware;
 
     /// <summary>

--- a/src/AWS.Messaging/Configuration/IMessageConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/IMessageConfiguration.cs
@@ -47,6 +47,11 @@ public interface IMessageConfiguration
     SubscriberMapping? GetSubscriberMapping(string messageTypeIdentifier);
 
     /// <summary>
+    /// Maps the middleware types to be used in order of execution.
+    /// </summary>
+    IList<SubscriberMiddleware> SubscriberMiddleware { get; }
+
+    /// <summary>
     /// List of configurations for subscriber to poll for messages from an AWS service endpoint.
     /// </summary>
     IList<IMessagePollerConfiguration> MessagePollerConfigurations { get; set; }

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -99,13 +99,23 @@ public class MessageBusBuilder : IMessageBusBuilder
     public IMessageBusBuilder AddMessageHandler<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] THandler, TMessage>(string? messageTypeIdentifier = null)
         where THandler : IMessageHandler<TMessage>
     {
-        return AddMessageHandler(typeof(THandler), typeof(TMessage), () => new MessageEnvelope<TMessage>(), messageTypeIdentifier);
+        var subscriberMapping = SubscriberMapping.Create<THandler, TMessage>(messageTypeIdentifier);
+        _messageConfiguration.SubscriberMappings.Add(subscriberMapping);
+        return this;
     }
 
-    private IMessageBusBuilder AddMessageHandler([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type handlerType, Type messageType, Func<MessageEnvelope> envelopeFactory, string? messageTypeIdentifier = null)
+    private IMessageBusBuilder AddMessageHandler([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type handlerType, Type messageType, Func<MessageEnvelope> envelopeFactory, MethodInfo middlewareInvokeAsyncMethodInfo, string? messageTypeIdentifier = null)
     {
-        var subscriberMapping = new SubscriberMapping(handlerType, messageType, envelopeFactory, messageTypeIdentifier);
+        var subscriberMapping = new SubscriberMapping(handlerType, messageType, envelopeFactory, middlewareInvokeAsyncMethodInfo, messageTypeIdentifier);
         _messageConfiguration.SubscriberMappings.Add(subscriberMapping);
+        return this;
+    }
+
+    public IMessageBusBuilder AddMiddleware<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMiddleware>(ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
+        where TMiddleware : class, IMiddleware
+    {
+        var subscriberMiddleware = SubscriberMiddleware.Create<TMiddleware>(serviceLifetime);
+        _messageConfiguration.SubscriberMiddleware.Add(subscriberMiddleware);
         return this;
     }
 
@@ -260,6 +270,11 @@ public class MessageBusBuilder : IMessageBusBuilder
 
         if (settings.MessageHandlers != null)
         {
+            // This is not Native AOT compatible but the method in general is marked
+            // as not being Native AOT compatible due to loading dynamic types. So this
+            // not being Native AOT compatible is okay.
+            var middlewareInvokeMethod = typeof(IMiddleware).GetMethod(nameof(IMiddleware.InvokeAsync))!;
+
             foreach (var messageHandler in settings.MessageHandlers)
             {
                 var messageType = GetTypeFromAssemblies(callingAssembly, messageHandler.MessageType)
@@ -282,7 +297,12 @@ public class MessageBusBuilder : IMessageBusBuilder
                     return (MessageEnvelope)envelope;
                 }
 
-                AddMessageHandler(handlerType, messageType, envelopeFactory, messageHandler.MessageTypeIdentifier);
+                // MakeGenericMethod is not Native AOT compatible but the method in general is marked
+                // as not being Native AOT compatible due to loading dynamic types. So this
+                // method not being Native AOT compatible is okay.
+                var middlewareInvokeAsyncMethodInfo = middlewareInvokeMethod.MakeGenericMethod(messageType);
+
+                AddMessageHandler(handlerType, messageType, envelopeFactory, middlewareInvokeAsyncMethodInfo, messageHandler.MessageTypeIdentifier);
             }
         }
 
@@ -421,6 +441,11 @@ public class MessageBusBuilder : IMessageBusBuilder
             foreach (var subscriberMapping in _messageConfiguration.SubscriberMappings)
             {
                 _serviceCollection.TryAddScoped(subscriberMapping.HandlerType);
+            }
+
+            foreach (var subscriberMiddleware in _messageConfiguration.SubscriberMiddleware)
+            {
+                _serviceCollection.TryAdd(new ServiceDescriptor(subscriberMiddleware.Type, subscriberMiddleware.Type, subscriberMiddleware.ServiceLifetime));
             }
         }
 

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Reflection;
 using AWS.Messaging.Configuration.Internal;
 using AWS.Messaging.Publishers;
 using AWS.Messaging.Publishers.EventBridge;
@@ -12,13 +15,11 @@ using AWS.Messaging.Services;
 using AWS.Messaging.Services.Backoff;
 using AWS.Messaging.Services.Backoff.Policies;
 using AWS.Messaging.Telemetry;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 
 namespace AWS.Messaging.Configuration;
 
@@ -104,10 +105,17 @@ public class MessageBusBuilder : IMessageBusBuilder
         return this;
     }
 
-    private IMessageBusBuilder AddMessageHandler([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type handlerType, Type messageType, Func<MessageEnvelope> envelopeFactory, MethodInfo middlewareInvokeAsyncMethodInfo, string? messageTypeIdentifier = null)
+    private IMessageBusBuilder AddMessageHandler([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type handlerType, Type messageType, Func<MessageEnvelope> envelopeFactory, HandlerInvokerDelegate handlerInvokerDelegate, string? messageTypeIdentifier = null)
     {
-        var subscriberMapping = new SubscriberMapping(handlerType, messageType, envelopeFactory, middlewareInvokeAsyncMethodInfo, messageTypeIdentifier);
+        var subscriberMapping = new SubscriberMapping(handlerType, messageType, envelopeFactory, handlerInvokerDelegate, messageTypeIdentifier);
         _messageConfiguration.SubscriberMappings.Add(subscriberMapping);
+        return this;
+    }
+
+    public IMessageBusBuilder AddMessageErrorHandler<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
+        where T: IMessageErrorHandler
+    {
+        AddAdditionalService(new ServiceDescriptor(typeof(IMessageErrorHandler), typeof(T), serviceLifetime));
         return this;
     }
 
@@ -270,11 +278,6 @@ public class MessageBusBuilder : IMessageBusBuilder
 
         if (settings.MessageHandlers != null)
         {
-            // This is not Native AOT compatible but the method in general is marked
-            // as not being Native AOT compatible due to loading dynamic types. So this
-            // not being Native AOT compatible is okay.
-            var middlewareInvokeMethod = typeof(IMiddleware).GetMethod(nameof(IMiddleware.InvokeAsync))!;
-
             foreach (var messageHandler in settings.MessageHandlers)
             {
                 var messageType = GetTypeFromAssemblies(callingAssembly, messageHandler.MessageType)
@@ -282,12 +285,13 @@ public class MessageBusBuilder : IMessageBusBuilder
                 var handlerType = GetTypeFromAssemblies(callingAssembly, messageHandler.HandlerType)
                     ?? throw new InvalidAppSettingsConfigurationException($"Unable to find the provided message handler type '{messageHandler.HandlerType}'.");
 
+                var messageEnvelopeType = typeof(MessageEnvelope<>).MakeGenericType(messageType);
+
                 // This func is not Native AOT compatible but the method in general is marked
                 // as not being Native AOT compatible due to loading dynamic types. So this
                 // func not being Native AOT compatible is okay.
                 MessageEnvelope envelopeFactory()
                 {
-                    var messageEnvelopeType = typeof(MessageEnvelope<>).MakeGenericType(messageType);
                     var envelope = Activator.CreateInstance(messageEnvelopeType);
                     if (envelope == null || envelope is not MessageEnvelope)
                     {
@@ -297,12 +301,8 @@ public class MessageBusBuilder : IMessageBusBuilder
                     return (MessageEnvelope)envelope;
                 }
 
-                // MakeGenericMethod is not Native AOT compatible but the method in general is marked
-                // as not being Native AOT compatible due to loading dynamic types. So this
-                // method not being Native AOT compatible is okay.
-                var middlewareInvokeAsyncMethodInfo = middlewareInvokeMethod.MakeGenericMethod(messageType);
-
-                AddMessageHandler(handlerType, messageType, envelopeFactory, middlewareInvokeAsyncMethodInfo, messageHandler.MessageTypeIdentifier);
+                var handlerInoker = BuildHandlerInvoker(messageType, messageEnvelopeType);
+                AddMessageHandler(handlerType, messageType, envelopeFactory, handlerInoker, messageHandler.MessageTypeIdentifier);
             }
         }
 
@@ -347,6 +347,29 @@ public class MessageBusBuilder : IMessageBusBuilder
         }
 
         return this;
+
+        // This is not Native AOT compatible but the method in general is marked
+        // as not being Native AOT compatible due to loading dynamic types. So this
+        // func not being Native AOT compatible is okay.
+        static HandlerInvokerDelegate BuildHandlerInvoker(Type messageType, Type messageEnvelopeType)
+        {
+            var invokerParam = Expression.Parameter(typeof(HandlerInvoker), "invoker");
+            var envelopeParam = Expression.Parameter(typeof(MessageEnvelope), "envelope");
+            var mappingParam = Expression.Parameter(typeof(SubscriberMapping), "mapping");
+            var tokenParam = Expression.Parameter(typeof(CancellationToken), "token");
+
+            // invoker.InvokeAsync<T>( (MessageEnvelope<T>) envelope, mapping, token )
+            var genericMethodDef = typeof(HandlerInvoker)
+                .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                .First(m => m.Name == nameof(HandlerInvoker.InvokeAsync) && m.IsGenericMethodDefinition)
+                .GetGenericMethodDefinition();
+
+            var closedMethod = genericMethodDef.MakeGenericMethod(messageType);
+            var typedEnvelope = Expression.Convert(envelopeParam, messageEnvelopeType);
+            var call = Expression.Call(invokerParam, closedMethod, typedEnvelope, mappingParam, tokenParam);
+            var lambda = Expression.Lambda<HandlerInvokerDelegate>(call, invokerParam, envelopeParam, mappingParam, tokenParam);
+            return lambda.Compile();
+        }
     }
 
     [RequiresUnreferencedCode("This method requires loading types dynamically as defined in the configuration system.")]

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -121,7 +121,7 @@ public class MessageBusBuilder : IMessageBusBuilder
     }
 
     public IMessageBusBuilder AddMiddleware<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMiddleware>(ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
-        where TMiddleware : class, IMiddleware
+        where TMiddleware : class, IHandlerMiddleware
     {
         var subscriberMiddleware = SubscriberMiddleware.Create<TMiddleware>(serviceLifetime);
         _messageConfiguration.SubscriberMiddleware.Add(subscriberMiddleware);
@@ -359,7 +359,6 @@ public class MessageBusBuilder : IMessageBusBuilder
             var mappingParam = Expression.Parameter(typeof(SubscriberMapping), "mapping");
             var tokenParam = Expression.Parameter(typeof(CancellationToken), "token");
 
-            // invoker.InvokeAsync<T>( (MessageEnvelope<T>) envelope, mapping, token )
             var genericMethodDef = typeof(HandlerInvoker)
                 .GetMethods(BindingFlags.Public | BindingFlags.Instance)
                 .First(m => m.Name == nameof(HandlerInvoker.InvokeAsync) && m.IsGenericMethodDefinition)

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -120,7 +120,7 @@ public class MessageBusBuilder : IMessageBusBuilder
         return this;
     }
 
-    public IMessageBusBuilder AddMiddleware<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMiddleware>(ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
+    public IMessageBusBuilder AddHandlerMiddleware<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMiddleware>(ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
         where TMiddleware : class, IHandlerMiddleware
     {
         var subscriberMiddleware = SubscriberMiddleware.Create<TMiddleware>(serviceLifetime);

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -112,8 +112,9 @@ public class MessageBusBuilder : IMessageBusBuilder
         return this;
     }
 
+    /// <inheritdoc/>
     public IMessageBusBuilder AddMessageErrorHandler<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
-        where T: IMessageErrorHandler
+        where T : IMessageErrorHandler
     {
         AddAdditionalService(new ServiceDescriptor(typeof(IMessageErrorHandler), typeof(T), serviceLifetime));
         return this;

--- a/src/AWS.Messaging/Configuration/MessageConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/MessageConfiguration.cs
@@ -40,6 +40,9 @@ public class MessageConfiguration : IMessageConfiguration
     }
 
     /// <inheritdoc/>
+    public IList<SubscriberMiddleware> SubscriberMiddleware { get; } = new List<SubscriberMiddleware>();
+
+    /// <inheritdoc/>
     public IList<IMessagePollerConfiguration> MessagePollerConfigurations { get; set; } = new List<IMessagePollerConfiguration>();
 
     /// <inheritdoc/>

--- a/src/AWS.Messaging/Configuration/SingleTypeMessageConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/SingleTypeMessageConfiguration.cs
@@ -48,6 +48,9 @@ internal class SingleTypeMessageConfiguration : IMessageConfiguration
             : null;
 
     /// <inheritdoc/>
+    public IList<SubscriberMiddleware> SubscriberMiddleware => _inner.SubscriberMiddleware;
+
+    /// <inheritdoc/>
     public IList<IMessagePollerConfiguration> MessagePollerConfigurations
     {
         get => _inner.MessagePollerConfigurations;

--- a/src/AWS.Messaging/Configuration/SubscriberMapping.cs
+++ b/src/AWS.Messaging/Configuration/SubscriberMapping.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
+using AWS.Messaging.Services;
 
 namespace AWS.Messaging.Configuration;
 
@@ -19,7 +19,7 @@ public class SubscriberMapping
     public Type MessageType { get; }
 
     /// <inheritdoc/>
-    public MethodInfo MiddlewareInvokeAsyncMethodInfo { get; }
+    public HandlerInvokerDelegate HandlerInvoker { get; }
 
     /// <inheritdoc/>
     public string MessageTypeIdentifier { get; }
@@ -36,10 +36,10 @@ public class SubscriberMapping
     /// <param name="handlerType">The type that implements <see cref="IMessageHandler{T}"/></param>
     /// <param name="messageType">The type that will be message data will deserialized into</param>
     /// <param name="envelopeFactory">Func for creating <see cref="MessageEnvelope{messageType}"/></param>
-    /// <param name="middlewareInvokeAsyncMethodInfo"><see cref="MethodInfo"/> to invoke middleware of <see cref="MessageType"/>.</param>
+    /// <param name="handlerInvoker">Delegate to invoke handler of <see cref="MessageType"/>.</param>
     /// <param name="messageTypeIdentifier">Optional message type identifier. If not set the full name of the <see cref="MessageType"/> is used.</param>
 
-    internal SubscriberMapping([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type handlerType, Type messageType, Func<MessageEnvelope> envelopeFactory, MethodInfo middlewareInvokeAsyncMethodInfo, string? messageTypeIdentifier = null)
+    internal SubscriberMapping([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type handlerType, Type messageType, Func<MessageEnvelope> envelopeFactory, HandlerInvokerDelegate handlerInvoker, string? messageTypeIdentifier = null)
     {
         HandlerType = handlerType;
         MessageType = messageType;
@@ -49,7 +49,7 @@ public class SubscriberMapping
             messageType.FullName ?? throw new InvalidMessageTypeException("Unable to retrieve the Full Name of the provided Message Type.");
 
         MessageEnvelopeFactory = envelopeFactory;
-        MiddlewareInvokeAsyncMethodInfo = middlewareInvokeAsyncMethodInfo;
+        HandlerInvoker = handlerInvoker;
     }
 
     /// <summary>
@@ -67,19 +67,13 @@ public class SubscriberMapping
             return new MessageEnvelope<TMessage>();
         }
 
-        return new SubscriberMapping(typeof(THandler), typeof(TMessage), envelopeFactory, MiddlewareMethodCache<TMessage>.InvokeAsyncMethod, messageTypeIdentifier);
-    }
+        static Task<MessageProcessStatus> handlerInvoker(HandlerInvoker invoker, MessageEnvelope messageEnvelope, SubscriberMapping subscriberMapping, CancellationToken token = default)
+        {
+            return invoker.InvokeAsync((MessageEnvelope<TMessage>)messageEnvelope, subscriberMapping, token);
+        }
 
-    private static class MiddlewareMethodCache<T>
-    {
-        public static readonly MethodInfo InvokeAsyncMethod = MiddlewareMethod.OpenGenericInvokeAsyncMethod.MakeGenericMethod(typeof(T));
-    }
-
-    private static class MiddlewareMethod
-    {
-        // resolved once, globally
-        public static readonly MethodInfo OpenGenericInvokeAsyncMethod = typeof(IMiddleware)
-            .GetMethods()
-            .First(m => m.Name == nameof(IMiddleware.InvokeAsync) && m.IsGenericMethod);
+        return new SubscriberMapping(typeof(THandler), typeof(TMessage), envelopeFactory, handlerInvoker, messageTypeIdentifier);
     }
 }
+
+public delegate Task<MessageProcessStatus> HandlerInvokerDelegate(HandlerInvoker invoker, MessageEnvelope messageEnvelope, SubscriberMapping subscriberMapping, CancellationToken token = default);

--- a/src/AWS.Messaging/Configuration/SubscriberMiddleware.cs
+++ b/src/AWS.Messaging/Configuration/SubscriberMiddleware.cs
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AWS.Messaging.Configuration;
+
+/// <summary>
+/// Tracks the <see cref="IMiddleware"/> to be processed by the <see cref="Services.IHandlerInvoker"/> implementation and its <see cref="ServiceLifetime"/>.
+/// </summary>
+public class SubscriberMiddleware
+{
+    /// <summary>
+    /// Constructs an instance of <see cref="SubscriberMiddleware"/>
+    /// </summary>
+    /// <param name="type">The type that implements <see cref="IMiddleware"/>.</param>
+    /// <param name="serviceLifetime">The lifetime of the middleware.</param>
+    internal SubscriberMiddleware([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type, ServiceLifetime serviceLifetime)
+    {
+        Type = type;
+        ServiceLifetime = serviceLifetime;
+    }
+
+    /// <summary>
+    /// Type that implements <see cref="IMiddleware"/>.
+    /// </summary>
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+    public Type Type { get; }
+
+    /// <summary>
+    /// Service lifetime of the middleware.
+    /// </summary>
+    public ServiceLifetime ServiceLifetime { get; }
+
+    /// <summary>
+    /// Creates a SubscriberMiddleware from the generic parameters for the middleware.
+    /// </summary>
+    /// <typeparam name="TMiddleware">The type that implements <see cref="IMiddleware"/></typeparam>
+    /// <param name="serviceLifetime">The lifetime of the middleware.</param>
+    /// <returns><see cref="SubscriberMapping"/></returns>
+    public static SubscriberMiddleware Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMiddleware>(ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
+        where TMiddleware : class, IMiddleware
+    {
+        return new SubscriberMiddleware(typeof(TMiddleware), serviceLifetime);
+    }
+}

--- a/src/AWS.Messaging/Configuration/SubscriberMiddleware.cs
+++ b/src/AWS.Messaging/Configuration/SubscriberMiddleware.cs
@@ -7,14 +7,14 @@ using Microsoft.Extensions.DependencyInjection;
 namespace AWS.Messaging.Configuration;
 
 /// <summary>
-/// Tracks the <see cref="IMiddleware"/> to be processed by the <see cref="Services.IHandlerInvoker"/> implementation and its <see cref="ServiceLifetime"/>.
+/// Tracks the <see cref="IHandlerMiddleware"/> to be processed by the <see cref="Services.IHandlerInvoker"/> implementation and its <see cref="ServiceLifetime"/>.
 /// </summary>
 public class SubscriberMiddleware
 {
     /// <summary>
     /// Constructs an instance of <see cref="SubscriberMiddleware"/>
     /// </summary>
-    /// <param name="type">The type that implements <see cref="IMiddleware"/>.</param>
+    /// <param name="type">The type that implements <see cref="IHandlerMiddleware"/>.</param>
     /// <param name="serviceLifetime">The lifetime of the middleware.</param>
     internal SubscriberMiddleware([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type, ServiceLifetime serviceLifetime)
     {
@@ -23,7 +23,7 @@ public class SubscriberMiddleware
     }
 
     /// <summary>
-    /// Type that implements <see cref="IMiddleware"/>.
+    /// Type that implements <see cref="IHandlerMiddleware"/>.
     /// </summary>
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
     public Type Type { get; }
@@ -36,11 +36,11 @@ public class SubscriberMiddleware
     /// <summary>
     /// Creates a SubscriberMiddleware from the generic parameters for the middleware.
     /// </summary>
-    /// <typeparam name="TMiddleware">The type that implements <see cref="IMiddleware"/></typeparam>
+    /// <typeparam name="TMiddleware">The type that implements <see cref="IHandlerMiddleware"/></typeparam>
     /// <param name="serviceLifetime">The lifetime of the middleware.</param>
     /// <returns><see cref="SubscriberMapping"/></returns>
     public static SubscriberMiddleware Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMiddleware>(ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
-        where TMiddleware : class, IMiddleware
+        where TMiddleware : class, IHandlerMiddleware
     {
         return new SubscriberMiddleware(typeof(TMiddleware), serviceLifetime);
     }

--- a/src/AWS.Messaging/IHandlerMiddleware.cs
+++ b/src/AWS.Messaging/IHandlerMiddleware.cs
@@ -6,7 +6,7 @@ namespace AWS.Messaging;
 /// <summary>
 /// This interface is implemented by the users of this library for each layer of middleware that should be processed.
 /// </summary>
-public interface IMiddleware
+public interface IHandlerMiddleware
 {
     /// <summary>
     /// Processes a message through the middleware pipeline, invoking the next middleware or the message handler.

--- a/src/AWS.Messaging/IMessageErrorHandler.cs
+++ b/src/AWS.Messaging/IMessageErrorHandler.cs
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging;
+
+public interface IMessageErrorHandler
+{
+    /// <summary>
+    /// Handles errors that occur during message processing.
+    /// </summary>
+    /// <param name="messageEnvelope">The message being processed.</param>
+    /// <param name="exception"><see cref="Exception"/> raised while processing message.</param>
+    /// <param name="attempts">Number of attempts made at processing this message</param>
+    /// <param name="token"><see cref="CancellationToken"/></param>
+    /// <returns><see cref="MessageErrorHandlerResponse"/></returns>
+    public ValueTask<MessageErrorHandlerResponse> OnHandleError<T>(MessageEnvelope<T> messageEnvelope, Exception exception, int attempts, CancellationToken token);
+}
+
+public enum MessageErrorHandlerResponse
+{
+    /// <summary>
+    /// Failed response.
+    /// </summary>
+    Failed,
+
+    /// <summary>
+    /// Retry the message processing in the same process.
+    /// </summary>
+    Retry,
+
+    /// <summary>
+    /// Success response.
+    /// </summary>
+    Success
+}

--- a/src/AWS.Messaging/IMessageErrorHandler.cs
+++ b/src/AWS.Messaging/IMessageErrorHandler.cs
@@ -3,6 +3,15 @@
 
 namespace AWS.Messaging;
 
+/// <summary>
+/// Defines a handler for errors that occur during message processing in the subscriber pipeline.
+/// Implementations can control retry behavior, override the message processing result, or handle exceptions.
+/// </summary>
+/// <remarks>
+/// Register an error handler using <c>builder.AddMessageErrorHandler&lt;T&gt;()</c>.
+/// Only one error handler may be registered. If an error handler is not registered, exceptions
+/// thrown during message processing will result in a <see cref="MessageProcessStatus"/> of Failed.
+/// </remarks>
 public interface IMessageErrorHandler
 {
     /// <summary>
@@ -16,6 +25,9 @@ public interface IMessageErrorHandler
     public ValueTask<MessageErrorHandlerResponse> OnHandleError<T>(MessageEnvelope<T> messageEnvelope, Exception exception, int attempts, CancellationToken token);
 }
 
+/// <summary>
+/// Defines the possible responses from an <see cref="IMessageErrorHandler"/> when handling a message processing error.
+/// </summary>
 public enum MessageErrorHandlerResponse
 {
     /// <summary>

--- a/src/AWS.Messaging/IMiddleware.cs
+++ b/src/AWS.Messaging/IMiddleware.cs
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging;
+
+/// <summary>
+/// This interface is implemented by the users of this library for each layer of middleware that should be processed.
+/// </summary>
+public interface IMiddleware
+{
+    /// <summary>
+    /// Processes a message through the middleware pipeline, invoking the next middleware or the message handler.
+    /// </summary>
+    /// <param name="messageEnvelope">The message read from the message source wrapped around a message envelope containing message metadata.</param>
+    /// <param name="next">Delegate to execute the next layer of middleware. When no further middleware remains, the delegate will execute the message handler.</param>
+    /// <param name="token">The optional cancellation token.</param>
+    /// <returns>
+    /// The status of the processed message. For example whether the message was successfully processed.
+    /// Default implementations should return the result returned from the next delegate.
+    /// </returns>
+    Task<MessageProcessStatus> InvokeAsync<T>(MessageEnvelope<T> messageEnvelope, RequestDelegate next, CancellationToken token = default);
+}
+
+/// <summary>
+/// The delegate used to invoke the next middleware layer or the message handler.
+/// </summary>
+/// <returns>
+/// The status of the processed message. For example whether the message was successfully processed.
+/// </returns>
+public delegate Task<MessageProcessStatus> RequestDelegate();

--- a/src/AWS.Messaging/Services/HandlerInvoker.cs
+++ b/src/AWS.Messaging/Services/HandlerInvoker.cs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Collections.Concurrent;
 using System.Reflection;
 using AWS.Messaging.Configuration;
 using AWS.Messaging.Telemetry;
@@ -17,12 +16,6 @@ public class HandlerInvoker : IHandlerInvoker
     private readonly ILogger<HandlerInvoker> _logger;
     private readonly ITelemetryFactory _telemetryFactory;
     private readonly IMessageConfiguration _messageConfiguration;
-
-    /// <summary>
-    /// Caches the <see cref="MethodInfo"/> of the <see cref="IMessageHandler{T}.HandleAsync(MessageEnvelope{T}, CancellationToken)"/>
-    /// method that will be invoked with the message envelope for each handler
-    /// </summary>
-    private readonly ConcurrentDictionary<Type, MethodInfo?> _handlerMethods = new();
 
     /// <summary>
     /// Constructs an instance of HandlerInvoker
@@ -43,8 +36,14 @@ public class HandlerInvoker : IHandlerInvoker
         _messageConfiguration = messageConfiguration;
     }
 
+    public Task<MessageProcessStatus> InvokeAsync(MessageEnvelope messageEnvelope, SubscriberMapping subscriberMapping, CancellationToken token = default)
+    {
+        // redirect to the generic version of InvokeAsync
+        return subscriberMapping.HandlerInvoker(this, messageEnvelope, subscriberMapping, token);
+    }
+
     /// <inheritdoc/>
-    public async Task<MessageProcessStatus> InvokeAsync(MessageEnvelope messageEnvelope, SubscriberMapping subscriberMapping, CancellationToken token = default)
+    public async Task<MessageProcessStatus> InvokeAsync<T>(MessageEnvelope<T> messageEnvelope, SubscriberMapping subscriberMapping, CancellationToken token = default)
     {
         using (var trace = _telemetryFactory.Trace("Processing message", messageEnvelope))
         {
@@ -58,60 +57,74 @@ public class HandlerInvoker : IHandlerInvoker
                     trace.AddMetadata(TelemetryKeys.SqsMessageId, messageEnvelope.SQSMetadata.MessageID);
                 }
 
-                await using (var scope = _serviceProvider.CreateAsyncScope())
+                var attempt = 0;
+                while (true)
                 {
-                    object handler;
+                    await using var scope = _serviceProvider.CreateAsyncScope();
                     try
                     {
-                        handler = scope.ServiceProvider.GetRequiredService(subscriberMapping.HandlerType);
-                    }
-                    catch (Exception e)
-                    {
-                        _logger.LogError("Unable to resolve a handler for {HandlerType} while handling message ID {MessageEnvelopeId}.", subscriberMapping.HandlerType, messageEnvelope.Id);
-                        throw new InvalidMessageHandlerSignatureException($"Unable to resolve a handler for {subscriberMapping.HandlerType} " +
-                                                                          $"while handling message ID {messageEnvelope.Id}.", e);
-                    }
 
-                    var method = _handlerMethods.GetOrAdd(subscriberMapping.MessageType, x =>
-                    {
-                        return subscriberMapping.HandlerType.GetMethod(    // Look up the method on the handler type with:
-                            nameof(IMessageHandler<MessageProcessStatus>.HandleAsync),              // name "HandleAsync"
-                            new Type[] { messageEnvelope.GetType(), typeof(CancellationToken) });   // parameters (MessageEnvelope<MessageType>, CancellationToken)
-                    });
-
-                    if (method == null)
-                    {
-                        _logger.LogError("Unable to resolve a compatible HandleAsync method for {HandlerType} while handling message ID {MessageEnvelopeId}.", subscriberMapping.HandlerType, messageEnvelope.Id);
-                        throw new InvalidMessageHandlerSignatureException($"Unable to resolve a compatible HandleAsync method for {subscriberMapping.HandlerType} while handling message ID {messageEnvelope.Id}.");
-                    }
-
-                    try
-                    {
-                        var middlewares = _messageConfiguration.SubscriberMiddleware.Select(subscriberMiddleware => (IMiddleware)scope.ServiceProvider.GetRequiredService(subscriberMiddleware.Type)!).ToList();
-                        return await ExecutePipelineAsync(messageEnvelope, subscriberMapping, middlewares, handler, method, subscriberMapping.MiddlewareInvokeAsyncMethodInfo, token).ConfigureAwait(false);
-                    }
-                    // Since we are invoking HandleAsync via reflection, we need to unwrap the TargetInvocationException
-                    // containing application exceptions that happened inside the IMessageHandler
-                    catch (TargetInvocationException ex)
-                    {
-                        trace.AddException(ex, false);
-
-                        if (ex.InnerException != null)
+                        IMessageHandler<T> handler;
+                        try
                         {
-                            _logger.LogError(ex.InnerException, "A handler exception occurred while handling message ID {MessageId}.", messageEnvelope.Id);
-                            return MessageProcessStatus.Failed();
+                            handler = (IMessageHandler<T>)scope.ServiceProvider.GetRequiredService(subscriberMapping.HandlerType);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, "Unable to resolve a handler for {HandlerType} while handling message ID {MessageEnvelopeId}.", subscriberMapping.HandlerType, messageEnvelope.Id);
+                            throw new InvalidMessageHandlerSignatureException($"Unable to resolve a handler for {subscriberMapping.HandlerType} while handling message ID {messageEnvelope.Id}.", ex);
+                        }
+
+                        var middlewares = _messageConfiguration.SubscriberMiddleware.Select(type => (IMiddleware)scope.ServiceProvider.GetRequiredService(type.Type)!).ToList();
+                        return await ExecutePipelineAsync(messageEnvelope, middlewares, handler, token).ConfigureAwait(false);
+                    }
+                    catch (Exception ex) when (ex is not InvalidMessageHandlerSignatureException)
+                    {
+                        if (ex is TargetInvocationException targetInvocationException)
+                        {
+                            // Since we are invoking HandleAsync via reflection, we need to unwrap the TargetInvocationException
+                            // containing application exceptions that happened inside the IMessageHandler
+                            if (targetInvocationException.InnerException != null)
+                            {
+                                ex = targetInvocationException.InnerException;
+                            }
                         }
                         else
                         {
-                            _logger.LogError(ex, "An unexpected exception occurred while handling message ID {MessageId}.", messageEnvelope.Id);
-                            return MessageProcessStatus.Failed();
+                            trace.AddException(ex, false);
                         }
-                    }
-                    catch (Exception ex)
-                    {
-                        trace.AddException(ex, false);
 
                         _logger.LogError(ex, "An unexpected exception occurred while handling message ID {MessageId}.", messageEnvelope.Id);
+
+                        try
+                        {
+                            var retryHandler = scope.ServiceProvider.GetService<IMessageErrorHandler>();
+                            if (retryHandler != null)
+                            {
+                                switch (await retryHandler!.OnHandleError(messageEnvelope, ex, ++attempt, token))
+                                {
+                                    case MessageErrorHandlerResponse.Failed:
+                                        _logger.LogError(ex, "An unexpected exception occurred while determining if message ID {MessageId} should be retried.", messageEnvelope.Id);
+                                        return MessageProcessStatus.Failed();
+
+                                    case MessageErrorHandlerResponse.Success:
+                                        return MessageProcessStatus.Success();
+
+                                    case MessageErrorHandlerResponse.Retry:
+                                        trace.AddMetadata(TelemetryKeys.Retry, attempt);
+                                        continue;
+
+                                    default:
+                                        throw new NotImplementedException();
+                                }
+                            }
+                        }
+                        catch (Exception retryException)
+                        {
+                            _logger.LogError(retryException, "An unexpected exception occurred while determining if message ID {MessageId} should be retried.", messageEnvelope.Id);
+                            return MessageProcessStatus.Failed();
+                        }
+
                         return MessageProcessStatus.Failed();
                     }
                 }
@@ -124,41 +137,15 @@ public class HandlerInvoker : IHandlerInvoker
         }
     }
 
-    private async Task<MessageProcessStatus> ExecutePipelineAsync(
-        MessageEnvelope messageEnvelope,
-        SubscriberMapping subscriberMapping,
-        IReadOnlyList<IMiddleware> middlewares,
-        object handler,
-        MethodInfo handlerMethod,
-        MethodInfo middlewareMethod,
-        CancellationToken token)
+    private static async Task<MessageProcessStatus> ExecutePipelineAsync<T>(MessageEnvelope<T> messageEnvelope, List<IMiddleware> middlewares, IMessageHandler<T> handler, CancellationToken token)
     {
-        RequestDelegate next = () =>
-        {
-            if (handlerMethod.Invoke(handler, new object[] { messageEnvelope, token }) is not Task<MessageProcessStatus> task)
-            {
-                _logger.LogError("Unexpected return type for the HandleAsync method on {HandlerType} while handling message ID {MessageEnvelopeId}. Expected {ExpectedType}", subscriberMapping.HandlerType, messageEnvelope.Id, nameof(Task<MessageProcessStatus>));
-                throw new InvalidMessageHandlerSignatureException($"Unexpected return type for the HandleAsync method on {subscriberMapping.HandlerType} while handling message ID {messageEnvelope.Id}. Expected {nameof(Task<MessageProcessStatus>)}");
-            }
-
-            return task;
-        };
+        RequestDelegate next = () => handler.HandleAsync(messageEnvelope, token);
 
         for (var i = middlewares.Count - 1; i >= 0; i--)
         {
             var capturedNext = next;
             var middleware = middlewares[i];
-
-            next = () =>
-            {
-                if (middlewareMethod.Invoke(middleware, new object[] { messageEnvelope, capturedNext, token }) is not Task<MessageProcessStatus> task)
-                {
-                    _logger.LogError("Unexpected return type for the InvokeAsync method on {MiddlewareType} while handling message ID {MessageEnvelopeId}. Expected {ExpectedType}", middleware.GetType(), messageEnvelope.Id, nameof(Task<MessageProcessStatus>));
-                    throw new InvalidMessageHandlerSignatureException($"Unexpected return type for the InvokeAsync method on {middleware.GetType()} while handling message ID {messageEnvelope.Id}. Expected {nameof(Task<MessageProcessStatus>)}");
-                }
-
-                return task;
-            };
+            next = () => middleware.InvokeAsync(messageEnvelope, capturedNext, token);
         }
 
         return await next().ConfigureAwait(false);

--- a/src/AWS.Messaging/Services/HandlerInvoker.cs
+++ b/src/AWS.Messaging/Services/HandlerInvoker.cs
@@ -75,7 +75,7 @@ public class HandlerInvoker : IHandlerInvoker
                             throw new InvalidMessageHandlerSignatureException($"Unable to resolve a handler for {subscriberMapping.HandlerType} while handling message ID {messageEnvelope.Id}.", ex);
                         }
 
-                        var middlewares = _messageConfiguration.SubscriberMiddleware.Select(type => (IMiddleware)scope.ServiceProvider.GetRequiredService(type.Type)!).ToList();
+                        var middlewares = _messageConfiguration.SubscriberMiddleware.Select(type => (IHandlerMiddleware)scope.ServiceProvider.GetRequiredService(type.Type)!).ToList();
                         return await ExecutePipelineAsync(messageEnvelope, middlewares, handler, token).ConfigureAwait(false);
                     }
                     catch (Exception ex) when (ex is not InvalidMessageHandlerSignatureException)
@@ -137,7 +137,7 @@ public class HandlerInvoker : IHandlerInvoker
         }
     }
 
-    private static async Task<MessageProcessStatus> ExecutePipelineAsync<T>(MessageEnvelope<T> messageEnvelope, List<IMiddleware> middlewares, IMessageHandler<T> handler, CancellationToken token)
+    private static async Task<MessageProcessStatus> ExecutePipelineAsync<T>(MessageEnvelope<T> messageEnvelope, List<IHandlerMiddleware> middlewares, IMessageHandler<T> handler, CancellationToken token)
     {
         RequestDelegate next = () => handler.HandleAsync(messageEnvelope, token);
 

--- a/src/AWS.Messaging/Telemetry/TelemetryKeys.cs
+++ b/src/AWS.Messaging/Telemetry/TelemetryKeys.cs
@@ -24,4 +24,5 @@ public static class TelemetryKeys
     internal const string MessageId = "aws.messaging.messageId";
     internal const string PublishTargetType = "aws.messaging.publishTargetType";
     internal const string HandlerType = "aws.messaging.handlerType";
+    internal const string Retry = "aws.messaging.retry";
 }

--- a/test/AWS.Messaging.Tests.Common/AWSUtilities.cs
+++ b/test/AWS.Messaging.Tests.Common/AWSUtilities.cs
@@ -118,7 +118,7 @@ public static class AWSUtilities
     {
         // Create bucket if it doesn't exist
         var listBucketsResponse = await s3Client.ListBucketsAsync();
-        if (listBucketsResponse.Buckets.Find((bucket) => bucket.BucketName == bucketName) == null)
+        if (listBucketsResponse.Buckets?.Find((bucket) => bucket.BucketName == bucketName) == null)
         {
             var putBucketRequest = new PutBucketRequest
             {

--- a/test/AWS.Messaging.UnitTests/HandlerInvokerTests.cs
+++ b/test/AWS.Messaging.UnitTests/HandlerInvokerTests.cs
@@ -39,7 +39,8 @@ public class HandlerInvokerTests
         var handlerInvoker = new HandlerInvoker(
             serviceProvider,
             new NullLogger<HandlerInvoker>(),
-            new DefaultTelemetryFactory(serviceProvider));
+            new DefaultTelemetryFactory(serviceProvider),
+            new MessageConfiguration());
 
         var envelope = new MessageEnvelope<ChatMessage>();
         var subscriberMapping = SubscriberMapping.Create<ChatMessageHandler, ChatMessage>();
@@ -67,7 +68,8 @@ public class HandlerInvokerTests
         var handlerInvoker = new HandlerInvoker(
             serviceProvider,
             new NullLogger<HandlerInvoker>(),
-            new DefaultTelemetryFactory(serviceProvider));
+            new DefaultTelemetryFactory(serviceProvider),
+            new MessageConfiguration());
 
         // Assert that ChatMessage is routed to the right handler method, which always succeeds
         var chatEnvelope = new MessageEnvelope<ChatMessage>();
@@ -105,7 +107,8 @@ public class HandlerInvokerTests
         var handlerInvoker = new HandlerInvoker(
             serviceProvider,
             mockLogger.Object,
-            new DefaultTelemetryFactory(serviceProvider));
+            new DefaultTelemetryFactory(serviceProvider),
+            new MessageConfiguration());
         var envelope = new MessageEnvelope<ChatMessage>()
         {
             Id = "123"
@@ -137,7 +140,8 @@ public class HandlerInvokerTests
         var handlerInvoker = new HandlerInvoker(
             serviceProvider,
             new NullLogger<HandlerInvoker>(),
-            new DefaultTelemetryFactory(serviceProvider));
+            new DefaultTelemetryFactory(serviceProvider),
+            new MessageConfiguration());
 
         // ACT and ASSERT - Invoke the GreetingHandler multiple times and verify that a new instance of IGreeter is created each time.
         var envelope = new MessageEnvelope<string>();
@@ -174,7 +178,8 @@ public class HandlerInvokerTests
         var handlerInvoker = new HandlerInvoker(
             serviceProvider,
             new NullLogger<HandlerInvoker>(),
-            new DefaultTelemetryFactory(serviceProvider));
+            new DefaultTelemetryFactory(serviceProvider),
+            new MessageConfiguration());
 
         var envelope = new MessageEnvelope<ChatMessage>();
         var subscriberMapping = SubscriberMapping.Create<ChatMessageHandlerWithDependencies, ChatMessage>();
@@ -204,7 +209,8 @@ public class HandlerInvokerTests
         var handlerInvoker = new HandlerInvoker(
             serviceProvider,
             new NullLogger<HandlerInvoker>(),
-            new DefaultTelemetryFactory(serviceProvider));
+            new DefaultTelemetryFactory(serviceProvider),
+            serviceProvider.GetRequiredService<IMessageConfiguration>());
 
         var envelope = new MessageEnvelope<ChatMessage>();
         var subscriberMapping = SubscriberMapping.Create<ChatMessageHandlerWithDisposableServices, ChatMessage>();
@@ -212,5 +218,117 @@ public class HandlerInvokerTests
 
         Assert.Equal(1, ChatMessageHandlerWithDisposableServices.TestDisposableService.CallCount);
         Assert.Equal(1, ChatMessageHandlerWithDisposableServices.TestDisposableServiceAsync.CallCount);
+    }
+
+    [Fact]
+    public async Task HandlerInvoker_Middleware_IsExecutedInOrderOfRegistration()
+    {
+        var serviceCollection = new ServiceCollection()
+            .AddAWSMessageBus(builder =>
+            {
+                builder.AddMessageHandler<SubscriberMiddlewareModels.SuccessMessageHandler<ChatMessage>, ChatMessage>("sqsQueueUrl");
+
+                builder.AddMiddleware<SubscriberMiddlewareModels.A>();
+                builder.AddMiddleware<SubscriberMiddlewareModels.B>();
+                builder.AddMiddleware<SubscriberMiddlewareModels.C>();
+            });
+
+        var middlewareTracker = new SubscriberMiddlewareModels.MiddlewareTracker();
+        serviceCollection.AddSingleton(middlewareTracker);
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var handlerInvoker = new HandlerInvoker(
+            serviceProvider,
+            new NullLogger<HandlerInvoker>(),
+            new DefaultTelemetryFactory(serviceProvider),
+            serviceProvider.GetRequiredService<IMessageConfiguration>());
+
+        var envelope = new MessageEnvelope<ChatMessage>();
+        var subscriberMapping = SubscriberMapping.Create<SubscriberMiddlewareModels.SuccessMessageHandler<ChatMessage>, ChatMessage>();
+        var messageProcessStatus = await handlerInvoker.InvokeAsync(envelope, subscriberMapping);
+
+        Assert.Equal(MessageProcessStatus.Success(), messageProcessStatus);
+
+        Assert.Equal(4, middlewareTracker.Executed.Count);
+        Assert.Equal(typeof(SubscriberMiddlewareModels.A), middlewareTracker.Executed[0]);
+        Assert.Equal(typeof(SubscriberMiddlewareModels.B), middlewareTracker.Executed[1]);
+        Assert.Equal(typeof(SubscriberMiddlewareModels.C), middlewareTracker.Executed[2]);
+        Assert.Equal(typeof(SubscriberMiddlewareModels.SuccessMessageHandler<ChatMessage>), middlewareTracker.Executed[3]);
+    }
+
+    [Fact]
+    public async Task HandlerInvoker_Middleware_MessageProcessStatusIsPropagated()
+    {
+        var serviceCollection = new ServiceCollection()
+            .AddAWSMessageBus(builder =>
+            {
+                builder.AddMessageHandler<SubscriberMiddlewareModels.FailMessageHandler<ChatMessage>, ChatMessage>("sqsQueueUrl");
+
+                builder.AddMiddleware<SubscriberMiddlewareModels.A>();
+                builder.AddMiddleware<SubscriberMiddlewareModels.B>();
+                builder.AddMiddleware<SubscriberMiddlewareModels.C>();
+            });
+
+        var middlewareTracker = new SubscriberMiddlewareModels.MiddlewareTracker();
+        serviceCollection.AddSingleton(middlewareTracker);
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var handlerInvoker = new HandlerInvoker(
+            serviceProvider,
+            new NullLogger<HandlerInvoker>(),
+            new DefaultTelemetryFactory(serviceProvider),
+            serviceProvider.GetRequiredService<IMessageConfiguration>());
+
+        var envelope = new MessageEnvelope<ChatMessage>();
+        var subscriberMapping = SubscriberMapping.Create<SubscriberMiddlewareModels.FailMessageHandler<ChatMessage>, ChatMessage>();
+        var messageProcessStatus = await handlerInvoker.InvokeAsync(envelope, subscriberMapping);
+
+        Assert.Equal(MessageProcessStatus.Failed(), messageProcessStatus);
+
+        Assert.Equal(4, middlewareTracker.Executed.Count);
+        Assert.Equal(typeof(SubscriberMiddlewareModels.A), middlewareTracker.Executed[0]);
+        Assert.Equal(typeof(SubscriberMiddlewareModels.B), middlewareTracker.Executed[1]);
+        Assert.Equal(typeof(SubscriberMiddlewareModels.C), middlewareTracker.Executed[2]);
+        Assert.Equal(typeof(SubscriberMiddlewareModels.FailMessageHandler<ChatMessage>), middlewareTracker.Executed[3]);
+    }
+
+
+
+    [Fact]
+    public async Task HandlerInvoker_Middleware_FailureDoesNotContinueChain()
+    {
+        var serviceCollection = new ServiceCollection()
+            .AddAWSMessageBus(builder =>
+            {
+                builder.AddMessageHandler<SubscriberMiddlewareModels.SuccessMessageHandler<ChatMessage>, ChatMessage>("sqsQueueUrl");
+
+                builder.AddMiddleware<SubscriberMiddlewareModels.A>();
+                builder.AddMiddleware<SubscriberMiddlewareModels.Error>();
+                builder.AddMiddleware<SubscriberMiddlewareModels.B>();
+                builder.AddMiddleware<SubscriberMiddlewareModels.C>();
+            });
+
+        var middlewareTracker = new SubscriberMiddlewareModels.MiddlewareTracker();
+        serviceCollection.AddSingleton(middlewareTracker);
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var handlerInvoker = new HandlerInvoker(
+            serviceProvider,
+            new NullLogger<HandlerInvoker>(),
+            new DefaultTelemetryFactory(serviceProvider),
+            serviceProvider.GetRequiredService<IMessageConfiguration>());
+
+        var envelope = new MessageEnvelope<ChatMessage>();
+        var subscriberMapping = SubscriberMapping.Create<SubscriberMiddlewareModels.SuccessMessageHandler<ChatMessage>, ChatMessage>();
+        var messageProcessStatus = await handlerInvoker.InvokeAsync(envelope, subscriberMapping);
+
+        Assert.Equal(MessageProcessStatus.Failed(), messageProcessStatus);
+
+        Assert.Equal(2, middlewareTracker.Executed.Count);
+        Assert.Equal(typeof(SubscriberMiddlewareModels.A), middlewareTracker.Executed[0]);
+        Assert.Equal(typeof(SubscriberMiddlewareModels.Error), middlewareTracker.Executed[1]);
     }
 }

--- a/test/AWS.Messaging.UnitTests/HandlerInvokerTests.cs
+++ b/test/AWS.Messaging.UnitTests/HandlerInvokerTests.cs
@@ -476,4 +476,196 @@ public class HandlerInvokerTests
         Assert.Equal(3, ChatExceptionHandlerAndDisposableServices.TestDisposableService.CallCount);
         Assert.Equal(3, ChatExceptionHandlerAndDisposableServices.TestDisposableServiceAsync.CallCount);
     }
+
+    /// <summary>
+    /// Tests that middleware works correctly with multiple message types, verifying the
+    /// delegate dispatch routes each type through the shared middleware to the correct handler.
+    /// </summary>
+    [Fact]
+    public async Task Middleware_WithMultipleMessageTypes_RoutesCorrectly()
+    {
+        var serviceCollection = new ServiceCollection()
+            .AddAWSMessageBus(builder =>
+            {
+                builder.AddMessageHandler<SubscriberMiddlewareModels.SuccessMessageHandler<ChatMessage>, ChatMessage>("chatMessage");
+                builder.AddMessageHandler<SubscriberMiddlewareModels.FailMessageHandler<AddressInfo>, AddressInfo>("addressInfo");
+
+                builder.AddMiddleware<SubscriberMiddlewareModels.A>();
+            });
+
+        var middlewareTracker = new SubscriberMiddlewareModels.MiddlewareTracker();
+        serviceCollection.AddSingleton(middlewareTracker);
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var handlerInvoker = new HandlerInvoker(
+            serviceProvider,
+            new NullLogger<HandlerInvoker>(),
+            new DefaultTelemetryFactory(serviceProvider),
+            serviceProvider.GetRequiredService<IMessageConfiguration>());
+
+        // Process a ChatMessage - should route to SuccessMessageHandler
+        var chatEnvelope = new MessageEnvelope<ChatMessage>();
+        var chatMapping = SubscriberMapping.Create<SubscriberMiddlewareModels.SuccessMessageHandler<ChatMessage>, ChatMessage>();
+        var chatResult = await handlerInvoker.InvokeAsync(chatEnvelope, chatMapping);
+
+        Assert.Equal(MessageProcessStatus.Success(), chatResult);
+        Assert.Equal(2, middlewareTracker.Executed.Count);
+        Assert.Equal(typeof(SubscriberMiddlewareModels.A), middlewareTracker.Executed[0]);
+        Assert.Equal(typeof(SubscriberMiddlewareModels.SuccessMessageHandler<ChatMessage>), middlewareTracker.Executed[1]);
+
+        // Process an AddressInfo - should route to FailMessageHandler through the same middleware
+        var addressEnvelope = new MessageEnvelope<AddressInfo>();
+        var addressMapping = SubscriberMapping.Create<SubscriberMiddlewareModels.FailMessageHandler<AddressInfo>, AddressInfo>();
+        var addressResult = await handlerInvoker.InvokeAsync(addressEnvelope, addressMapping);
+
+        Assert.Equal(MessageProcessStatus.Failed(), addressResult);
+        Assert.Equal(4, middlewareTracker.Executed.Count);
+        Assert.Equal(typeof(SubscriberMiddlewareModels.A), middlewareTracker.Executed[2]);
+        Assert.Equal(typeof(SubscriberMiddlewareModels.FailMessageHandler<AddressInfo>), middlewareTracker.Executed[3]);
+    }
+
+    /// <summary>
+    /// Tests that middleware can short-circuit the pipeline by returning a result without calling next().
+    /// Downstream middleware and the handler should NOT be executed.
+    /// </summary>
+    [Fact]
+    public async Task Middleware_ShortCircuit_DoesNotExecuteDownstream()
+    {
+        var serviceCollection = new ServiceCollection()
+            .AddAWSMessageBus(builder =>
+            {
+                builder.AddMessageHandler<SubscriberMiddlewareModels.SuccessMessageHandler<ChatMessage>, ChatMessage>("sqsQueueUrl");
+
+                builder.AddMiddleware<SubscriberMiddlewareModels.A>();
+                builder.AddMiddleware<SubscriberMiddlewareModels.ShortCircuit>();
+                builder.AddMiddleware<SubscriberMiddlewareModels.B>();
+            });
+
+        var middlewareTracker = new SubscriberMiddlewareModels.MiddlewareTracker();
+        serviceCollection.AddSingleton(middlewareTracker);
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var handlerInvoker = new HandlerInvoker(
+            serviceProvider,
+            new NullLogger<HandlerInvoker>(),
+            new DefaultTelemetryFactory(serviceProvider),
+            serviceProvider.GetRequiredService<IMessageConfiguration>());
+
+        var envelope = new MessageEnvelope<ChatMessage>();
+        var subscriberMapping = SubscriberMapping.Create<SubscriberMiddlewareModels.SuccessMessageHandler<ChatMessage>, ChatMessage>();
+        var messageProcessStatus = await handlerInvoker.InvokeAsync(envelope, subscriberMapping);
+
+        Assert.Equal(MessageProcessStatus.Success(), messageProcessStatus);
+
+        // Only A and ShortCircuit should execute - B and the handler should NOT
+        Assert.Equal(2, middlewareTracker.Executed.Count);
+        Assert.Equal(typeof(SubscriberMiddlewareModels.A), middlewareTracker.Executed[0]);
+        Assert.Equal(typeof(SubscriberMiddlewareModels.ShortCircuit), middlewareTracker.Executed[1]);
+    }
+
+    /// <summary>
+    /// Tests that the cancellation token is propagated through the middleware pipeline.
+    /// </summary>
+    [Fact]
+    public async Task Middleware_CancellationToken_IsPropagatedThroughPipeline()
+    {
+        SubscriberMiddlewareModels.CancellationAwareMiddleware.Reset();
+
+        var serviceCollection = new ServiceCollection()
+            .AddAWSMessageBus(builder =>
+            {
+                builder.AddMessageHandler<ChatMessageHandler, ChatMessage>("sqsQueueUrl");
+                builder.AddMiddleware<SubscriberMiddlewareModels.CancellationAwareMiddleware>();
+            });
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var handlerInvoker = new HandlerInvoker(
+            serviceProvider,
+            new NullLogger<HandlerInvoker>(),
+            new DefaultTelemetryFactory(serviceProvider),
+            serviceProvider.GetRequiredService<IMessageConfiguration>());
+
+        var envelope = new MessageEnvelope<ChatMessage>();
+        var subscriberMapping = SubscriberMapping.Create<ChatMessageHandler, ChatMessage>();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel(); // Pre-cancel the token
+
+        // The cancelled token should be propagated to the middleware
+        // Note: the framework catches exceptions, so the cancelled token may result in Failed status
+        await handlerInvoker.InvokeAsync(envelope, subscriberMapping, cts.Token);
+
+        Assert.True(SubscriberMiddlewareModels.CancellationAwareMiddleware.TokenWasReceived, "Middleware should receive a non-default CancellationToken");
+        Assert.True(SubscriberMiddlewareModels.CancellationAwareMiddleware.TokenWasCancelled, "Middleware should see the token is cancelled");
+    }
+
+    /// <summary>
+    /// Tests that singleton middleware resolves the same instance across multiple invocations,
+    /// while scoped middleware resolves a new instance per invocation.
+    /// </summary>
+    [Fact]
+    public async Task Middleware_SingletonVsScoped_LifetimeBehavior()
+    {
+        SubscriberMiddlewareModels.InstanceTrackingMiddleware.Reset();
+
+        var serviceCollection = new ServiceCollection()
+            .AddAWSMessageBus(builder =>
+            {
+                builder.AddMessageHandler<ChatMessageHandler, ChatMessage>("sqsQueueUrl");
+
+                // Register as Scoped - each invocation should get a new DI scope and thus a new instance
+                builder.AddMiddleware<SubscriberMiddlewareModels.InstanceTrackingMiddleware>(ServiceLifetime.Scoped);
+            });
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var handlerInvoker = new HandlerInvoker(
+            serviceProvider,
+            new NullLogger<HandlerInvoker>(),
+            new DefaultTelemetryFactory(serviceProvider),
+            serviceProvider.GetRequiredService<IMessageConfiguration>());
+
+        var envelope = new MessageEnvelope<ChatMessage>();
+        var subscriberMapping = SubscriberMapping.Create<ChatMessageHandler, ChatMessage>();
+
+        // Invoke 3 times - each should create a new scope and thus a new scoped middleware instance
+        await handlerInvoker.InvokeAsync(envelope, subscriberMapping);
+        await handlerInvoker.InvokeAsync(envelope, subscriberMapping);
+        await handlerInvoker.InvokeAsync(envelope, subscriberMapping);
+
+        // With scoped lifetime, each invocation creates a new scope, so we should get different instance IDs
+        Assert.Equal(3, SubscriberMiddlewareModels.InstanceTrackingMiddleware.ResolvedInstanceIds.Count);
+        var uniqueIds = new HashSet<int>(SubscriberMiddlewareModels.InstanceTrackingMiddleware.ResolvedInstanceIds);
+        Assert.Equal(3, uniqueIds.Count); // 3 different instances for scoped
+
+        // Now test Singleton behavior
+        SubscriberMiddlewareModels.InstanceTrackingMiddleware.Reset();
+
+        var singletonServiceCollection = new ServiceCollection()
+            .AddAWSMessageBus(builder =>
+            {
+                builder.AddMessageHandler<ChatMessageHandler, ChatMessage>("sqsQueueUrl");
+                builder.AddMiddleware<SubscriberMiddlewareModels.InstanceTrackingMiddleware>(ServiceLifetime.Singleton);
+            });
+
+        var singletonServiceProvider = singletonServiceCollection.BuildServiceProvider();
+
+        var singletonInvoker = new HandlerInvoker(
+            singletonServiceProvider,
+            new NullLogger<HandlerInvoker>(),
+            new DefaultTelemetryFactory(singletonServiceProvider),
+            singletonServiceProvider.GetRequiredService<IMessageConfiguration>());
+
+        await singletonInvoker.InvokeAsync(envelope, subscriberMapping);
+        await singletonInvoker.InvokeAsync(envelope, subscriberMapping);
+        await singletonInvoker.InvokeAsync(envelope, subscriberMapping);
+
+        // With singleton lifetime, all invocations should resolve the same instance
+        Assert.Equal(3, SubscriberMiddlewareModels.InstanceTrackingMiddleware.ResolvedInstanceIds.Count);
+        var singletonUniqueIds = new HashSet<int>(SubscriberMiddlewareModels.InstanceTrackingMiddleware.ResolvedInstanceIds);
+        Assert.Single(singletonUniqueIds); // All same instance for singleton
+    }
 }

--- a/test/AWS.Messaging.UnitTests/HandlerInvokerTests.cs
+++ b/test/AWS.Messaging.UnitTests/HandlerInvokerTests.cs
@@ -232,9 +232,9 @@ public class HandlerInvokerTests
             {
                 builder.AddMessageHandler<SubscriberMiddlewareModels.SuccessMessageHandler<ChatMessage>, ChatMessage>("sqsQueueUrl");
 
-                builder.AddMiddleware<SubscriberMiddlewareModels.A>();
-                builder.AddMiddleware<SubscriberMiddlewareModels.B>();
-                builder.AddMiddleware<SubscriberMiddlewareModels.C>();
+                builder.AddHandlerMiddleware<SubscriberMiddlewareModels.A>();
+                builder.AddHandlerMiddleware<SubscriberMiddlewareModels.B>();
+                builder.AddHandlerMiddleware<SubscriberMiddlewareModels.C>();
             });
 
         var middlewareTracker = new SubscriberMiddlewareModels.MiddlewareTracker();
@@ -272,9 +272,9 @@ public class HandlerInvokerTests
             {
                 builder.AddMessageHandler<SubscriberMiddlewareModels.FailMessageHandler<ChatMessage>, ChatMessage>("sqsQueueUrl");
 
-                builder.AddMiddleware<SubscriberMiddlewareModels.A>();
-                builder.AddMiddleware<SubscriberMiddlewareModels.B>();
-                builder.AddMiddleware<SubscriberMiddlewareModels.C>();
+                builder.AddHandlerMiddleware<SubscriberMiddlewareModels.A>();
+                builder.AddHandlerMiddleware<SubscriberMiddlewareModels.B>();
+                builder.AddHandlerMiddleware<SubscriberMiddlewareModels.C>();
             });
 
         var middlewareTracker = new SubscriberMiddlewareModels.MiddlewareTracker();
@@ -490,7 +490,7 @@ public class HandlerInvokerTests
                 builder.AddMessageHandler<SubscriberMiddlewareModels.SuccessMessageHandler<ChatMessage>, ChatMessage>("chatMessage");
                 builder.AddMessageHandler<SubscriberMiddlewareModels.FailMessageHandler<AddressInfo>, AddressInfo>("addressInfo");
 
-                builder.AddMiddleware<SubscriberMiddlewareModels.A>();
+                builder.AddHandlerMiddleware<SubscriberMiddlewareModels.A>();
             });
 
         var middlewareTracker = new SubscriberMiddlewareModels.MiddlewareTracker();
@@ -537,9 +537,9 @@ public class HandlerInvokerTests
             {
                 builder.AddMessageHandler<SubscriberMiddlewareModels.SuccessMessageHandler<ChatMessage>, ChatMessage>("sqsQueueUrl");
 
-                builder.AddMiddleware<SubscriberMiddlewareModels.A>();
-                builder.AddMiddleware<SubscriberMiddlewareModels.ShortCircuit>();
-                builder.AddMiddleware<SubscriberMiddlewareModels.B>();
+                builder.AddHandlerMiddleware<SubscriberMiddlewareModels.A>();
+                builder.AddHandlerMiddleware<SubscriberMiddlewareModels.ShortCircuit>();
+                builder.AddHandlerMiddleware<SubscriberMiddlewareModels.B>();
             });
 
         var middlewareTracker = new SubscriberMiddlewareModels.MiddlewareTracker();
@@ -577,7 +577,7 @@ public class HandlerInvokerTests
             .AddAWSMessageBus(builder =>
             {
                 builder.AddMessageHandler<ChatMessageHandler, ChatMessage>("sqsQueueUrl");
-                builder.AddMiddleware<SubscriberMiddlewareModels.CancellationAwareMiddleware>();
+                builder.AddHandlerMiddleware<SubscriberMiddlewareModels.CancellationAwareMiddleware>();
             });
 
         var serviceProvider = serviceCollection.BuildServiceProvider();
@@ -617,7 +617,7 @@ public class HandlerInvokerTests
                 builder.AddMessageHandler<ChatMessageHandler, ChatMessage>("sqsQueueUrl");
 
                 // Register as Scoped - each invocation should get a new DI scope and thus a new instance
-                builder.AddMiddleware<SubscriberMiddlewareModels.InstanceTrackingMiddleware>(ServiceLifetime.Scoped);
+                builder.AddHandlerMiddleware<SubscriberMiddlewareModels.InstanceTrackingMiddleware>(ServiceLifetime.Scoped);
             });
 
         var serviceProvider = serviceCollection.BuildServiceProvider();
@@ -648,7 +648,7 @@ public class HandlerInvokerTests
             .AddAWSMessageBus(builder =>
             {
                 builder.AddMessageHandler<ChatMessageHandler, ChatMessage>("sqsQueueUrl");
-                builder.AddMiddleware<SubscriberMiddlewareModels.InstanceTrackingMiddleware>(ServiceLifetime.Singleton);
+                builder.AddHandlerMiddleware<SubscriberMiddlewareModels.InstanceTrackingMiddleware>(ServiceLifetime.Singleton);
             });
 
         var singletonServiceProvider = singletonServiceCollection.BuildServiceProvider();

--- a/test/AWS.Messaging.UnitTests/MessageHandlers/Handlers.cs
+++ b/test/AWS.Messaging.UnitTests/MessageHandlers/Handlers.cs
@@ -74,6 +74,37 @@ public class ChatMessageHandlerWithDisposableServices : IMessageHandler<ChatMess
     }
 }
 
+public class ChatExceptionHandlerAndDisposableServices : IMessageHandler<ChatMessage>
+{
+    public ChatExceptionHandlerAndDisposableServices(TestDisposableServiceAsync testDisposableServiceAsync, TestDisposableService testDisposable)
+    {
+    }
+
+    public Task<MessageProcessStatus> HandleAsync(MessageEnvelope<ChatMessage> messageEnvelope, CancellationToken token = default)
+    {
+        throw new CustomHandlerException($"Unable to process message {messageEnvelope.Id}");
+    }
+
+    public class TestDisposableServiceAsync : IAsyncDisposable
+    {
+        public static long CallCount { get; set; } = 0;
+        public ValueTask DisposeAsync()
+        {
+            CallCount++;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public class TestDisposableService : IDisposable
+    {
+        public static long CallCount { get; set; } = 0;
+        public void Dispose()
+        {
+            CallCount++;
+        }
+    }
+}
+
 public class PlainTextHandler : IMessageHandler<string>
 {
     public Task<MessageProcessStatus> HandleAsync(MessageEnvelope<string> messageEnvelope, CancellationToken token = default)

--- a/test/AWS.Messaging.UnitTests/Models/SubscriberMiddlewareModels.cs
+++ b/test/AWS.Messaging.UnitTests/Models/SubscriberMiddlewareModels.cs
@@ -1,0 +1,103 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AWS.Messaging.UnitTests.Models;
+
+public static class SubscriberMiddlewareModels
+{
+    public class MiddlewareTracker
+    {
+        private readonly List<Type> _executed = [];
+
+        public IReadOnlyList<Type> Executed => _executed.AsReadOnly();
+
+        public void Add(object middleware)
+        {
+            _executed.Add(middleware.GetType());
+        }
+    }
+
+    public class SuccessMessageHandler<T> : IMessageHandler<T>
+    {
+        private readonly MiddlewareTracker _tracker;
+
+        public SuccessMessageHandler(MiddlewareTracker tracker)
+        {
+            _tracker = tracker;
+        }
+
+        public Task<MessageProcessStatus> HandleAsync(MessageEnvelope<T> messageEnvelope, CancellationToken token = default)
+        {
+            _tracker.Add(this);
+            return Task.FromResult(MessageProcessStatus.Success());
+        }
+    }
+
+    public class FailMessageHandler<T> : IMessageHandler<T>
+    {
+        private readonly MiddlewareTracker _tracker;
+
+        public FailMessageHandler(MiddlewareTracker tracker)
+        {
+            _tracker = tracker;
+        }
+
+        public Task<MessageProcessStatus> HandleAsync(MessageEnvelope<T> messageEnvelope, CancellationToken token = default)
+        {
+            _tracker.Add(this);
+            return Task.FromResult(MessageProcessStatus.Failed());
+        }
+    }
+
+    public abstract class TrackedMiddleware : IMiddleware
+    {
+        private readonly MiddlewareTracker _tracker;
+
+        protected TrackedMiddleware(MiddlewareTracker tracker)
+        {
+            _tracker = tracker;
+        }
+
+        public virtual Task<MessageProcessStatus> InvokeAsync<T>(MessageEnvelope<T> messageEnvelope, RequestDelegate next, CancellationToken cancellationToken = default)
+        {
+            _tracker.Add(this);
+            return next();
+        }
+    }
+
+    public class A : TrackedMiddleware
+    {
+        public A(MiddlewareTracker tracker) : base(tracker) { }
+    }
+
+    public class B : TrackedMiddleware
+    {
+        public B(MiddlewareTracker tracker) : base(tracker) { }
+    }
+
+    public class C : TrackedMiddleware
+    {
+        public C(MiddlewareTracker tracker) : base(tracker) { }
+    }
+
+    public class Error : IMiddleware
+    {
+        private readonly MiddlewareTracker _tracker;
+
+        public Error(MiddlewareTracker tracker)
+        {
+            _tracker = tracker;
+        }
+
+        public Task<MessageProcessStatus> InvokeAsync<T>(MessageEnvelope<T> messageEnvelope, RequestDelegate next, CancellationToken cancellationToken = default)
+        {
+            _tracker.Add(this);
+            throw new Exception("Error in middleware");
+        }
+    }
+}

--- a/test/AWS.Messaging.UnitTests/Models/SubscriberMiddlewareModels.cs
+++ b/test/AWS.Messaging.UnitTests/Models/SubscriberMiddlewareModels.cs
@@ -54,7 +54,7 @@ public static class SubscriberMiddlewareModels
         }
     }
 
-    public abstract class TrackedMiddleware : IMiddleware
+    public abstract class TrackedMiddleware : IHandlerMiddleware
     {
         private readonly MiddlewareTracker _tracker;
 
@@ -85,7 +85,7 @@ public static class SubscriberMiddlewareModels
         public C(MiddlewareTracker tracker) : base(tracker) { }
     }
 
-    public class Error : IMiddleware
+    public class Error : IHandlerMiddleware
     {
         private readonly MiddlewareTracker _tracker;
 
@@ -104,7 +104,7 @@ public static class SubscriberMiddlewareModels
     /// <summary>
     /// Middleware that short-circuits the pipeline by returning a result without calling next().
     /// </summary>
-    public class ShortCircuit : IMiddleware
+    public class ShortCircuit : IHandlerMiddleware
     {
         private readonly MiddlewareTracker _tracker;
 
@@ -124,7 +124,7 @@ public static class SubscriberMiddlewareModels
     /// <summary>
     /// Middleware that tracks its instance ID to verify scoped vs singleton behavior.
     /// </summary>
-    public class InstanceTrackingMiddleware : IMiddleware
+    public class InstanceTrackingMiddleware : IHandlerMiddleware
     {
         private static int _instanceCounter;
         public int InstanceId { get; }
@@ -152,7 +152,7 @@ public static class SubscriberMiddlewareModels
     /// <summary>
     /// Middleware that verifies the cancellation token is received.
     /// </summary>
-    public class CancellationAwareMiddleware : IMiddleware
+    public class CancellationAwareMiddleware : IHandlerMiddleware
     {
         public static bool TokenWasCancelled { get; set; }
         public static bool TokenWasReceived { get; set; }

--- a/test/AWS.Messaging.UnitTests/Models/SubscriberMiddlewareModels.cs
+++ b/test/AWS.Messaging.UnitTests/Models/SubscriberMiddlewareModels.cs
@@ -100,4 +100,74 @@ public static class SubscriberMiddlewareModels
             throw new Exception("Error in middleware");
         }
     }
+
+    /// <summary>
+    /// Middleware that short-circuits the pipeline by returning a result without calling next().
+    /// </summary>
+    public class ShortCircuit : IMiddleware
+    {
+        private readonly MiddlewareTracker _tracker;
+
+        public ShortCircuit(MiddlewareTracker tracker)
+        {
+            _tracker = tracker;
+        }
+
+        public Task<MessageProcessStatus> InvokeAsync<T>(MessageEnvelope<T> messageEnvelope, RequestDelegate next, CancellationToken cancellationToken = default)
+        {
+            _tracker.Add(this);
+            // Intentionally NOT calling next() - short-circuiting the pipeline
+            return Task.FromResult(MessageProcessStatus.Success());
+        }
+    }
+
+    /// <summary>
+    /// Middleware that tracks its instance ID to verify scoped vs singleton behavior.
+    /// </summary>
+    public class InstanceTrackingMiddleware : IMiddleware
+    {
+        private static int _instanceCounter;
+        public int InstanceId { get; }
+
+        public static List<int> ResolvedInstanceIds { get; } = new();
+
+        public InstanceTrackingMiddleware()
+        {
+            InstanceId = Interlocked.Increment(ref _instanceCounter);
+        }
+
+        public static void Reset()
+        {
+            _instanceCounter = 0;
+            ResolvedInstanceIds.Clear();
+        }
+
+        public Task<MessageProcessStatus> InvokeAsync<T>(MessageEnvelope<T> messageEnvelope, RequestDelegate next, CancellationToken cancellationToken = default)
+        {
+            ResolvedInstanceIds.Add(InstanceId);
+            return next();
+        }
+    }
+
+    /// <summary>
+    /// Middleware that verifies the cancellation token is received.
+    /// </summary>
+    public class CancellationAwareMiddleware : IMiddleware
+    {
+        public static bool TokenWasCancelled { get; set; }
+        public static bool TokenWasReceived { get; set; }
+
+        public static void Reset()
+        {
+            TokenWasCancelled = false;
+            TokenWasReceived = false;
+        }
+
+        public Task<MessageProcessStatus> InvokeAsync<T>(MessageEnvelope<T> messageEnvelope, RequestDelegate next, CancellationToken cancellationToken = default)
+        {
+            TokenWasReceived = cancellationToken != default;
+            TokenWasCancelled = cancellationToken.IsCancellationRequested;
+            return next();
+        }
+    }
 }

--- a/test/AWS.Messaging.UnitTests/OpenTelemetryTests.cs
+++ b/test/AWS.Messaging.UnitTests/OpenTelemetryTests.cs
@@ -87,7 +87,8 @@ public class OpenTelemetryTests
         _handler = new HandlerInvoker(
             _serviceProvider,
             new NullLogger<HandlerInvoker>(),
-            new DefaultTelemetryFactory(_serviceProvider));
+            new DefaultTelemetryFactory(_serviceProvider),
+            new MessageConfiguration());
     }
 
     /// <summary>


### PR DESCRIPTION
This is a partial implementation of the feature requested in #218 (limited to subscriber middleware)

The change modifies `HandlerInvoker` to add middleware to the execution pipeline. 

I acknowledge that both the PR and implementation are unsolicited, and am happy to modify/withdraw as required.

Example usage:
```cs
services.AddAWSMessageBus(builder =>
{
    builder.AddMiddleware<LoggingMiddleware>();  // Singleton by default
    ...
}

public class LoggingMiddleware(ILogger<LoggingMiddleware> Logger) : IMiddleware
{
    public Task<MessageProcessStatus> InvokeAsync<T>(MessageEnvelope<T> messageEnvelope, RequestDelegate next, CancellationToken token = default)
    {
        var stopwatch = Stopwatch.StartNew();
        try
        {
            return next();
        }
        finally
        {
            stopwatch.Stop();
            Logger.LogInformation("Processed message with ID: {MessageId} and Type: {MessageType} in {Elapsed}",
                messageEnvelope.Id,
                messageEnvelope.MessageTypeIdentifier,
                stopwatch.Elapsed);
        }
    }
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
