### PR TITLE
Update AWS SDK Dependencies

### DIFF
--- a/.autover/changes/1aea9c77-b388-412d-8398-42ac0eede68d.json
+++ b/.autover/changes/1aea9c77-b388-412d-8398-42ac0eede68d.json
@@ -1,0 +1,18 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update AWS SDK Dependencies"
+      ]
+    },
+    {
+      "Name": "AWS.Messaging.Lambda",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update AWS SDK Dependencies"
+      ]
+    }	
+  ]
+}

--- a/sampleapps/AppHost/AppHost.csproj
+++ b/sampleapps/AppHost/AppHost.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.AppHost" Version="9.1.0" />
-    <PackageReference Include="Aspire.Hosting.AWS" Version="9.1.5" />
+    <PackageReference Include="Aspire.Hosting.AWS" Version="9.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sampleapps/LambdaMessaging/LambdaMessaging.csproj
+++ b/sampleapps/LambdaMessaging/LambdaMessaging.csproj
@@ -10,9 +10,9 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Annotations" Version="1.7.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
-    <PackageReference Include="Amazon.Lambda.Logging.AspNetCore" Version="3.1.0" />
+    <PackageReference Include="Amazon.Lambda.Annotations" Version="1.9.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.5" />
+    <PackageReference Include="Amazon.Lambda.Logging.AspNetCore" Version="4.1.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/sampleapps/LambdaMessaging/serverless.template
+++ b/sampleapps/LambdaMessaging/serverless.template
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
-  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v1.7.0.0).",
+  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v1.9.0.0).",
   "Resources": {
     "ChatQueue": {
       "Type": "AWS::SQS::Queue",

--- a/src/AWS.Messaging.Lambda/AWS.Messaging.Lambda.csproj
+++ b/src/AWS.Messaging.Lambda/AWS.Messaging.Lambda.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -25,8 +25,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.8.0" />
-    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.8.1" />
+    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/AWS.Messaging/AWS.Messaging.csproj
+++ b/src/AWS.Messaging/AWS.Messaging.csproj
@@ -27,10 +27,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.EventBridge" Version="4.0.5.4" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.11" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.2.4" />
-    <PackageReference Include="AWSSDK.SQS" Version="4.0.2.2" />
+    <PackageReference Include="AWSSDK.EventBridge" Version="4.0.5.16" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.23" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.2.17" />
+    <PackageReference Include="AWSSDK.SQS" Version="4.0.2.15" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.*" />

--- a/test/AWS.Messaging.IntegrationTests/AWS.Messaging.IntegrationTests.csproj
+++ b/test/AWS.Messaging.IntegrationTests/AWS.Messaging.IntegrationTests.csproj
@@ -9,16 +9,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="4.0.9.2" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.6" />
-    <PackageReference Include="AWSSDK.Lambda" Version="4.0.6.2" />
-    <PackageReference Include="AWSSDK.S3" Version="4.0.11.1" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.4" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="4.0.14.6" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.9.8" />
+    <PackageReference Include="AWSSDK.Lambda" Version="4.0.13.2" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.18.7" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.10" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.11" />
-    <PackageReference Include="AWSSDK.SQS" Version="4.0.2.2" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.23" />
+    <PackageReference Include="AWSSDK.SQS" Version="4.0.2.15" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/AWS.Messaging.Tests.Common/AWS.Messaging.Tests.Common.csproj
+++ b/test/AWS.Messaging.Tests.Common/AWS.Messaging.Tests.Common.csproj
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="4.0.9.2" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.6" />
-    <PackageReference Include="AWSSDK.Lambda" Version="4.0.6.2" />
-    <PackageReference Include="AWSSDK.S3" Version="4.0.11.1" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.4" />
-    <PackageReference Include="AWSSDK.SQS" Version="4.0.2.2" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="4.0.14.6" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.9.8" />
+    <PackageReference Include="AWSSDK.Lambda" Version="4.0.13.2" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.18.7" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.10" />
+    <PackageReference Include="AWSSDK.SQS" Version="4.0.2.15" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.*" />

--- a/test/AWS.Messaging.Tests.LambdaFunctions/AWS.Messaging.Tests.LambdaFunctions.csproj
+++ b/test/AWS.Messaging.Tests.LambdaFunctions/AWS.Messaging.Tests.LambdaFunctions.csproj
@@ -11,9 +11,9 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.8.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
-    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.8.1" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.5" />
+    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.*" />

--- a/test/AWS.Messaging.UnitTests/AWS.Messaging.UnitTests.csproj
+++ b/test/AWS.Messaging.UnitTests/AWS.Messaging.UnitTests.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="3.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.*" />


### PR DESCRIPTION
*Description of changes:*
Updated the AWS SDK for .NET dependencies references. This is driven making sure the default version of the SDK is above 4.0.3 which has a reported vulnerability. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
