### PR TITLE
Add single message type pollers with raw message support

### DIFF
--- a/.autover/changes/25e615a7-b592-4762-ae54-f77baff2e588.json
+++ b/.autover/changes/25e615a7-b592-4762-ae54-f77baff2e588.json
@@ -4,7 +4,7 @@
       "Name": "AWS.Messaging",
       "Type": "Minor",
       "ChangelogMessages": [
-        "Added support to pollers that are tied to a single message type. This change also allows processing messages that use the CloudEvents envelope as well as those that do not."
+        "Added support for pollers that are tied to a single message type. This change also allows processing messages that use the CloudEvents envelope as well as those that do not."
       ]
     }
   ]

--- a/.autover/changes/25e615a7-b592-4762-ae54-f77baff2e588.json
+++ b/.autover/changes/25e615a7-b592-4762-ae54-f77baff2e588.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Added support to pollers that are tied to a single message type. This change also allows processing messages that use the CloudEvents envelope as well as those that do not."
+      ]
+    }
+  ]
+}

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -61,6 +61,26 @@ public interface IMessageBusBuilder
     IMessageBusBuilder AddSQSPoller(string queueUrl, Action<SQSMessagePollerOptions>? options = null);
 
     /// <summary>
+    /// Adds an SQS queue to poll for messages of a single message type.
+    /// <para/>
+    /// When configured this way, inbound message processing is restricted to the subscriber mapping for <typeparamref name="TMessage"/>.
+    /// This is especially useful when using a dedicated queue per message type or when ingesting raw JSON payloads that do not carry
+    /// a CloudEvents envelope (and therefore cannot be type-routed).
+    /// </summary>
+    /// <param name="queueUrl">The SQS queue to poll for messages.</param>
+    /// <param name="messageTypeIdentifier">Optional message type identifier to use when selecting the subscriber mapping for <typeparamref name="TMessage"/>.</param>
+    /// <param name="usesMessageEnvelope">
+    /// When true (default), inbound messages are expected to be in the CloudEvents envelope format.
+    /// When false, inbound messages are expected to be a raw payload of <typeparamref name="TMessage"/>.
+    /// </param>
+    /// <param name="options">Optional configuration for polling messages from SQS.</param>
+    IMessageBusBuilder AddSQSPoller<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(
+        string queueUrl,
+        string? messageTypeIdentifier = null,
+        bool usesMessageEnvelope = true,
+        Action<SQSMessagePollerOptions>? options = null);
+
+    /// <summary>
     /// Configures an instance of <see cref="SerializationOptions"/> to control the serialization/de-serialization logic for the application message.
     /// </summary>
     IMessageBusBuilder ConfigureSerializationOptions(Action<SerializationOptions> options);

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -69,15 +69,15 @@ public interface IMessageBusBuilder
     /// </summary>
     /// <param name="queueUrl">The SQS queue to poll for messages.</param>
     /// <param name="messageTypeIdentifier">Optional message type identifier to use when selecting the subscriber mapping for <typeparamref name="TMessage"/>.</param>
-    /// <param name="usesMessageEnvelope">
-    /// When true (default), inbound messages are expected to be in the CloudEvents envelope format.
-    /// When false, inbound messages are expected to be a raw payload of <typeparamref name="TMessage"/>.
+    /// <param name="messageEnvelopeMode">
+    /// When 'Supported' (default), inbound messages are expected to be in the CloudEvents envelope format.
+    /// When 'NotSupported', inbound messages are expected to be a raw payload of <typeparamref name="TMessage"/>.
     /// </param>
     /// <param name="options">Optional configuration for polling messages from SQS.</param>
     IMessageBusBuilder AddSQSPoller<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(
         string queueUrl,
         string? messageTypeIdentifier = null,
-        bool usesMessageEnvelope = true,
+        MessageEnvelopeMode messageEnvelopeMode = MessageEnvelopeMode.Supported,
         Action<SQSMessagePollerOptions>? options = null);
 
     /// <summary>

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -138,7 +138,7 @@ public class MessageBusBuilder : IMessageBusBuilder
     public IMessageBusBuilder AddSQSPoller<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(
         string queueUrl,
         string? messageTypeIdentifier = null,
-        bool usesMessageEnvelope = true,
+        MessageEnvelopeMode messageEnvelopeMode = MessageEnvelopeMode.Supported,
         Action<SQSMessagePollerOptions>? options = null)
     {
         // Create the user-provided options class
@@ -159,7 +159,7 @@ public class MessageBusBuilder : IMessageBusBuilder
             IsExceptionFatal = sqsMessagePollerOptions.IsExceptionFatal,
 
             SingleMessageTypeIdentifier = messageTypeIdentifier,
-            UsesMessageEnvelope = usesMessageEnvelope
+            MessageEnvelopeMode = messageEnvelopeMode
         };
 
         _messageConfiguration.MessagePollerConfigurations.Add(sqsMessagePollerConfiguration);

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -135,6 +135,38 @@ public class MessageBusBuilder : IMessageBusBuilder
     }
 
     /// <inheritdoc/>
+    public IMessageBusBuilder AddSQSPoller<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(
+        string queueUrl,
+        string? messageTypeIdentifier = null,
+        bool usesMessageEnvelope = true,
+        Action<SQSMessagePollerOptions>? options = null)
+    {
+        // Create the user-provided options class
+        var sqsMessagePollerOptions = new SQSMessagePollerOptions();
+
+        options?.Invoke(sqsMessagePollerOptions);
+
+        sqsMessagePollerOptions.Validate();
+
+        // Copy that to our internal options class
+        var sqsMessagePollerConfiguration = new SingleTypeSQSMessagePollerConfiguration(queueUrl, typeof(TMessage))
+        {
+            MaxNumberOfConcurrentMessages = sqsMessagePollerOptions.MaxNumberOfConcurrentMessages,
+            VisibilityTimeout = sqsMessagePollerOptions.VisibilityTimeout,
+            VisibilityTimeoutExtensionThreshold = sqsMessagePollerOptions.VisibilityTimeoutExtensionThreshold,
+            VisibilityTimeoutExtensionHeartbeatInterval = sqsMessagePollerOptions.VisibilityTimeoutExtensionHeartbeatInterval,
+            WaitTimeSeconds = sqsMessagePollerOptions.WaitTimeSeconds,
+            IsExceptionFatal = sqsMessagePollerOptions.IsExceptionFatal,
+
+            SingleMessageTypeIdentifier = messageTypeIdentifier,
+            UsesMessageEnvelope = usesMessageEnvelope
+        };
+
+        _messageConfiguration.MessagePollerConfigurations.Add(sqsMessagePollerConfiguration);
+        return this;
+    }
+
+    /// <inheritdoc/>
     public IMessageBusBuilder ConfigureSerializationOptions(Action<SerializationOptions> options)
     {
         options(_messageConfiguration.SerializationOptions);

--- a/src/AWS.Messaging/Configuration/MessageEnvelopeMode.cs
+++ b/src/AWS.Messaging/Configuration/MessageEnvelopeMode.cs
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Configuration;
+
+/// <summary>
+/// The mode indicating how message envelopes are used in message transport.
+/// </summary>
+public enum MessageEnvelopeMode
+{
+    /// <summary>
+    /// Message envelopes are used in message transport.
+    /// </summary>
+    Supported,
+    /// <summary>
+    /// Message envelopes are not used in message transport.
+    /// </summary>
+    NotSupported
+}

--- a/src/AWS.Messaging/Configuration/SingleTypeMessageConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/SingleTypeMessageConfiguration.cs
@@ -12,7 +12,7 @@ namespace AWS.Messaging.Configuration;
 /// to a single configured subscriber mapping. This is used to create a poller instance that only
 /// processes one message type.
 /// </summary>
-public class SingleTypeMessageConfiguration : IMessageConfiguration
+internal class SingleTypeMessageConfiguration : IMessageConfiguration
 {
     private readonly IMessageConfiguration _inner;
     private readonly SubscriberMapping _subscriberMapping;

--- a/src/AWS.Messaging/Configuration/SingleTypeMessageConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/SingleTypeMessageConfiguration.cs
@@ -1,0 +1,99 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Messaging.Configuration.Internal;
+using AWS.Messaging.Serialization;
+using AWS.Messaging.Services.Backoff.Policies.Options;
+
+namespace AWS.Messaging.Configuration;
+
+/// <summary>
+/// Wraps an existing <see cref="IMessageConfiguration"/> but restricts subscriber mapping resolution
+/// to a single configured subscriber mapping. This is used to create a poller instance that only
+/// processes one message type.
+/// </summary>
+public class SingleTypeMessageConfiguration : IMessageConfiguration
+{
+    private readonly IMessageConfiguration _inner;
+    private readonly SubscriberMapping _subscriberMapping;
+
+    /// <summary>
+    /// Construct an instance of <see cref="SingleTypeMessageConfiguration"/>
+    /// </summary>
+    public SingleTypeMessageConfiguration(
+        IMessageConfiguration inner,
+        SubscriberMapping subscriberMapping)
+    {
+        _inner = inner;
+        _subscriberMapping = subscriberMapping;
+    }
+
+    /// <inheritdoc/>
+    public IList<PublisherMapping> PublisherMappings => _inner.PublisherMappings;
+
+    /// <inheritdoc/>
+    public PublisherMapping? GetPublisherMapping(Type messageType) => _inner.GetPublisherMapping(messageType);
+
+    /// <inheritdoc/>
+    public IList<SubscriberMapping> SubscriberMappings => new[] { _subscriberMapping };
+
+    /// <inheritdoc/>
+    public SubscriberMapping? GetSubscriberMapping(Type messageType)
+        => messageType == _subscriberMapping.MessageType ? _subscriberMapping : null;
+
+    /// <inheritdoc/>
+    public SubscriberMapping? GetSubscriberMapping(string messageTypeIdentifier)
+        => string.Equals(messageTypeIdentifier, _subscriberMapping.MessageTypeIdentifier, StringComparison.Ordinal)
+            ? _subscriberMapping
+            : null;
+
+    /// <inheritdoc/>
+    public IList<IMessagePollerConfiguration> MessagePollerConfigurations
+    {
+        get => _inner.MessagePollerConfigurations;
+        set => _inner.MessagePollerConfigurations = value;
+    }
+
+    /// <inheritdoc/>
+    public SerializationOptions SerializationOptions => _inner.SerializationOptions;
+
+    /// <inheritdoc/>
+    public IList<ISerializationCallback> SerializationCallbacks => _inner.SerializationCallbacks;
+
+    /// <inheritdoc/>
+    public string? Source
+    {
+        get => _inner.Source;
+        set => _inner.Source = value;
+    }
+
+    /// <inheritdoc/>
+    public string? SourceSuffix
+    {
+        get => _inner.SourceSuffix;
+        set => _inner.SourceSuffix = value;
+    }
+
+    /// <inheritdoc/>
+    public bool LogMessageContent
+    {
+        get => _inner.LogMessageContent;
+        set => _inner.LogMessageContent = value;
+    }
+
+    /// <inheritdoc/>
+    public BackoffPolicy BackoffPolicy
+    {
+        get => _inner.BackoffPolicy;
+        set => _inner.BackoffPolicy = value;
+    }
+
+    /// <inheritdoc/>
+    public IntervalBackoffOptions IntervalBackoffOptions => _inner.IntervalBackoffOptions;
+
+    /// <inheritdoc/>
+    public CappedExponentialBackoffOptions CappedExponentialBackoffOptions => _inner.CappedExponentialBackoffOptions;
+
+    /// <inheritdoc/>
+    public PollingControlToken PollingControlToken => _inner.PollingControlToken;
+}

--- a/src/AWS.Messaging/Configuration/SingleTypeSQSMessagePollerConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/SingleTypeSQSMessagePollerConfiguration.cs
@@ -19,7 +19,7 @@ public class SingleTypeSQSMessagePollerConfiguration : SQSMessagePollerConfigura
     }
 
     /// <summary>
-    /// Th poller will only attempt to process messages for the specified message type.
+    /// The poller will only attempt to process messages for the specified message type.
     /// This is useful for queues that are dedicated to a single message type or when enabling raw JSON ingestion
     /// without requiring type-based routing.
     /// </summary>
@@ -33,8 +33,8 @@ public class SingleTypeSQSMessagePollerConfiguration : SQSMessagePollerConfigura
 
     /// <summary>
     /// Controls how inbound messages are interpreted when this poller is configured for a single message type.
-    /// When true (default), inbound messages are expected to be in the CloudEvents envelope format.
-    /// When false, inbound messages are expected to be a raw payload of the single message type.
+    /// When 'Supported' (default), inbound messages are expected to be in the CloudEvents envelope format.
+    /// When 'NotSupported', inbound messages are expected to be a raw payload of the single message type.
     /// </summary>
-    internal bool UsesMessageEnvelope { get; init; } = true;
+    internal MessageEnvelopeMode MessageEnvelopeMode { get; init; } = MessageEnvelopeMode.Supported;
 }

--- a/src/AWS.Messaging/Configuration/SingleTypeSQSMessagePollerConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/SingleTypeSQSMessagePollerConfiguration.cs
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Configuration;
+
+/// <summary>
+/// Internal configuration for polling a single type of messages from SQS
+/// </summary>
+public class SingleTypeSQSMessagePollerConfiguration : SQSMessagePollerConfiguration
+{
+    /// <summary>
+    /// Construct an instance of <see cref="SingleTypeSQSMessagePollerConfiguration" />
+    /// </summary>
+    /// <param name="queueUrl">The SQS QueueUrl to poll messages from.</param>
+    /// <param name="singleMessageType">The single message type to poll for.</param>
+    public SingleTypeSQSMessagePollerConfiguration(string queueUrl, Type singleMessageType) : base(queueUrl)
+    {
+        SingleMessageType = singleMessageType;
+    }
+
+    /// <summary>
+    /// Th poller will only attempt to process messages for the specified message type.
+    /// This is useful for queues that are dedicated to a single message type or when enabling raw JSON ingestion
+    /// without requiring type-based routing.
+    /// </summary>
+    public Type SingleMessageType { get; init; }
+
+    /// <summary>
+    /// Message type identifier to use for the single message type poller.
+    /// If not set, the framework will use the configured subscriber mapping for <see cref="SingleMessageType"/>.
+    /// </summary>
+    internal string? SingleMessageTypeIdentifier { get; init; }
+
+    /// <summary>
+    /// Controls how inbound messages are interpreted when this poller is configured for a single message type.
+    /// When true (default), inbound messages are expected to be in the CloudEvents envelope format.
+    /// When false, inbound messages are expected to be a raw payload of the single message type.
+    /// </summary>
+    internal bool UsesMessageEnvelope { get; init; } = true;
+}

--- a/src/AWS.Messaging/Constants.cs
+++ b/src/AWS.Messaging/Constants.cs
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging;
+
+/// <summary>
+/// Constants related to AWS.Messaging
+/// </summary>
+internal class Constants
+{
+    /// <summary>
+    /// CloudEvent spec version used in message envelopes
+    /// </summary>
+    public const string CLOUD_EVENT_SPEC_VERSION = "1.0";
+}

--- a/src/AWS.Messaging/SQS/SQSMessagePoller.cs
+++ b/src/AWS.Messaging/SQS/SQSMessagePoller.cs
@@ -71,6 +71,8 @@ internal class SQSMessagePoller : IMessagePoller, ISQSMessageCommunication
         _messageManager = messageManagerFactory.CreateMessageManager(this, _configuration.ToMessageManagerConfiguration());
     }
 
+    internal IEnvelopeSerializer EnvelopeSerializer => _envelopeSerializer;
+
     /// <inheritdoc/>
     public async Task StartPollingAsync(CancellationToken token = default)
     {

--- a/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
+++ b/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
@@ -20,7 +20,6 @@ namespace AWS.Messaging.Serialization;
 internal class EnvelopeSerializer : IEnvelopeSerializer
 {
     private Uri? MessageSource { get; set; }
-    private const string CLOUD_EVENT_SPEC_VERSION = "1.0";
 
     private readonly IMessageConfiguration _messageConfiguration;
     private readonly IMessageSerializer _messageSerializer;
@@ -76,7 +75,7 @@ internal class EnvelopeSerializer : IEnvelopeSerializer
         {
             Id = messageId,
             Source = MessageSource,
-            Version = CLOUD_EVENT_SPEC_VERSION,
+            Version = Constants.CLOUD_EVENT_SPEC_VERSION,
             MessageTypeIdentifier = publisherMapping.MessageTypeIdentifier,
             TimeStamp = timeStamp,
             Message = message

--- a/src/AWS.Messaging/Serialization/SingleTypeSqsPollerEnvelopeSerializer.cs
+++ b/src/AWS.Messaging/Serialization/SingleTypeSqsPollerEnvelopeSerializer.cs
@@ -17,14 +17,12 @@ namespace AWS.Messaging.Serialization;
 /// </summary>
 internal sealed class SingleTypeSqsPollerEnvelopeSerializer : IEnvelopeSerializer
 {
-    private const string CLOUD_EVENT_SPEC_VERSION = "1.0";
-
     private readonly ILogger<SingleTypeSqsPollerEnvelopeSerializer> _logger;
     private readonly IEnvelopeSerializer _envelopedMessageSerializer;
     private readonly IMessageSerializer _messageSerializer;
     private readonly IDateTimeHandler _dateTimeHandler;
     private readonly SubscriberMapping _subscriberMapping;
-    private readonly bool _usesMessageEnvelope;
+    private readonly MessageEnvelopeMode _messageEnvelopeMode;
 
     public SingleTypeSqsPollerEnvelopeSerializer(
         ILogger<SingleTypeSqsPollerEnvelopeSerializer> logger,
@@ -32,14 +30,14 @@ internal sealed class SingleTypeSqsPollerEnvelopeSerializer : IEnvelopeSerialize
         IMessageSerializer messageSerializer,
         IDateTimeHandler dateTimeHandler,
         SubscriberMapping subscriberMapping,
-        bool usesMessageEnvelope)
+        MessageEnvelopeMode messageEnvelopeMode)
     {
         _logger = logger;
         _envelopedMessageSerializer = envelopedMessageSerializer;
         _messageSerializer = messageSerializer;
         _dateTimeHandler = dateTimeHandler;
         _subscriberMapping = subscriberMapping;
-        _usesMessageEnvelope = usesMessageEnvelope;
+        _messageEnvelopeMode = messageEnvelopeMode;
     }
 
     /// <inheritdoc/>
@@ -53,7 +51,7 @@ internal sealed class SingleTypeSqsPollerEnvelopeSerializer : IEnvelopeSerialize
     /// <inheritdoc/>
     public async ValueTask<ConvertToEnvelopeResult> ConvertToEnvelopeAsync(Message message)
     {
-        if (_usesMessageEnvelope)
+        if (_messageEnvelopeMode == MessageEnvelopeMode.Supported)
         {
             var result = await _envelopedMessageSerializer.ConvertToEnvelopeAsync(message);
 
@@ -76,7 +74,7 @@ internal sealed class SingleTypeSqsPollerEnvelopeSerializer : IEnvelopeSerialize
         // Populate minimum envelope fields. These aren't present in raw messages.
         envelope.Id = message.MessageId ?? Guid.NewGuid().ToString("D");
         envelope.Source = new Uri("/aws/messaging/raw", UriKind.Relative);
-        envelope.Version = CLOUD_EVENT_SPEC_VERSION;
+        envelope.Version = Constants.CLOUD_EVENT_SPEC_VERSION;
         envelope.MessageTypeIdentifier = _subscriberMapping.MessageTypeIdentifier;
         envelope.TimeStamp = _dateTimeHandler.GetUtcNow();
         envelope.DataContentType = "application/json";

--- a/src/AWS.Messaging/Serialization/SingleTypeSqsPollerEnvelopeSerializer.cs
+++ b/src/AWS.Messaging/Serialization/SingleTypeSqsPollerEnvelopeSerializer.cs
@@ -1,0 +1,100 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.SQS.Model;
+using AWS.Messaging.Configuration;
+using AWS.Messaging.Serialization.Handlers;
+using AWS.Messaging.Services;
+using Microsoft.Extensions.Logging;
+
+namespace AWS.Messaging.Serialization;
+
+/// <summary>
+/// Envelope serializer used only for SQS pollers that are configured for a single message type.
+/// It supports two modes:
+/// - usesMessageEnvelope=true: inbound messages must be CloudEvents envelopes.
+/// - usesMessageEnvelope=false: inbound messages must be raw payloads of the configured message type.
+/// </summary>
+internal sealed class SingleTypeSqsPollerEnvelopeSerializer : IEnvelopeSerializer
+{
+    private const string CLOUD_EVENT_SPEC_VERSION = "1.0";
+
+    private readonly ILogger<SingleTypeSqsPollerEnvelopeSerializer> _logger;
+    private readonly IEnvelopeSerializer _envelopedMessageSerializer;
+    private readonly IMessageSerializer _messageSerializer;
+    private readonly IDateTimeHandler _dateTimeHandler;
+    private readonly SubscriberMapping _subscriberMapping;
+    private readonly bool _usesMessageEnvelope;
+
+    public SingleTypeSqsPollerEnvelopeSerializer(
+        ILogger<SingleTypeSqsPollerEnvelopeSerializer> logger,
+        IEnvelopeSerializer envelopedMessageSerializer,
+        IMessageSerializer messageSerializer,
+        IDateTimeHandler dateTimeHandler,
+        SubscriberMapping subscriberMapping,
+        bool usesMessageEnvelope)
+    {
+        _logger = logger;
+        _envelopedMessageSerializer = envelopedMessageSerializer;
+        _messageSerializer = messageSerializer;
+        _dateTimeHandler = dateTimeHandler;
+        _subscriberMapping = subscriberMapping;
+        _usesMessageEnvelope = usesMessageEnvelope;
+    }
+
+    /// <inheritdoc/>
+    public ValueTask<string> SerializeAsync<T>(MessageEnvelope<T> envelope)
+        => _envelopedMessageSerializer.SerializeAsync(envelope);
+
+    /// <inheritdoc/>
+    public ValueTask<MessageEnvelope<T>> CreateEnvelopeAsync<T>(T message)
+        => _envelopedMessageSerializer.CreateEnvelopeAsync(message);
+
+    /// <inheritdoc/>
+    public async ValueTask<ConvertToEnvelopeResult> ConvertToEnvelopeAsync(Message message)
+    {
+        if (_usesMessageEnvelope)
+        {
+            var result = await _envelopedMessageSerializer.ConvertToEnvelopeAsync(message);
+
+            // Extra safety: if for any reason a different mapping was resolved, reject it.
+            if (result.Mapping.MessageType != _subscriberMapping.MessageType
+                || !string.Equals(result.Mapping.MessageTypeIdentifier, _subscriberMapping.MessageTypeIdentifier, StringComparison.Ordinal))
+            {
+                throw new InvalidDataException(
+                    $"Received message resolved to subscriber mapping '{result.Mapping.MessageTypeIdentifier}', " +
+                    $"but this poller is configured for '{_subscriberMapping.MessageTypeIdentifier}'.");
+            }
+
+            return result;
+        }
+
+        var payload = message.Body ?? string.Empty;
+
+        var envelope = _subscriberMapping.MessageEnvelopeFactory.Invoke();
+
+        // Populate minimum envelope fields. These aren't present in raw messages.
+        envelope.Id = message.MessageId ?? Guid.NewGuid().ToString("D");
+        envelope.Source = new Uri("/aws/messaging/raw", UriKind.Relative);
+        envelope.Version = CLOUD_EVENT_SPEC_VERSION;
+        envelope.MessageTypeIdentifier = _subscriberMapping.MessageTypeIdentifier;
+        envelope.TimeStamp = _dateTimeHandler.GetUtcNow();
+        envelope.DataContentType = "application/json";
+
+        try
+        {
+            var deserialized = _messageSerializer.Deserialize(payload, _subscriberMapping.MessageType);
+            envelope.SetMessage(deserialized);
+        }
+        catch (Exception deserializeEx)
+        {
+            _logger.LogError(deserializeEx, "Failed to deserialize raw payload for message type '{MessageType}'.", _subscriberMapping.MessageType);
+            throw new FailedToCreateMessageEnvelopeException($"Failed to deserialize raw payload into '{_subscriberMapping.MessageType.FullName}'", deserializeEx);
+        }
+
+        // Attach basic SQS metadata.
+        envelope.SQSMetadata = MessageMetadataHandler.CreateSQSMetadata(message);
+
+        return new ConvertToEnvelopeResult(envelope, _subscriberMapping);
+    }
+}

--- a/src/AWS.Messaging/Services/IMessagePollerFactory.cs
+++ b/src/AWS.Messaging/Services/IMessagePollerFactory.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using AWS.Messaging.Configuration;
+using AWS.Messaging.Serialization;
 using AWS.Messaging.SQS;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -40,7 +41,47 @@ internal class DefaultMessagePollerFactory : IMessagePollerFactory
     public IMessagePoller CreateMessagePoller(IMessagePollerConfiguration pollerConfiguration)
     {
         IMessagePoller poller;
-        if(pollerConfiguration is SQSMessagePollerConfiguration sqsPollerConfiguration)
+        if (pollerConfiguration is SingleTypeSQSMessagePollerConfiguration singleTypeSQSPollerConfiguration)
+        {
+            // If the poller is tied to a single message type, create a poller-scoped
+            // EnvelopeSerializer that only resolves that single subscriber mapping.
+            var messageConfiguration = _serviceProvider.GetRequiredService<IMessageConfiguration>();
+
+            SubscriberMapping? mapping;
+
+            if (!string.IsNullOrEmpty(singleTypeSQSPollerConfiguration.SingleMessageTypeIdentifier))
+            {
+                mapping = messageConfiguration.GetSubscriberMapping(singleTypeSQSPollerConfiguration.SingleMessageTypeIdentifier);
+            }
+            else
+            {
+                mapping = messageConfiguration.GetSubscriberMapping(singleTypeSQSPollerConfiguration.SingleMessageType);
+            }
+
+            if (mapping is null)
+            {
+                throw new ConfigurationException(
+                    $"A subscriber mapping for message type '{singleTypeSQSPollerConfiguration.SingleMessageType.FullName}' " +
+                    $"(identifier '{singleTypeSQSPollerConfiguration.SingleMessageTypeIdentifier ?? "<default>"}') was not found.");
+            }
+
+            var scopedConfiguration = new SingleTypeMessageConfiguration(messageConfiguration, mapping);
+
+            var scopedEnvelopeSerializer = ActivatorUtilities.CreateInstance<EnvelopeSerializer>(_serviceProvider, scopedConfiguration);
+
+            IEnvelopeSerializer serializerToUse = scopedEnvelopeSerializer;
+            if (!singleTypeSQSPollerConfiguration.UsesMessageEnvelope)
+            {
+                serializerToUse = ActivatorUtilities.CreateInstance<SingleTypeSqsPollerEnvelopeSerializer>(
+                    _serviceProvider,
+                    scopedEnvelopeSerializer,
+                    mapping,
+                    singleTypeSQSPollerConfiguration.UsesMessageEnvelope);
+            }
+
+            poller = ActivatorUtilities.CreateInstance<SQSMessagePoller>(_serviceProvider, singleTypeSQSPollerConfiguration, serializerToUse);
+        }
+        else if(pollerConfiguration is SQSMessagePollerConfiguration sqsPollerConfiguration)
         {
             poller = ActivatorUtilities.CreateInstance<SQSMessagePoller>(_serviceProvider, sqsPollerConfiguration);
         }

--- a/src/AWS.Messaging/Services/IMessagePollerFactory.cs
+++ b/src/AWS.Messaging/Services/IMessagePollerFactory.cs
@@ -47,16 +47,9 @@ internal class DefaultMessagePollerFactory : IMessagePollerFactory
             // EnvelopeSerializer that only resolves that single subscriber mapping.
             var messageConfiguration = _serviceProvider.GetRequiredService<IMessageConfiguration>();
 
-            SubscriberMapping? mapping;
-
-            if (!string.IsNullOrEmpty(singleTypeSQSPollerConfiguration.SingleMessageTypeIdentifier))
-            {
-                mapping = messageConfiguration.GetSubscriberMapping(singleTypeSQSPollerConfiguration.SingleMessageTypeIdentifier);
-            }
-            else
-            {
-                mapping = messageConfiguration.GetSubscriberMapping(singleTypeSQSPollerConfiguration.SingleMessageType);
-            }
+            SubscriberMapping? mapping = !string.IsNullOrEmpty(singleTypeSQSPollerConfiguration.SingleMessageTypeIdentifier)
+                ? messageConfiguration.GetSubscriberMapping(singleTypeSQSPollerConfiguration.SingleMessageTypeIdentifier)
+                : messageConfiguration.GetSubscriberMapping(singleTypeSQSPollerConfiguration.SingleMessageType);
 
             if (mapping is null)
             {
@@ -65,18 +58,27 @@ internal class DefaultMessagePollerFactory : IMessagePollerFactory
                     $"(identifier '{singleTypeSQSPollerConfiguration.SingleMessageTypeIdentifier ?? "<default>"}') was not found.");
             }
 
+            if (!string.IsNullOrEmpty(singleTypeSQSPollerConfiguration.SingleMessageTypeIdentifier) &&
+                mapping.MessageType != singleTypeSQSPollerConfiguration.SingleMessageType)
+            {
+                throw new ConfigurationException(
+                    $"The subscriber mapping identifier '{singleTypeSQSPollerConfiguration.SingleMessageTypeIdentifier}' resolves to message type " +
+                    $"'{mapping.MessageType.FullName}', but the poller is configured for single message type " +
+                    $"'{singleTypeSQSPollerConfiguration.SingleMessageType.FullName}'.");
+            }
+
             var scopedConfiguration = new SingleTypeMessageConfiguration(messageConfiguration, mapping);
 
             var scopedEnvelopeSerializer = ActivatorUtilities.CreateInstance<EnvelopeSerializer>(_serviceProvider, scopedConfiguration);
 
             IEnvelopeSerializer serializerToUse = scopedEnvelopeSerializer;
-            if (!singleTypeSQSPollerConfiguration.UsesMessageEnvelope)
+            if (singleTypeSQSPollerConfiguration.MessageEnvelopeMode == MessageEnvelopeMode.NotSupported)
             {
                 serializerToUse = ActivatorUtilities.CreateInstance<SingleTypeSqsPollerEnvelopeSerializer>(
                     _serviceProvider,
                     scopedEnvelopeSerializer,
                     mapping,
-                    singleTypeSQSPollerConfiguration.UsesMessageEnvelope);
+                    singleTypeSQSPollerConfiguration.MessageEnvelopeMode);
             }
 
             poller = ActivatorUtilities.CreateInstance<SQSMessagePoller>(_serviceProvider, singleTypeSQSPollerConfiguration, serializerToUse);

--- a/test/AWS.Messaging.UnitTests/OpenTelemetryTests.cs
+++ b/test/AWS.Messaging.UnitTests/OpenTelemetryTests.cs
@@ -100,7 +100,7 @@ public class OpenTelemetryTests
 
 
         using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(Constants.SourceName)
+            .AddSource(AWS.Messaging.Telemetry.OpenTelemetry.Constants.SourceName)
             .ConfigureResource(resource => resource.AddService("unittest"))
             .AddInMemoryExporter(activities).Build())
         {
@@ -136,7 +136,7 @@ public class OpenTelemetryTests
         Activity.Current = existingActivity;
 
         using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(Constants.SourceName)
+            .AddSource(AWS.Messaging.Telemetry.OpenTelemetry.Constants.SourceName)
             .ConfigureResource(resource => resource.AddService("unittest"))
             .AddInMemoryExporter(activities).Build())
         {
@@ -167,7 +167,7 @@ public class OpenTelemetryTests
         };
 
         using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(Constants.SourceName)
+            .AddSource(AWS.Messaging.Telemetry.OpenTelemetry.Constants.SourceName)
             .ConfigureResource(resource => resource.AddService("unittest"))
             .AddInMemoryExporter(activities).Build())
         {
@@ -208,7 +208,7 @@ public class OpenTelemetryTests
         };
 
         using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(Constants.SourceName)
+            .AddSource(AWS.Messaging.Telemetry.OpenTelemetry.Constants.SourceName)
             .ConfigureResource(resource => resource.AddService("unittest"))
             .AddInMemoryExporter(activities).Build())
         {

--- a/test/AWS.Messaging.UnitTests/SQSMessagePollerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SQSMessagePollerTests.cs
@@ -12,6 +12,7 @@ using AWS.Messaging.Configuration;
 using AWS.Messaging.Services;
 using AWS.Messaging.UnitTests.MessageHandlers;
 using AWS.Messaging.UnitTests.Models;
+using AWS.Messaging.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Moq;
@@ -19,6 +20,7 @@ using Xunit;
 using AWS.Messaging.Tests.Common.Services;
 using AWS.Messaging.SQS;
 using Microsoft.Extensions.Logging;
+using System.Reflection;
 
 namespace AWS.Messaging.UnitTests;
 
@@ -319,6 +321,93 @@ public class SQSMessagePollerTests
 
         client.Verify(x => x.ReceiveMessageAsync(It.IsAny<ReceiveMessageRequest>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce());
     }
+
+    [Fact]
+    public async Task SQSMessagePollerFactory_SingleMessageType_UsesRawOnly_WhenUsesMessageEnvelopeFalse()
+    {
+        // Raw JSON payload without CloudEvents envelope and without a 'type' discriminator.
+        const string rawJson = "{\"MessageDescription\":\"hello\"}";
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging();
+
+        // Add a second mapping to make raw ingestion ambiguous without the single-type poller.
+        serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPoller<ChatMessage>(TEST_QUEUE_URL, usesMessageEnvelope: false);
+            builder.AddMessageHandler<ChatMessageHandler, ChatMessage>();
+            builder.AddMessageHandler<AddressInfoHandler, AddressInfo>();
+        });
+
+        serviceCollection.AddSingleton(new Mock<IAmazonSQS>().Object);
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var messageConfiguration = serviceProvider.GetRequiredService<IMessageConfiguration>();
+        var pollerConfiguration = messageConfiguration.MessagePollerConfigurations.OfType<SQSMessagePollerConfiguration>().Single();
+
+        var messagePollerFactory = serviceProvider.GetRequiredService<IMessagePollerFactory>();
+        var poller = messagePollerFactory.CreateMessagePoller(pollerConfiguration);
+
+        var envelopeSerializerField = poller.GetType().GetField("_envelopeSerializer", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(envelopeSerializerField);
+
+        var envelopeSerializer = envelopeSerializerField.GetValue(poller) as IEnvelopeSerializer;
+        Assert.NotNull(envelopeSerializer);
+
+        var result = await envelopeSerializer.ConvertToEnvelopeAsync(new Message
+        {
+            MessageId = "m-1",
+            ReceiptHandle = "rh-1",
+            Body = rawJson
+        });
+
+        Assert.Equal(typeof(ChatMessage), result.Mapping.MessageType);
+        var envelope = Assert.IsType<MessageEnvelope<ChatMessage>>(result.Envelope);
+        Assert.Equal("hello", envelope.Message.MessageDescription);
+    }
+
+    [Fact]
+    public async Task SQSMessagePollerFactory_SingleMessageType_RequiresEnvelope_ByDefault()
+    {
+        // Raw JSON payload without CloudEvents envelope.
+        const string rawJson = "{\"MessageDescription\":\"hello\"}";
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging();
+
+        // Raw payload ingestion is disabled by default. We do not override it here.
+        serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPoller<ChatMessage>(TEST_QUEUE_URL);
+            builder.AddMessageHandler<ChatMessageHandler, ChatMessage>();
+        });
+
+        serviceCollection.AddSingleton(new Mock<IAmazonSQS>().Object);
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var messageConfiguration = serviceProvider.GetRequiredService<IMessageConfiguration>();
+        var pollerConfiguration = messageConfiguration.MessagePollerConfigurations.OfType<SQSMessagePollerConfiguration>().Single();
+
+        var messagePollerFactory = serviceProvider.GetRequiredService<IMessagePollerFactory>();
+        var poller = messagePollerFactory.CreateMessagePoller(pollerConfiguration);
+
+        var envelopeSerializerField = poller.GetType().GetField("_envelopeSerializer", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(envelopeSerializerField);
+
+        var envelopeSerializer = envelopeSerializerField.GetValue(poller) as IEnvelopeSerializer;
+        Assert.NotNull(envelopeSerializer);
+
+        await Assert.ThrowsAsync<FailedToCreateMessageEnvelopeException>(async () =>
+        {
+            await envelopeSerializer.ConvertToEnvelopeAsync(new Message
+            {
+                MessageId = "m-1",
+                ReceiptHandle = "rh-1",
+                Body = rawJson
+            });
+        });
+    }
+
 
     /// <summary>
     /// Helper function that initializes and starts a <see cref="MessagePumpService"/> with

--- a/test/AWS.Messaging.UnitTests/SQSMessagePollerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SQSMessagePollerTests.cs
@@ -100,10 +100,10 @@ public class SQSMessagePollerTests
 
         // Start polling and wait for a message to be received
         pollingControlToken.StartPolling();
-        
+
         // Wait for a message to be received with a timeout
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        try 
+        try
         {
             await messageReceived.Task.WaitAsync(cts.Token);
         }
@@ -334,7 +334,7 @@ public class SQSMessagePollerTests
         // Add a second mapping to make raw ingestion ambiguous without the single-type poller.
         serviceCollection.AddAWSMessageBus(builder =>
         {
-            builder.AddSQSPoller<ChatMessage>(TEST_QUEUE_URL, usesMessageEnvelope: false);
+            builder.AddSQSPoller<ChatMessage>(TEST_QUEUE_URL, messageEnvelopeMode: MessageEnvelopeMode.NotSupported);
             builder.AddMessageHandler<ChatMessageHandler, ChatMessage>();
             builder.AddMessageHandler<AddressInfoHandler, AddressInfo>();
         });
@@ -348,11 +348,8 @@ public class SQSMessagePollerTests
         var messagePollerFactory = serviceProvider.GetRequiredService<IMessagePollerFactory>();
         var poller = messagePollerFactory.CreateMessagePoller(pollerConfiguration);
 
-        var envelopeSerializerField = poller.GetType().GetField("_envelopeSerializer", BindingFlags.Instance | BindingFlags.NonPublic);
-        Assert.NotNull(envelopeSerializerField);
-
-        var envelopeSerializer = envelopeSerializerField.GetValue(poller) as IEnvelopeSerializer;
-        Assert.NotNull(envelopeSerializer);
+        var sqsPoller = Assert.IsType<SQSMessagePoller>(poller);
+        var envelopeSerializer = sqsPoller.EnvelopeSerializer;
 
         var result = await envelopeSerializer.ConvertToEnvelopeAsync(new Message
         {
@@ -364,6 +361,32 @@ public class SQSMessagePollerTests
         Assert.Equal(typeof(ChatMessage), result.Mapping.MessageType);
         var envelope = Assert.IsType<MessageEnvelope<ChatMessage>>(result.Envelope);
         Assert.Equal("hello", envelope.Message.MessageDescription);
+    }
+
+    [Fact]
+    public void SQSMessagePollerFactory_SingleMessageType_Throws_WhenIdentifierResolvesToDifferentMessageType()
+    {
+        const string addressInfoIdentifier = "address-info";
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging();
+
+        serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPoller<ChatMessage>(TEST_QUEUE_URL, messageTypeIdentifier: addressInfoIdentifier, messageEnvelopeMode: MessageEnvelopeMode.NotSupported);
+            builder.AddMessageHandler<ChatMessageHandler, ChatMessage>();
+            builder.AddMessageHandler<AddressInfoHandler, AddressInfo>(messageTypeIdentifier: addressInfoIdentifier);
+        });
+
+        serviceCollection.AddSingleton(new Mock<IAmazonSQS>().Object);
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var messageConfiguration = serviceProvider.GetRequiredService<IMessageConfiguration>();
+        var pollerConfiguration = messageConfiguration.MessagePollerConfigurations.OfType<SQSMessagePollerConfiguration>().Single();
+
+        var messagePollerFactory = serviceProvider.GetRequiredService<IMessagePollerFactory>();
+
+        Assert.Throws<ConfigurationException>(() => messagePollerFactory.CreateMessagePoller(pollerConfiguration));
     }
 
     [Fact]
@@ -391,11 +414,8 @@ public class SQSMessagePollerTests
         var messagePollerFactory = serviceProvider.GetRequiredService<IMessagePollerFactory>();
         var poller = messagePollerFactory.CreateMessagePoller(pollerConfiguration);
 
-        var envelopeSerializerField = poller.GetType().GetField("_envelopeSerializer", BindingFlags.Instance | BindingFlags.NonPublic);
-        Assert.NotNull(envelopeSerializerField);
-
-        var envelopeSerializer = envelopeSerializerField.GetValue(poller) as IEnvelopeSerializer;
-        Assert.NotNull(envelopeSerializer);
+        var sqsPoller = Assert.IsType<SQSMessagePoller>(poller);
+        var envelopeSerializer = sqsPoller.EnvelopeSerializer;
 
         await Assert.ThrowsAsync<FailedToCreateMessageEnvelopeException>(async () =>
         {


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7590

*Description of changes:*
Added the ability for users to add a SQS Poller that only processes messages of a single type. 
Users will also be able to specify whether the message type will use a message envelope or not. This will fix the issue https://github.com/aws/aws-dotnet-messaging/issues/141. By default, messages will have an envelope unless specified otherwise.

```
builder.AddSQSPoller<ChatMessage>(
        "https://sqs.us-west-2.amazonaws.com/012345678910/MPF", 
        usesMessageEnvelope: false);
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
