### PR TITLE
chore: add user agent feature for single-type poller

### DIFF
--- a/.autover/changes/bf1911b9-54a7-4fbd-a509-af56e8eead4a.json
+++ b/.autover/changes/bf1911b9-54a7-4fbd-a509-af56e8eead4a.json
@@ -1,0 +1,12 @@
+{
+    "Projects": [
+        {
+            "Name": "AWS.Messaging",
+            "Type": "Patch",
+            "ChangelogMessages": [
+                "Added a user agent feature for the single-type SQS poller to help with telemetry and understanding adoption of this feature."
+            ]
+        }
+    ]
+}
+

--- a/src/AWS.Messaging/Configuration/AWSClientProvider.cs
+++ b/src/AWS.Messaging/Configuration/AWSClientProvider.cs
@@ -12,6 +12,7 @@ namespace AWS.Messaging.Configuration;
 internal class AWSClientProvider : IAWSClientProvider
 {
     private static readonly string _userAgentString = $"lib/aws-dotnet-messaging#{TelemetryKeys.AWSMessagingAssemblyVersion}";
+    private static readonly HashSet<string> _userAgentFeatures = new ();
 
     private readonly IServiceProvider _serviceProvider;
 
@@ -40,6 +41,19 @@ internal class AWSClientProvider : IAWSClientProvider
         if (args != null && args.Request is Amazon.Runtime.Internal.IAmazonWebServiceRequest internalRequest && !internalRequest.UserAgentDetails.GetCustomUserAgentComponents().Contains(_userAgentString))
         {
             internalRequest.UserAgentDetails.AddUserAgentComponent(_userAgentString);
+            foreach (var feature in _userAgentFeatures)
+            {
+                internalRequest.UserAgentDetails.AddUserAgentComponent($" ft/{feature}");
+            }
         }
+    }
+
+    /// <summary>
+    /// Adds a feature to the user agent string for all AWS service clients created by this provider. This is used for telemetry purposes to identify which features of the library are being used.
+    /// </summary>
+    /// <param name="feature">The feature to add to the user agent string.</param>
+    internal static void AddUserAgentFeature(string feature)
+    {
+        _userAgentFeatures.Add(feature);
     }
 }

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -163,6 +163,10 @@ public class MessageBusBuilder : IMessageBusBuilder
         };
 
         _messageConfiguration.MessagePollerConfigurations.Add(sqsMessagePollerConfiguration);
+
+        // Adding a user agent feature for the single-type SQS poller to help with telemetry and understanding adoption of this feature.
+        AWSClientProvider.AddUserAgentFeature("SINGLE_TYPE_SQS_POLLER");
+
         return this;
     }
 


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-8520

*Description of changes:*
Added a user agent feature for the single-type SQS poller to help with telemetry and understanding adoption of this feature.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
