### PR TITLE
Add SentTimestamp to SQSMetadata

### DIFF
--- a/.autover/changes/45a6ab22-5bb9-4b65-bfb1-94571b502622.json
+++ b/.autover/changes/45a6ab22-5bb9-4b65-bfb1-94571b502622.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add SentTimestamp to SQSMetadata"
+      ]
+    }
+  ]
+}

--- a/src/AWS.Messaging/SQSMetadata.cs
+++ b/src/AWS.Messaging/SQSMetadata.cs
@@ -31,6 +31,11 @@ namespace AWS.Messaging
         public string? MessageGroupId { get; set; }
 
         /// <summary>
+        /// The time at which the message was sent to the queue (epoch time in milliseconds).
+        /// </summary>
+        public string? SentTimestamp { get; set; }
+
+        /// <summary>
         /// Each message attribute consists of a Name, Type, and Value.For more information, see Amazon SQS message attributes (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-metadata.html#sqs-message-attributes)
         /// </summary>
         public Dictionary<string, MessageAttributeValue>? MessageAttributes { get; set; }

--- a/src/AWS.Messaging/Serialization/Handlers/MessageMetadataHandler.cs
+++ b/src/AWS.Messaging/Serialization/Handlers/MessageMetadataHandler.cs
@@ -31,6 +31,7 @@ internal static class MessageMetadataHandler
         {
             metadata.MessageGroupId = JsonPropertyHelper.GetAttributeValue(message.Attributes, "MessageGroupId");
             metadata.MessageDeduplicationId = JsonPropertyHelper.GetAttributeValue(message.Attributes, "MessageDeduplicationId");
+            metadata.SentTimestamp = JsonPropertyHelper.GetAttributeValue(message.Attributes, "SentTimestamp");
         }
 
         return metadata;


### PR DESCRIPTION
#283 

Adds the SentTimestamp message system attribute to the SQSMetadata class and maps it in the MessageMetadataHandler.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.