### PR TITLE
#281 Access to underlying service collection in builder

### DIFF
--- a/.autover/changes/55b720e8-c5d2-41e0-abda-658b2f39f77e.json
+++ b/.autover/changes/55b720e8-c5d2-41e0-abda-658b2f39f77e.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add builder overload to modify underlying service collection on build"
+      ]
+    }
+  ]
+}

--- a/.autover/changes/55b720e8-c5d2-41e0-abda-658b2f39f77e.json
+++ b/.autover/changes/55b720e8-c5d2-41e0-abda-658b2f39f77e.json
@@ -2,7 +2,7 @@
   "Projects": [
     {
       "Name": "AWS.Messaging",
-      "Type": "Patch",
+      "Type": "Minor",
       "ChangelogMessages": [
         "Add builder overload to modify underlying service collection on build"
       ]

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -102,6 +102,13 @@ public interface IMessageBusBuilder
     IMessageBusBuilder AddAdditionalService(ServiceDescriptor serviceDescriptor);
 
     /// <summary>
+    /// Add additional services to the <see cref="IMessageBusBuilder"/>. This method is used for AWS.Messaging plugins to add services for messaging.
+    /// </summary>
+    /// <param name="action">Configuration action to perform against the service collection.</param>
+    /// <returns></returns>
+    IMessageBusBuilder AddAdditionalService(Action<IMessageConfiguration, IServiceCollection> action);
+
+    /// <summary>
     /// Enables the visibility of data messages in the logging framework, exception handling and other areas.
     /// If this is enabled, messages sent by this framework will be visible in plain text across the framework's components.
     /// This means any sensitive user data sent by this framework will be visible in logs, any exceptions thrown and others.

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -102,9 +102,15 @@ public interface IMessageBusBuilder
     IMessageBusBuilder AddAdditionalService(ServiceDescriptor serviceDescriptor);
 
     /// <summary>
-    /// Add additional services to the <see cref="IMessageBusBuilder"/>. This method is used for AWS.Messaging plugins to add services for messaging.
+    /// Add additional services to the <see cref="IMessageBusBuilder"/> by registering a callback that receives the current
+    /// <see cref="IMessageConfiguration"/> and the target <see cref="IServiceCollection"/>. This method is used for
+    /// AWS.Messaging plugins to add services for messaging. The callback is invoked during <c>builder.Build()</c>, so
+    /// changes to <see cref="IMessageConfiguration"/> made in this action should not be assumed to affect registrations
+    /// that were performed earlier in the build process.
     /// </summary>
-    /// <param name="action">Configuration action to perform against the service collection.</param>
+    /// <param name="action">Configuration action to perform during <c>builder.Build()</c>. The first parameter is the current
+    /// <see cref="IMessageConfiguration"/>, and the second parameter is the <see cref="IServiceCollection"/> to which
+    /// additional services can be added.</param>
     /// <returns></returns>
     IMessageBusBuilder AddAdditionalService(Action<IMessageConfiguration, IServiceCollection> action);
 

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -155,13 +155,13 @@ public interface IMessageBusBuilder
     /// <summary>
     /// Add additional services to the <see cref="IMessageBusBuilder"/> by registering a callback that receives the current
     /// <see cref="IMessageConfiguration"/> and the target <see cref="IServiceCollection"/>. This method is used for
-    /// AWS.Messaging plugins to add services for messaging. The callback is invoked during <c>builder.Build()</c>, so
-    /// changes to <see cref="IMessageConfiguration"/> made in this action should not be assumed to affect registrations
-    /// that were performed earlier in the build process.
+    /// AWS.Messaging plugins to add services for messaging. The callback is invoked during <c>builder.Build()</c> after
+    /// all framework service registrations have completed. The <see cref="IMessageConfiguration"/> parameter should be
+    /// treated as read-only; any mutations to it will not be reflected in the services already registered by the framework.
     /// </summary>
     /// <param name="action">Configuration action to perform during <c>builder.Build()</c>. The first parameter is the current
-    /// <see cref="IMessageConfiguration"/>, and the second parameter is the <see cref="IServiceCollection"/> to which
-    /// additional services can be added.</param>
+    /// <see cref="IMessageConfiguration"/> (read-only — mutations will not affect prior registrations), and the second
+    /// parameter is the <see cref="IServiceCollection"/> to which additional services can be added.</param>
     /// <returns></returns>
     IMessageBusBuilder AddAdditionalService(Action<IMessageConfiguration, IServiceCollection> action);
 

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -153,9 +153,15 @@ public interface IMessageBusBuilder
     IMessageBusBuilder AddAdditionalService(ServiceDescriptor serviceDescriptor);
 
     /// <summary>
-    /// Add additional services to the <see cref="IMessageBusBuilder"/>. This method is used for AWS.Messaging plugins to add services for messaging.
+    /// Add additional services to the <see cref="IMessageBusBuilder"/> by registering a callback that receives the current
+    /// <see cref="IMessageConfiguration"/> and the target <see cref="IServiceCollection"/>. This method is used for
+    /// AWS.Messaging plugins to add services for messaging. The callback is invoked during <c>builder.Build()</c>, so
+    /// changes to <see cref="IMessageConfiguration"/> made in this action should not be assumed to affect registrations
+    /// that were performed earlier in the build process.
     /// </summary>
-    /// <param name="action">Configuration action to perform against the service collection.</param>
+    /// <param name="action">Configuration action to perform during <c>builder.Build()</c>. The first parameter is the current
+    /// <see cref="IMessageConfiguration"/>, and the second parameter is the <see cref="IServiceCollection"/> to which
+    /// additional services can be added.</param>
     /// <returns></returns>
     IMessageBusBuilder AddAdditionalService(Action<IMessageConfiguration, IServiceCollection> action);
 

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -153,6 +153,13 @@ public interface IMessageBusBuilder
     IMessageBusBuilder AddAdditionalService(ServiceDescriptor serviceDescriptor);
 
     /// <summary>
+    /// Add additional services to the <see cref="IMessageBusBuilder"/>. This method is used for AWS.Messaging plugins to add services for messaging.
+    /// </summary>
+    /// <param name="action">Configuration action to perform against the service collection.</param>
+    /// <returns></returns>
+    IMessageBusBuilder AddAdditionalService(Action<IMessageConfiguration, IServiceCollection> action);
+
+    /// <summary>
     /// Enables the visibility of data messages in the logging framework, exception handling and other areas.
     /// If this is enabled, messages sent by this framework will be visible in plain text across the framework's components.
     /// This means any sensitive user data sent by this framework will be visible in logs, any exceptions thrown and others.

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -29,7 +29,7 @@ public class MessageBusBuilder : IMessageBusBuilder
 {
     private static readonly ConcurrentDictionary<IServiceCollection, MessageConfiguration> _messageConfigurations = new();
     private readonly MessageConfiguration _messageConfiguration;
-    private readonly IList<ServiceDescriptor> _additionalServices = new List<ServiceDescriptor>();
+    private readonly IList<Action<IMessageConfiguration, IServiceCollection>> _additionalServices = new List<Action<IMessageConfiguration, IServiceCollection>>();
     private readonly IServiceCollection _serviceCollection;
 
     /// <summary>
@@ -301,7 +301,14 @@ public class MessageBusBuilder : IMessageBusBuilder
     /// <inheritdoc/>
     public IMessageBusBuilder AddAdditionalService(ServiceDescriptor serviceDescriptor)
     {
-        _additionalServices.Add(serviceDescriptor);
+        _additionalServices.Add((_, services) => services.TryAdd(serviceDescriptor));
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public IMessageBusBuilder AddAdditionalService(Action<IMessageConfiguration, IServiceCollection> action)
+    {
+        _additionalServices.Add(action);
         return this;
     }
 
@@ -410,9 +417,9 @@ public class MessageBusBuilder : IMessageBusBuilder
             }
         }
 
-        foreach (var service in _additionalServices)
+        foreach (var action in _additionalServices)
         {
-            _serviceCollection.TryAdd(service);
+            action.Invoke(_messageConfiguration, _serviceCollection);
         }
     }
 

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -301,6 +301,7 @@ public class MessageBusBuilder : IMessageBusBuilder
     /// <inheritdoc/>
     public IMessageBusBuilder AddAdditionalService(ServiceDescriptor serviceDescriptor)
     {
+        ArgumentNullException.ThrowIfNull(serviceDescriptor);
         _additionalServices.Add((_, services) => services.TryAdd(serviceDescriptor));
         return this;
     }
@@ -308,6 +309,7 @@ public class MessageBusBuilder : IMessageBusBuilder
     /// <inheritdoc/>
     public IMessageBusBuilder AddAdditionalService(Action<IMessageConfiguration, IServiceCollection> action)
     {
+        ArgumentNullException.ThrowIfNull(action);
         _additionalServices.Add(action);
         return this;
     }

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -30,7 +30,7 @@ public class MessageBusBuilder : IMessageBusBuilder
 {
     private static readonly ConcurrentDictionary<IServiceCollection, MessageConfiguration> _messageConfigurations = new();
     private readonly MessageConfiguration _messageConfiguration;
-    private readonly IList<ServiceDescriptor> _additionalServices = new List<ServiceDescriptor>();
+    private readonly IList<Action<IMessageConfiguration, IServiceCollection>> _additionalServices = new List<Action<IMessageConfiguration, IServiceCollection>>();
     private readonly IServiceCollection _serviceCollection;
 
     /// <summary>
@@ -388,7 +388,14 @@ public class MessageBusBuilder : IMessageBusBuilder
     /// <inheritdoc/>
     public IMessageBusBuilder AddAdditionalService(ServiceDescriptor serviceDescriptor)
     {
-        _additionalServices.Add(serviceDescriptor);
+        _additionalServices.Add((_, services) => services.TryAdd(serviceDescriptor));
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public IMessageBusBuilder AddAdditionalService(Action<IMessageConfiguration, IServiceCollection> action)
+    {
+        _additionalServices.Add(action);
         return this;
     }
 
@@ -505,9 +512,9 @@ public class MessageBusBuilder : IMessageBusBuilder
             }
         }
 
-        foreach (var service in _additionalServices)
+        foreach (var action in _additionalServices)
         {
-            _serviceCollection.TryAdd(service);
+            action.Invoke(_messageConfiguration, _serviceCollection);
         }
     }
 

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -388,6 +388,7 @@ public class MessageBusBuilder : IMessageBusBuilder
     /// <inheritdoc/>
     public IMessageBusBuilder AddAdditionalService(ServiceDescriptor serviceDescriptor)
     {
+        ArgumentNullException.ThrowIfNull(serviceDescriptor);
         _additionalServices.Add((_, services) => services.TryAdd(serviceDescriptor));
         return this;
     }
@@ -395,6 +396,7 @@ public class MessageBusBuilder : IMessageBusBuilder
     /// <inheritdoc/>
     public IMessageBusBuilder AddAdditionalService(Action<IMessageConfiguration, IServiceCollection> action)
     {
+        ArgumentNullException.ThrowIfNull(action);
         _additionalServices.Add(action);
         return this;
     }

--- a/test/AWS.Messaging.UnitTests/MessageBusBuilderTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessageBusBuilderTests.cs
@@ -680,6 +680,114 @@ public class MessageBusBuilderTests
         Assert.IsType<MessageSerializer>(messageSerializer);
     }
 
+    [Fact]
+    public void MessageBus_AddAdditionalService_ServiceDescriptor()
+    {
+        var instance = new AdditionalServiceFixture();
+
+        _serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddAdditionalService(new ServiceDescriptor(typeof(AdditionalServiceFixture), instance));
+        });
+
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+
+        var resolved = serviceProvider.GetService<AdditionalServiceFixture>();
+        Assert.NotNull(resolved);
+        Assert.Same(instance, resolved);
+    }
+
+    [Fact]
+    public void MessageBus_AddAdditionalService_ServiceDescriptor_TryAdd_DoesNotOverwriteExistingRegistration()
+    {
+        var firstInstance = new AdditionalServiceFixture();
+        var secondInstance = new AdditionalServiceFixture();
+
+        _serviceCollection.AddSingleton(firstInstance);
+
+        _serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddAdditionalService(new ServiceDescriptor(typeof(AdditionalServiceFixture), secondInstance));
+        });
+
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+
+        var resolved = serviceProvider.GetService<AdditionalServiceFixture>();
+        Assert.Same(firstInstance, resolved);
+    }
+
+    [Fact]
+    public void MessageBus_AddAdditionalService_ServiceDescriptor_NullThrows()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            _serviceCollection.AddAWSMessageBus(builder =>
+            {
+                builder.AddAdditionalService((ServiceDescriptor)null!);
+            }));
+    }
+
+    [Fact]
+    public void MessageBus_AddAdditionalService_Action_PassesConfigurationToCallback()
+    {
+        var instance = new AdditionalServiceFixture();
+        IMessageConfiguration? capturedConfiguration = null;
+
+        _serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPublisher<OrderInfo>("sqsQueueUrl");
+            builder.AddAdditionalService((configuration, services) =>
+            {
+                capturedConfiguration = configuration;
+                services.AddSingleton(instance);
+            });
+        });
+
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+
+        var resolved = serviceProvider.GetService<AdditionalServiceFixture>();
+        Assert.NotNull(resolved);
+        Assert.Same(instance, resolved);
+
+        Assert.NotNull(capturedConfiguration);
+        Assert.Same(serviceProvider.GetRequiredService<IMessageConfiguration>(), capturedConfiguration);
+        Assert.NotNull(capturedConfiguration!.GetPublisherMapping(typeof(OrderInfo)));
+    }
+
+    [Fact]
+    public void MessageBus_AddAdditionalService_Action_CanOverwriteExistingRegistration()
+    {
+        var firstInstance = new AdditionalServiceFixture();
+        var secondInstance = new AdditionalServiceFixture();
+
+        _serviceCollection.AddSingleton(firstInstance);
+
+        _serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddAdditionalService((_, services) =>
+            {
+                services.AddSingleton(secondInstance);
+            });
+        });
+
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+
+        var resolved = serviceProvider.GetService<AdditionalServiceFixture>();
+        Assert.Same(secondInstance, resolved);
+    }
+
+    [Fact]
+    public void MessageBus_AddAdditionalService_Action_NullThrows()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            _serviceCollection.AddAWSMessageBus(builder =>
+            {
+                builder.AddAdditionalService((Action<IMessageConfiguration, IServiceCollection>)null!);
+            }));
+    }
+
+    private sealed class AdditionalServiceFixture
+    {
+    }
 
     // These services must be present irrespective of whether publishers or subscribers are configured.
     private void CheckRequiredServices(ServiceProvider serviceProvider)


### PR DESCRIPTION
#281 

Adds an overload to `MessageBusBuilder.AddAdditionalService` to expose underlying `IMessageConfiguration` and `IServiceCollection` for finer control of service manipulation.

Sample usage:
```cs

public static IMessageBusBuilder WithOutbox(this IMessageBusBuilder builder)
{
   builder.AddAdditionalService((_, services) => 
   {
      ... // other services related to the outbox
      services.AddHostedService<OutboxPublishBackgroundService>();
      services.Replace(new ServiceDescriptor(typeof(IMessagePublisher), typeof(OutboxMessageRoutingPublisher), ServiceLifetime.Scoped));
  });

   return builder;
}
```

Although not included in the sample message, I suspect that there would be other times where having the message configuration may be useful but I am happy to remove it if there is an objection.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
