### PR TITLE
Adds SQS `SendMessageBatch` support to `ISQSPublisher`,

### DIFF
--- a/.autover/changes/e375f502-9033-457a-ba40-4e46f525d969.json
+++ b/.autover/changes/e375f502-9033-457a-ba40-4e46f525d969.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Added SendBatchAsync API"
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -212,8 +212,10 @@ var response = await sqsPublisher.SendBatchAsync(entries);
 
 ### Handling the batch response
 `SendBatchAsync` returns a `SQSSendBatchResponse` that contains:
-* `Successful` — a list of `SQSSendBatchResponseEntry` with the `Id` (correlation ID) and `MessageId` (SQS-assigned ID) for each successfully sent message.
+* `Successful` — a list of `SQSSendBatchResponseEntry` with the `Id` and `MessageId` (SQS-assigned ID) for each successfully sent message.
 * `Failed` — a list of `SQSSendBatchResponseFailedEntry` with `Id`, `Code`, `Message`, and `SenderFault` for each message that failed.
+
+The `Id` on each response entry corresponds to the `MessageEnvelope.Id` that the framework generated for that message, so you can correlate successes and failures back to your original inputs.
 
 ```csharp
 var response = await sqsPublisher.SendBatchAsync(messages);
@@ -230,6 +232,23 @@ foreach (var failure in response.Failed)
 ```
 
 > **Note:** Messages are automatically chunked into groups of 10. If you send 25 messages, the framework will make 3 SQS `SendMessageBatch` API calls (10 + 10 + 5) and aggregate the results into a single `SQSSendBatchResponse`.
+
+### Error handling and partial results
+If an `AmazonSQSException` is thrown during a batch send (e.g., on the second chunk after the first chunk already succeeded), the framework throws a `FailedToPublishBatchException`. This exception includes a `PartialResponse` property containing any results from chunks that were sent before the failure occurred, so you can determine what was already published and avoid duplicate retries.
+
+```csharp
+try
+{
+    var response = await sqsPublisher.SendBatchAsync(messages);
+}
+catch (FailedToPublishBatchException ex)
+{
+    // Some messages from earlier chunks may have been sent successfully
+    var alreadySent = ex.PartialResponse?.Successful ?? new List<SQSSendBatchResponseEntry>();
+    Console.WriteLine($"{alreadySent.Count} message(s) were sent before the failure.");
+    Console.WriteLine($"Error: {ex.InnerException?.Message}");
+}
+```
 
 # Consuming Messages
 

--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ The `ISQSPublisher` also supports sending messages in batches using the SQS [`Se
 
 The `SendBatchAsync` method accepts a collection of messages and automatically chunks them into groups of 10 (the SQS maximum per batch request).
 
-### Simple batch — shared options for all messages
-When all messages in the batch share the same options (e.g., the same `MessageGroupId` for a FIFO queue), you can pass the messages as a collection along with a single `SQSOptions`:
+### Simple batch — no per-message options
+For standard (non-FIFO) queues where no per-message options are needed, you can pass the messages as a simple collection:
 
 ```csharp
 var sqsPublisher = serviceProvider.GetRequiredService<ISQSPublisher>();
@@ -181,11 +181,8 @@ var messages = new List<ChatMessage>
     new ChatMessage { MessageDescription = "Batch!" }
 };
 
-// Send all messages in a batch with shared options
-var response = await sqsPublisher.SendBatchAsync(messages, new SQSOptions
-{
-    MessageGroupId = "my-group" // Required for FIFO queues
-});
+// Send all messages in a batch
+var response = await sqsPublisher.SendBatchAsync(messages);
 
 // Check the results
 Console.WriteLine($"Successful: {response.Successful.Count}");
@@ -193,21 +190,30 @@ Console.WriteLine($"Failed: {response.Failed.Count}");
 ```
 
 ### Per-message options using `SQSBatchEntry`
-When each message in the batch needs different options (e.g., different `MessageGroupId` values for FIFO queues), use `SQSBatchEntry<T>` to pair each message with its own `SQSOptions`:
+When each message in the batch needs its own options (e.g., different `MessageGroupId` values for FIFO queues), use `SQSBatchEntry<T>` to pair each message with its own `SQSMessageOptions`:
 
 ```csharp
 var entries = new List<SQSBatchEntry<ChatMessage>>
 {
     new SQSBatchEntry<ChatMessage>(
         new ChatMessage { MessageDescription = "User A's message" },
-        new SQSOptions { MessageGroupId = "userA" }),
+        new SQSMessageOptions { MessageGroupId = "userA" }),
     new SQSBatchEntry<ChatMessage>(
         new ChatMessage { MessageDescription = "User B's message" },
-        new SQSOptions { MessageGroupId = "userB" }),
+        new SQSMessageOptions { MessageGroupId = "userB" }),
 };
 
 // Send with per-message options
 var response = await sqsPublisher.SendBatchAsync(entries);
+```
+
+You can also override the queue URL or SQS client for the entire batch using `SQSBatchOptions`:
+
+```csharp
+var response = await sqsPublisher.SendBatchAsync(entries, new SQSBatchOptions
+{
+    QueueUrl = "https://sqs.us-west-2.amazonaws.com/012345678910/AnotherQueue"
+});
 ```
 
 ### Handling the batch response

--- a/README.md
+++ b/README.md
@@ -162,6 +162,75 @@ await _eventBridgePublisher.PublishAsync(message, new EventBridgeOptions
 });
 ```
 
+## Batch publishing to SQS
+
+The `ISQSPublisher` also supports sending messages in batches using the SQS [`SendMessageBatch`](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessageBatch.html) API. This can significantly increase throughput — from 300 messages per second with individual sends to up to 3,000 messages per second with batching.
+
+The `SendBatchAsync` method accepts a collection of messages and automatically chunks them into groups of 10 (the SQS maximum per batch request).
+
+### Simple batch — shared options for all messages
+When all messages in the batch share the same options (e.g., the same `MessageGroupId` for a FIFO queue), you can pass the messages as a collection along with a single `SQSOptions`:
+
+```csharp
+var sqsPublisher = serviceProvider.GetRequiredService<ISQSPublisher>();
+
+var messages = new List<ChatMessage>
+{
+    new ChatMessage { MessageDescription = "Hello" },
+    new ChatMessage { MessageDescription = "World" },
+    new ChatMessage { MessageDescription = "Batch!" }
+};
+
+// Send all messages in a batch with shared options
+var response = await sqsPublisher.SendBatchAsync(messages, new SQSOptions
+{
+    MessageGroupId = "my-group" // Required for FIFO queues
+});
+
+// Check the results
+Console.WriteLine($"Successful: {response.Successful.Count}");
+Console.WriteLine($"Failed: {response.Failed.Count}");
+```
+
+### Per-message options using `SQSBatchEntry`
+When each message in the batch needs different options (e.g., different `MessageGroupId` values for FIFO queues), use `SQSBatchEntry<T>` to pair each message with its own `SQSOptions`:
+
+```csharp
+var entries = new List<SQSBatchEntry<ChatMessage>>
+{
+    new SQSBatchEntry<ChatMessage>(
+        new ChatMessage { MessageDescription = "User A's message" },
+        new SQSOptions { MessageGroupId = "userA" }),
+    new SQSBatchEntry<ChatMessage>(
+        new ChatMessage { MessageDescription = "User B's message" },
+        new SQSOptions { MessageGroupId = "userB" }),
+};
+
+// Send with per-message options
+var response = await sqsPublisher.SendBatchAsync(entries);
+```
+
+### Handling the batch response
+`SendBatchAsync` returns a `SQSSendBatchResponse` that contains:
+* `Successful` — a list of `SQSSendBatchResponseEntry` with the `Id` (correlation ID) and `MessageId` (SQS-assigned ID) for each successfully sent message.
+* `Failed` — a list of `SQSSendBatchResponseFailedEntry` with `Id`, `Code`, `Message`, and `SenderFault` for each message that failed.
+
+```csharp
+var response = await sqsPublisher.SendBatchAsync(messages);
+
+foreach (var success in response.Successful)
+{
+    Console.WriteLine($"Sent message {success.Id} with SQS MessageId: {success.MessageId}");
+}
+
+foreach (var failure in response.Failed)
+{
+    Console.WriteLine($"Failed to send {failure.Id}: [{failure.Code}] {failure.Message}");
+}
+```
+
+> **Note:** Messages are automatically chunked into groups of 10. If you send 25 messages, the framework will make 3 SQS `SendMessageBatch` API calls (10 + 10 + 5) and aggregate the results into a single `SQSSendBatchResponse`.
+
 # Consuming Messages
 
 To consume messages, implement a message handler using the `IMessageHandler` interface for each message type you wish to process. The mapping between message types and message handlers is configured in the project startup.
@@ -438,7 +507,8 @@ To use the AWS Message Processing Framework for .NET to publish a message to an 
             "Sid": "Statement1",
             "Effect": "Allow",
             "Action": [
-                "sqs:sendmessage"
+                "sqs:sendmessage",
+                "sqs:sendmessagebatch"
             ],
             "Resource": [
                 "arn:aws:sqs:<region>:<account>:<queue>"

--- a/src/AWS.Messaging/Exceptions.cs
+++ b/src/AWS.Messaging/Exceptions.cs
@@ -274,6 +274,28 @@ public class InvalidFifoPublishingRequestException : AWSMessagingException
 }
 
 /// <summary>
+/// Thrown if an exception occurs while publishing a batch of messages.
+/// Contains partial results from chunks that may have already succeeded before the failure.
+/// </summary>
+public class FailedToPublishBatchException : FailedToPublishException
+{
+    /// <summary>
+    /// The partial response containing results from batch chunks that were sent before the failure occurred.
+    /// Earlier chunks may have succeeded even though a later chunk failed.
+    /// </summary>
+    public Publishers.SQS.SQSSendBatchResponse? PartialResponse { get; }
+
+    /// <summary>
+    /// Creates an instance of <see cref="FailedToPublishBatchException"/>.
+    /// </summary>
+    public FailedToPublishBatchException(string message, Exception? innerException = null, Publishers.SQS.SQSSendBatchResponse? partialResponse = null)
+        : base(message, innerException)
+    {
+        PartialResponse = partialResponse;
+    }
+}
+
+/// <summary>
 /// Thrown if the <see cref="EventBridgePublishResponse"/> contains a message with an error code
 /// </summary>
 public class EventBridgePutEventsException : AWSMessagingException

--- a/src/AWS.Messaging/Publishers/SQS/ISQSPublisher.cs
+++ b/src/AWS.Messaging/Publishers/SQS/ISQSPublisher.cs
@@ -8,8 +8,8 @@ namespace AWS.Messaging.Publishers.SQS
     /// <summary>
     /// This interface allows sending messages from application code to Amazon SQS.
     /// It exposes the <see cref="SendAsync{T}(T, SQSOptions?, CancellationToken)"/> method which takes in a user-defined message, and <see cref="SQSOptions"/> to set additional parameters while sending messages to SQS.
-    /// It also exposes <see cref="SendBatchAsync{T}(IEnumerable{T}, SQSOptions?, CancellationToken)"/> and
-    /// <see cref="SendBatchAsync{T}(IEnumerable{SQSBatchEntry{T}}, SQSOptions?, CancellationToken)"/> methods
+    /// It also exposes <see cref="SendBatchAsync{T}(IEnumerable{T}, CancellationToken)"/> and
+    /// <see cref="SendBatchAsync{T}(IEnumerable{SQSBatchEntry{T}}, SQSBatchOptions?, CancellationToken)"/> methods
     /// for sending up to multiple messages in batches using the SQS SendMessageBatch API.
     /// Using dependency injection, this interface is available to inject anywhere in the code.
     /// </summary>
@@ -25,31 +25,31 @@ namespace AWS.Messaging.Publishers.SQS
 
         /// <summary>
         /// Sends a batch of application messages to SQS using the SendMessageBatch API.
-        /// All messages share the same <see cref="SQSOptions"/>.
         /// Messages are automatically chunked into groups of 10 (the SQS maximum per batch request).
+        /// <para>
+        /// This is a convenience overload for sending simple batches where no per-message options
+        /// are needed. For FIFO queues or when per-message options are required, use
+        /// <see cref="SendBatchAsync{T}(IEnumerable{SQSBatchEntry{T}}, SQSBatchOptions?, CancellationToken)"/> instead.
+        /// </para>
         /// </summary>
         /// <typeparam name="T">The .NET type of the application message.</typeparam>
         /// <param name="messages">The application messages that will be serialized and sent to an SQS queue.</param>
-        /// <param name="sqsOptions">Contains additional parameters that apply to all messages in the batch, including
-        /// <see cref="SQSOptions.QueueUrl"/> and <see cref="SQSOptions.OverrideClient"/> as well as
-        /// message-level properties like <see cref="SQSOptions.MessageGroupId"/>.</param>
         /// <param name="token">The cancellation token used to cancel the request.</param>
         /// <returns>A <see cref="SQSSendBatchResponse"/> containing the results for each message in the batch.</returns>
-        Task<SQSSendBatchResponse> SendBatchAsync<T>(IEnumerable<T> messages, SQSOptions? sqsOptions = null, CancellationToken token = default);
+        Task<SQSSendBatchResponse> SendBatchAsync<T>(IEnumerable<T> messages, CancellationToken token = default);
 
         /// <summary>
         /// Sends a batch of application messages to SQS using the SendMessageBatch API,
-        /// with per-message <see cref="SQSOptions"/> allowing different options (e.g. <see cref="SQSOptions.MessageGroupId"/>)
+        /// with per-message <see cref="SQSMessageOptions"/> allowing different options (e.g. <see cref="SQSMessageOptions.MessageGroupId"/>)
         /// for each message in the batch.
         /// Messages are automatically chunked into groups of 10 (the SQS maximum per batch request).
         /// </summary>
         /// <typeparam name="T">The .NET type of the application message.</typeparam>
-        /// <param name="entries">The batch entries, each containing a message and optional per-message SQS options.</param>
-        /// <param name="sqsOptions">Contains batch-level parameters such as <see cref="SQSOptions.QueueUrl"/>
-        /// and <see cref="SQSOptions.OverrideClient"/>. Message-level properties on this parameter serve as
-        /// defaults and are overridden by per-entry options when specified.</param>
+        /// <param name="entries">The batch entries, each containing a message and optional per-message options.</param>
+        /// <param name="batchOptions">Optional batch-level parameters such as <see cref="SQSBatchOptions.QueueUrl"/>
+        /// and <see cref="SQSBatchOptions.OverrideClient"/>.</param>
         /// <param name="token">The cancellation token used to cancel the request.</param>
         /// <returns>A <see cref="SQSSendBatchResponse"/> containing the results for each message in the batch.</returns>
-        Task<SQSSendBatchResponse> SendBatchAsync<T>(IEnumerable<SQSBatchEntry<T>> entries, SQSOptions? sqsOptions = null, CancellationToken token = default);
+        Task<SQSSendBatchResponse> SendBatchAsync<T>(IEnumerable<SQSBatchEntry<T>> entries, SQSBatchOptions? batchOptions = null, CancellationToken token = default);
     }
 }

--- a/src/AWS.Messaging/Publishers/SQS/ISQSPublisher.cs
+++ b/src/AWS.Messaging/Publishers/SQS/ISQSPublisher.cs
@@ -8,6 +8,9 @@ namespace AWS.Messaging.Publishers.SQS
     /// <summary>
     /// This interface allows sending messages from application code to Amazon SQS.
     /// It exposes the <see cref="SendAsync{T}(T, SQSOptions?, CancellationToken)"/> method which takes in a user-defined message, and <see cref="SQSOptions"/> to set additional parameters while sending messages to SQS.
+    /// It also exposes <see cref="SendBatchAsync{T}(IEnumerable{T}, SQSOptions?, CancellationToken)"/> and
+    /// <see cref="SendBatchAsync{T}(IEnumerable{SQSBatchEntry{T}}, SQSOptions?, CancellationToken)"/> methods
+    /// for sending up to multiple messages in batches using the SQS SendMessageBatch API.
     /// Using dependency injection, this interface is available to inject anywhere in the code.
     /// </summary>
     public interface ISQSPublisher : ICommandPublisher
@@ -19,5 +22,34 @@ namespace AWS.Messaging.Publishers.SQS
         /// <param name="sqsOptions">Contains additional parameters that can be set while sending a message to an SQS queue</param>
         /// <param name="token">The cancellation token used to cancel the request.</param>
         Task<SQSSendResponse> SendAsync<T>(T message, SQSOptions? sqsOptions, CancellationToken token = default);
+
+        /// <summary>
+        /// Sends a batch of application messages to SQS using the SendMessageBatch API.
+        /// All messages share the same <see cref="SQSOptions"/>.
+        /// Messages are automatically chunked into groups of 10 (the SQS maximum per batch request).
+        /// </summary>
+        /// <typeparam name="T">The .NET type of the application message.</typeparam>
+        /// <param name="messages">The application messages that will be serialized and sent to an SQS queue.</param>
+        /// <param name="sqsOptions">Contains additional parameters that apply to all messages in the batch, including
+        /// <see cref="SQSOptions.QueueUrl"/> and <see cref="SQSOptions.OverrideClient"/> as well as
+        /// message-level properties like <see cref="SQSOptions.MessageGroupId"/>.</param>
+        /// <param name="token">The cancellation token used to cancel the request.</param>
+        /// <returns>A <see cref="SQSSendBatchResponse"/> containing the results for each message in the batch.</returns>
+        Task<SQSSendBatchResponse> SendBatchAsync<T>(IEnumerable<T> messages, SQSOptions? sqsOptions = null, CancellationToken token = default);
+
+        /// <summary>
+        /// Sends a batch of application messages to SQS using the SendMessageBatch API,
+        /// with per-message <see cref="SQSOptions"/> allowing different options (e.g. <see cref="SQSOptions.MessageGroupId"/>)
+        /// for each message in the batch.
+        /// Messages are automatically chunked into groups of 10 (the SQS maximum per batch request).
+        /// </summary>
+        /// <typeparam name="T">The .NET type of the application message.</typeparam>
+        /// <param name="entries">The batch entries, each containing a message and optional per-message SQS options.</param>
+        /// <param name="sqsOptions">Contains batch-level parameters such as <see cref="SQSOptions.QueueUrl"/>
+        /// and <see cref="SQSOptions.OverrideClient"/>. Message-level properties on this parameter serve as
+        /// defaults and are overridden by per-entry options when specified.</param>
+        /// <param name="token">The cancellation token used to cancel the request.</param>
+        /// <returns>A <see cref="SQSSendBatchResponse"/> containing the results for each message in the batch.</returns>
+        Task<SQSSendBatchResponse> SendBatchAsync<T>(IEnumerable<SQSBatchEntry<T>> entries, SQSOptions? sqsOptions = null, CancellationToken token = default);
     }
 }

--- a/src/AWS.Messaging/Publishers/SQS/SQSBatchEntry.cs
+++ b/src/AWS.Messaging/Publishers/SQS/SQSBatchEntry.cs
@@ -5,7 +5,7 @@ namespace AWS.Messaging.Publishers.SQS;
 
 /// <summary>
 /// Represents a single entry in a batch send operation to SQS.
-/// Pairs an application message with optional per-message <see cref="SQSOptions"/>.
+/// Pairs an application message with optional per-message <see cref="SQSMessageOptions"/>.
 /// </summary>
 /// <typeparam name="T">The .NET type of the application message.</typeparam>
 public class SQSBatchEntry<T>
@@ -22,7 +22,7 @@ public class SQSBatchEntry<T>
     /// </summary>
     /// <param name="message">The application message to send.</param>
     /// <param name="options">Optional per-message SQS options.</param>
-    public SQSBatchEntry(T message, SQSOptions? options = null)
+    public SQSBatchEntry(T message, SQSMessageOptions? options = null)
     {
         Message = message;
         Options = options;
@@ -34,15 +34,9 @@ public class SQSBatchEntry<T>
     public T Message { get; set; } = default!;
 
     /// <summary>
-    /// Optional per-message SQS options such as <see cref="SQSOptions.MessageGroupId"/>,
-    /// <see cref="SQSOptions.MessageDeduplicationId"/>, <see cref="SQSOptions.DelaySeconds"/>,
-    /// and <see cref="SQSOptions.MessageAttributes"/>.
-    /// <para>
-    /// Note: <see cref="SQSOptions.QueueUrl"/> and <see cref="SQSOptions.OverrideClient"/> are only
-    /// used from the shared <see cref="SQSOptions"/> parameter passed to
-    /// <see cref="ISQSPublisher.SendBatchAsync{T}(IEnumerable{T}, SQSOptions?, CancellationToken)"/>.
-    /// If set on individual entries, they will be ignored.
-    /// </para>
+    /// Optional per-message options such as <see cref="SQSMessageOptions.MessageGroupId"/>,
+    /// <see cref="SQSMessageOptions.MessageDeduplicationId"/>, <see cref="SQSMessageOptions.DelaySeconds"/>,
+    /// and <see cref="SQSMessageOptions.MessageAttributes"/>.
     /// </summary>
-    public SQSOptions? Options { get; set; }
+    public SQSMessageOptions? Options { get; set; }
 }

--- a/src/AWS.Messaging/Publishers/SQS/SQSBatchEntry.cs
+++ b/src/AWS.Messaging/Publishers/SQS/SQSBatchEntry.cs
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Publishers.SQS;
+
+/// <summary>
+/// Represents a single entry in a batch send operation to SQS.
+/// Pairs an application message with optional per-message <see cref="SQSOptions"/>.
+/// </summary>
+/// <typeparam name="T">The .NET type of the application message.</typeparam>
+public class SQSBatchEntry<T>
+{
+    /// <summary>
+    /// Creates an instance of <see cref="SQSBatchEntry{T}"/>.
+    /// </summary>
+    public SQSBatchEntry()
+    {
+    }
+
+    /// <summary>
+    /// Creates an instance of <see cref="SQSBatchEntry{T}"/> with the specified message and options.
+    /// </summary>
+    /// <param name="message">The application message to send.</param>
+    /// <param name="options">Optional per-message SQS options.</param>
+    public SQSBatchEntry(T message, SQSOptions? options = null)
+    {
+        Message = message;
+        Options = options;
+    }
+
+    /// <summary>
+    /// The application message that will be serialized and sent to an SQS queue.
+    /// </summary>
+    public T Message { get; set; } = default!;
+
+    /// <summary>
+    /// Optional per-message SQS options such as <see cref="SQSOptions.MessageGroupId"/>,
+    /// <see cref="SQSOptions.MessageDeduplicationId"/>, <see cref="SQSOptions.DelaySeconds"/>,
+    /// and <see cref="SQSOptions.MessageAttributes"/>.
+    /// <para>
+    /// Note: <see cref="SQSOptions.QueueUrl"/> and <see cref="SQSOptions.OverrideClient"/> are only
+    /// used from the shared <see cref="SQSOptions"/> parameter passed to
+    /// <see cref="ISQSPublisher.SendBatchAsync{T}(IEnumerable{T}, SQSOptions?, CancellationToken)"/>.
+    /// If set on individual entries, they will be ignored.
+    /// </para>
+    /// </summary>
+    public SQSOptions? Options { get; set; }
+}

--- a/src/AWS.Messaging/Publishers/SQS/SQSBatchOptions.cs
+++ b/src/AWS.Messaging/Publishers/SQS/SQSBatchOptions.cs
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.SQS;
+
+namespace AWS.Messaging.Publishers.SQS;
+
+/// <summary>
+/// Contains batch-level properties that apply to an entire batch send operation to SQS.
+/// <para>
+/// This class is used on the <see cref="ISQSPublisher.SendBatchAsync{T}(IEnumerable{SQSBatchEntry{T}}, SQSBatchOptions?, CancellationToken)"/>
+/// method to override the queue URL or SQS client for the batch. Per-message properties such as
+/// <see cref="SQSMessageOptions.MessageGroupId"/> should be set on each <see cref="SQSBatchEntry{T}.Options"/> instead.
+/// </para>
+/// </summary>
+public class SQSBatchOptions
+{
+    /// <summary>
+    /// The SQS queue URL which the publisher will use for the batch. This can be used to override the queue URL
+    /// that is configured for a given message type when publishing a batch.
+    /// </summary>
+    public string? QueueUrl { get; set; }
+
+    /// <summary>
+    /// An alternative SQS client that can be used to publish this batch,
+    /// instead of the client provided by the registered <see cref="Configuration.IAWSClientProvider"/> implementation.
+    /// </summary>
+    public IAmazonSQS? OverrideClient { get; set; }
+}

--- a/src/AWS.Messaging/Publishers/SQS/SQSMessageOptions.cs
+++ b/src/AWS.Messaging/Publishers/SQS/SQSMessageOptions.cs
@@ -1,0 +1,54 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.SQS.Model;
+
+namespace AWS.Messaging.Publishers.SQS;
+
+/// <summary>
+/// Contains per-message properties that can be set when sending individual messages
+/// within a batch to an SQS queue.
+/// <para>
+/// This class is used on <see cref="SQSBatchEntry{T}.Options"/> to specify message-level
+/// settings such as <see cref="MessageGroupId"/> and <see cref="MessageDeduplicationId"/>.
+/// </para>
+/// </summary>
+public class SQSMessageOptions
+{
+    /// <summary>
+    /// The length of time, in seconds, for which to delay a specific message.
+    /// Its valid values are between 0 to 900.
+    /// Messages with a positive DelaySeconds value become available for processing after the delay period is finished.
+    /// If you don't specify a value, the default value for the queue applies.
+    /// When you set FifoQueue, you can't set DelaySeconds per message. You can set this parameter only on a queue level.
+    /// </summary>
+    public int? DelaySeconds { get; set; }
+
+    /// <summary>
+    /// Each message attribute consists of a Name, Type, and Value.
+    /// For more information, see <see href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-metadata.html#sqs-message-attributes">the Amazon SQS developer guide.</see>
+    /// </summary>
+    public Dictionary<string, MessageAttributeValue>? MessageAttributes { get; set; }
+
+    /// <summary>
+    /// This parameter applies only to FIFO(first-in-first-out) queues and is used for deduplication of sent messages.
+    /// If a message with a particular MessageDeduplicationId is sent successfully, any messages sent with the same
+    /// MessageDeduplicationId are accepted successfully but aren't delivered during the 5-minute deduplication interval.
+    /// For more information, see <see href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues-exactly-once-processing.html">Exactly-once processing</see>
+    /// in the Amazon SQS Developer Guide.
+    /// <para>
+    /// Each message in a batch should have a unique MessageDeduplicationId. Setting the same deduplication ID
+    /// across multiple messages in a batch would incorrectly indicate they are duplicates of each other.
+    /// </para>
+    /// </summary>
+    public string? MessageDeduplicationId { get; set; }
+
+    /// <summary>
+    /// This parameter applies only to FIFO(first-in-first-out) queues and specifies that a message belongs to a specific message group.
+    /// Messages that belong to the same message group are processed in a FIFO manner
+    /// (however, messages in different message groups might be processed out of order).
+    /// To interleave multiple ordered streams within a single queue, use MessageGroupId values
+    /// (for example, session data for multiple users).
+    /// </summary>
+    public string? MessageGroupId { get; set; }
+}

--- a/src/AWS.Messaging/Publishers/SQS/SQSPublisher.cs
+++ b/src/AWS.Messaging/Publishers/SQS/SQSPublisher.cs
@@ -24,6 +24,7 @@ internal class SQSPublisher : ISQSPublisher
     private IAmazonSQS? _sqsClient;
 
     private const string FIFO_SUFFIX = ".fifo";
+    private const int MAX_BATCH_SIZE = 10;
 
     /// <summary>
     /// Creates an instance of <see cref="SQSPublisher"/>.
@@ -121,6 +122,192 @@ internal class SQSPublisher : ISQSPublisher
                 throw;
             }
         }
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <exception cref="FailedToPublishException">If the batch request failed due to an SQS SDK exception.</exception>
+    /// <exception cref="InvalidMessageException">If any message in the batch is null.</exception>
+    /// <exception cref="MissingMessageTypeConfigurationException">If cannot find the publisher configuration for the message type.</exception>
+    public async Task<SQSSendBatchResponse> SendBatchAsync<T>(IEnumerable<T> messages, SQSOptions? sqsOptions = null, CancellationToken token = default)
+    {
+        var entries = messages.Select(m => new SQSBatchEntry<T>(m, null));
+        return await SendBatchAsync(entries, sqsOptions, token);
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <exception cref="FailedToPublishException">If the batch request failed due to an SQS SDK exception.</exception>
+    /// <exception cref="InvalidMessageException">If any message in the batch is null.</exception>
+    /// <exception cref="MissingMessageTypeConfigurationException">If cannot find the publisher configuration for the message type.</exception>
+    public async Task<SQSSendBatchResponse> SendBatchAsync<T>(IEnumerable<SQSBatchEntry<T>> entries, SQSOptions? sqsOptions = null, CancellationToken token = default)
+    {
+        using (var trace = _telemetryFactory.Trace("Publish batch to AWS SQS"))
+        {
+            try
+            {
+                trace.AddMetadata(TelemetryKeys.ObjectType, typeof(T).FullName!);
+
+                _logger.LogDebug("Publishing a batch of messages of type '{MessageType}' using the {PublisherType}.", typeof(T), nameof(SQSPublisher));
+
+                var queueUrl = GetPublisherEndpoint(trace, typeof(T), sqsOptions);
+                var client = ResolveClient(sqsOptions);
+
+                // Serialize all messages and build batch request entries
+                var batchRequestEntries = new List<SendMessageBatchRequestEntry>();
+                foreach (var entry in entries)
+                {
+                    if (entry.Message == null)
+                    {
+                        _logger.LogError("A message of type '{MessageType}' in the batch has a null value.", typeof(T));
+                        throw new InvalidMessageException("A message in the batch cannot be null.");
+                    }
+
+                    var messageEnvelope = await _envelopeSerializer.CreateEnvelopeAsync(entry.Message);
+                    var messageBody = await _envelopeSerializer.SerializeAsync(messageEnvelope);
+
+                    var batchEntry = CreateSendMessageBatchRequestEntry(queueUrl, messageBody, sqsOptions, entry.Options);
+                    batchRequestEntries.Add(batchEntry);
+                }
+
+                if (batchRequestEntries.Count == 0)
+                {
+                    _logger.LogDebug("No messages to send in the batch of type '{MessageType}'.", typeof(T));
+                    return new SQSSendBatchResponse();
+                }
+
+                _logger.LogDebug("Sending a batch of {MessageCount} message(s) of type '{MessageType}' to SQS. Publisher Endpoint: {Endpoint}",
+                    batchRequestEntries.Count, typeof(T), queueUrl);
+
+                // Chunk into groups of MAX_BATCH_SIZE (10) and send each chunk
+                var aggregatedResponse = new SQSSendBatchResponse();
+                var chunks = Chunk(batchRequestEntries, MAX_BATCH_SIZE);
+
+                foreach (var chunk in chunks)
+                {
+                    var request = new SendMessageBatchRequest
+                    {
+                        QueueUrl = queueUrl,
+                        Entries = chunk
+                    };
+
+                    var response = await client.SendMessageBatchAsync(request, token);
+
+                    // Aggregate successful entries
+                    if (response.Successful != null)
+                    {
+                        foreach (var success in response.Successful)
+                        {
+                            aggregatedResponse.Successful.Add(new SQSSendBatchResponseEntry
+                            {
+                                Id = success.Id,
+                                MessageId = success.MessageId
+                            });
+                        }
+                    }
+
+                    // Aggregate failed entries
+                    if (response.Failed != null)
+                    {
+                        foreach (var failure in response.Failed)
+                        {
+                            _logger.LogError(
+                                "Failed to send message with Id '{MessageId}' in batch to SQS. Error Code: {ErrorCode}, Error Message: {ErrorMessage}",
+                                failure.Id, failure.Code, failure.Message);
+
+                            aggregatedResponse.Failed.Add(new SQSSendBatchResponseFailedEntry
+                            {
+                                Id = failure.Id,
+                                Code = failure.Code,
+                                Message = failure.Message,
+                                SenderFault = failure.SenderFault ?? false
+                            });
+                        }
+                    }
+                }
+
+                _logger.LogDebug(
+                    "Batch send of type '{MessageType}' completed. {SuccessCount} message(s) succeeded, {FailCount} message(s) failed.",
+                    typeof(T), aggregatedResponse.Successful.Count, aggregatedResponse.Failed.Count);
+
+                return aggregatedResponse;
+            }
+            catch (Exception ex)
+            {
+                trace.AddException(ex);
+                if (ex is AmazonSQSException)
+                    throw new FailedToPublishException("Message batch failed to publish.", ex);
+                throw;
+            }
+        }
+    }
+
+    private IAmazonSQS ResolveClient(SQSOptions? sqsOptions)
+    {
+        if (sqsOptions?.OverrideClient != null)
+        {
+            return sqsOptions.OverrideClient;
+        }
+
+        _sqsClient ??= _awsClientProvider.GetServiceClient<IAmazonSQS>();
+        return _sqsClient;
+    }
+
+    private SendMessageBatchRequestEntry CreateSendMessageBatchRequestEntry(
+        string queueUrl,
+        string messageBody,
+        SQSOptions? sharedOptions,
+        SQSOptions? entryOptions)
+    {
+        // Resolve effective per-message options: entry-level overrides shared-level
+        var effectiveMessageGroupId = entryOptions?.MessageGroupId ?? sharedOptions?.MessageGroupId;
+        var effectiveMessageDeduplicationId = entryOptions?.MessageDeduplicationId ?? sharedOptions?.MessageDeduplicationId;
+        var effectiveDelaySeconds = entryOptions?.DelaySeconds ?? sharedOptions?.DelaySeconds;
+        var effectiveMessageAttributes = entryOptions?.MessageAttributes ?? sharedOptions?.MessageAttributes;
+
+        if (queueUrl.EndsWith(FIFO_SUFFIX) && string.IsNullOrEmpty(effectiveMessageGroupId))
+        {
+            var errorMessage =
+                $"You are attempting to send to a FIFO SQS queue but the request does not include a message group ID. " +
+                $"Please specify a message group ID via {nameof(SQSOptions.MessageGroupId)} on either the shared " +
+                $"{nameof(SQSOptions)} parameter or the per-entry {nameof(SQSBatchEntry<object>.Options)}. " +
+                $"Additionally, {nameof(SQSOptions.MessageDeduplicationId)} must also be specified if content based de-duplication is not enabled on the queue.";
+
+            _logger.LogError(errorMessage);
+            throw new InvalidFifoPublishingRequestException(errorMessage);
+        }
+
+        var entry = new SendMessageBatchRequestEntry
+        {
+            Id = Guid.NewGuid().ToString(),
+            MessageBody = messageBody
+        };
+
+        if (!string.IsNullOrEmpty(effectiveMessageGroupId))
+            entry.MessageGroupId = effectiveMessageGroupId;
+
+        if (!string.IsNullOrEmpty(effectiveMessageDeduplicationId))
+            entry.MessageDeduplicationId = effectiveMessageDeduplicationId;
+
+        if (effectiveDelaySeconds.HasValue)
+            entry.DelaySeconds = (int)effectiveDelaySeconds;
+
+        if (effectiveMessageAttributes is not null)
+            entry.MessageAttributes = effectiveMessageAttributes;
+
+        return entry;
+    }
+
+    private static List<List<T>> Chunk<T>(List<T> source, int chunkSize)
+    {
+        var chunks = new List<List<T>>();
+        for (var i = 0; i < source.Count; i += chunkSize)
+        {
+            chunks.Add(source.GetRange(i, Math.Min(chunkSize, source.Count - i)));
+        }
+        return chunks;
     }
 
     private SendMessageRequest CreateSendMessageRequest(string queueUrl, string messageBody, SQSOptions? sqsOptions)

--- a/src/AWS.Messaging/Publishers/SQS/SQSPublisher.cs
+++ b/src/AWS.Messaging/Publishers/SQS/SQSPublisher.cs
@@ -91,19 +91,7 @@ internal class SQSPublisher : ISQSPublisher
 
                 var messageBody = await _envelopeSerializer.SerializeAsync(messageEnvelope);
 
-                IAmazonSQS client;
-                if (sqsOptions?.OverrideClient != null)
-                {
-                    // Use the client that the user specified for this message
-                    client = sqsOptions.OverrideClient;
-                }
-                else // use the publisher-level client
-                {
-                    // If we haven't resolved the client yet for this publisher, do so now
-                    _sqsClient ??= _awsClientProvider.GetServiceClient<IAmazonSQS>();
-
-                    client = _sqsClient;
-                }
+                var client = ResolveClient(sqsOptions);
 
                 _logger.LogDebug("Sending the message of type '{MessageType}' to SQS. Publisher Endpoint: {Endpoint}", typeof(T), queueUrl);
                 var sendMessageRequest = CreateSendMessageRequest(queueUrl, messageBody, sqsOptions);

--- a/src/AWS.Messaging/Publishers/SQS/SQSPublisher.cs
+++ b/src/AWS.Messaging/Publishers/SQS/SQSPublisher.cs
@@ -81,7 +81,7 @@ internal class SQSPublisher : ISQSPublisher
                     throw new InvalidMessageException("The message cannot be null.");
                 }
 
-                var queueUrl = GetPublisherEndpoint(trace, typeof(T), sqsOptions);
+                var queueUrl = GetPublisherEndpoint(trace, typeof(T), sqsOptions?.QueueUrl);
 
                 _logger.LogDebug("Creating the message envelope for the message of type '{MessageType}'.", typeof(T));
                 var messageEnvelope = await _envelopeSerializer.CreateEnvelopeAsync(message);
@@ -91,7 +91,7 @@ internal class SQSPublisher : ISQSPublisher
 
                 var messageBody = await _envelopeSerializer.SerializeAsync(messageEnvelope);
 
-                var client = ResolveClient(sqsOptions);
+                var client = ResolveClient(sqsOptions?.OverrideClient);
 
                 _logger.LogDebug("Sending the message of type '{MessageType}' to SQS. Publisher Endpoint: {Endpoint}", typeof(T), queueUrl);
                 var sendMessageRequest = CreateSendMessageRequest(queueUrl, messageBody, sqsOptions);
@@ -118,7 +118,7 @@ internal class SQSPublisher : ISQSPublisher
     /// <exception cref="FailedToPublishException">If the batch request failed due to an SQS SDK exception.</exception>
     /// <exception cref="InvalidMessageException">If any message in the batch is null.</exception>
     /// <exception cref="MissingMessageTypeConfigurationException">If cannot find the publisher configuration for the message type.</exception>
-    public async Task<SQSSendBatchResponse> SendBatchAsync<T>(IEnumerable<T> messages, SQSOptions? sqsOptions = null, CancellationToken token = default)
+    public async Task<SQSSendBatchResponse> SendBatchAsync<T>(IEnumerable<T> messages, CancellationToken token = default)
     {
         if (messages == null)
         {
@@ -126,7 +126,7 @@ internal class SQSPublisher : ISQSPublisher
         }
 
         var entries = messages.Select(m => new SQSBatchEntry<T>(m, null));
-        return await SendBatchAsync(entries, sqsOptions, token);
+        return await SendBatchAsync(entries, null, token);
     }
 
     /// <summary>
@@ -135,7 +135,7 @@ internal class SQSPublisher : ISQSPublisher
     /// <exception cref="FailedToPublishException">If the batch request failed due to an SQS SDK exception.</exception>
     /// <exception cref="InvalidMessageException">If any message in the batch is null.</exception>
     /// <exception cref="MissingMessageTypeConfigurationException">If cannot find the publisher configuration for the message type.</exception>
-    public async Task<SQSSendBatchResponse> SendBatchAsync<T>(IEnumerable<SQSBatchEntry<T>> entries, SQSOptions? sqsOptions = null, CancellationToken token = default)
+    public async Task<SQSSendBatchResponse> SendBatchAsync<T>(IEnumerable<SQSBatchEntry<T>> entries, SQSBatchOptions? batchOptions = null, CancellationToken token = default)
     {
         if (entries == null)
         {
@@ -153,8 +153,8 @@ internal class SQSPublisher : ISQSPublisher
 
                 _logger.LogDebug("Publishing a batch of messages of type '{MessageType}' using the {PublisherType}.", typeof(T), nameof(SQSPublisher));
 
-                var queueUrl = GetPublisherEndpoint(trace, typeof(T), sqsOptions);
-                var client = ResolveClient(sqsOptions);
+                var queueUrl = GetPublisherEndpoint(trace, typeof(T), batchOptions?.QueueUrl);
+                var client = ResolveClient(batchOptions?.OverrideClient);
 
                 // Serialize all messages and build batch request entries
                 var batchRequestEntries = new List<SendMessageBatchRequestEntry>();
@@ -175,7 +175,7 @@ internal class SQSPublisher : ISQSPublisher
 
                     // Use the MessageEnvelope.Id as the batch entry Id so callers can correlate
                     // successes/failures in the response back to their original input messages
-                    var batchEntry = CreateSendMessageBatchRequestEntry(messageEnvelope.Id, queueUrl, messageBody, sqsOptions, entry.Options);
+                    var batchEntry = CreateSendMessageBatchRequestEntry(messageEnvelope.Id, queueUrl, messageBody, entry.Options);
                     batchRequestEntries.Add(batchEntry);
                 }
 
@@ -259,11 +259,11 @@ internal class SQSPublisher : ISQSPublisher
         }
     }
 
-    private IAmazonSQS ResolveClient(SQSOptions? sqsOptions)
+    private IAmazonSQS ResolveClient(IAmazonSQS? overrideClient)
     {
-        if (sqsOptions?.OverrideClient != null)
+        if (overrideClient != null)
         {
-            return sqsOptions.OverrideClient;
+            return overrideClient;
         }
 
         _sqsClient ??= _awsClientProvider.GetServiceClient<IAmazonSQS>();
@@ -274,22 +274,15 @@ internal class SQSPublisher : ISQSPublisher
         string entryId,
         string queueUrl,
         string messageBody,
-        SQSOptions? sharedOptions,
-        SQSOptions? entryOptions)
+        SQSMessageOptions? entryOptions)
     {
-        // Resolve effective per-message options: entry-level overrides shared-level
-        var effectiveMessageGroupId = entryOptions?.MessageGroupId ?? sharedOptions?.MessageGroupId;
-        var effectiveMessageDeduplicationId = entryOptions?.MessageDeduplicationId ?? sharedOptions?.MessageDeduplicationId;
-        var effectiveDelaySeconds = entryOptions?.DelaySeconds ?? sharedOptions?.DelaySeconds;
-        var effectiveMessageAttributes = entryOptions?.MessageAttributes ?? sharedOptions?.MessageAttributes;
-
-        if (queueUrl.EndsWith(FIFO_SUFFIX) && string.IsNullOrEmpty(effectiveMessageGroupId))
+        if (queueUrl.EndsWith(FIFO_SUFFIX) && string.IsNullOrEmpty(entryOptions?.MessageGroupId))
         {
             var errorMessage =
                 $"You are attempting to send to a FIFO SQS queue but the request does not include a message group ID. " +
-                $"Please specify a message group ID via {nameof(SQSOptions.MessageGroupId)} on either the shared " +
-                $"{nameof(SQSOptions)} parameter or the per-entry {nameof(SQSBatchEntry<object>.Options)}. " +
-                $"Additionally, {nameof(SQSOptions.MessageDeduplicationId)} must also be specified if content based de-duplication is not enabled on the queue.";
+                $"Please specify a message group ID via {nameof(SQSMessageOptions.MessageGroupId)} on the " +
+                $"{nameof(SQSBatchEntry<object>.Options)} for each entry. " +
+                $"Additionally, {nameof(SQSMessageOptions.MessageDeduplicationId)} must also be specified if content based de-duplication is not enabled on the queue.";
 
             _logger.LogError(errorMessage);
             throw new InvalidFifoPublishingRequestException(errorMessage);
@@ -301,17 +294,20 @@ internal class SQSPublisher : ISQSPublisher
             MessageBody = messageBody
         };
 
-        if (!string.IsNullOrEmpty(effectiveMessageGroupId))
-            entry.MessageGroupId = effectiveMessageGroupId;
+        if (entryOptions is null)
+            return entry;
 
-        if (!string.IsNullOrEmpty(effectiveMessageDeduplicationId))
-            entry.MessageDeduplicationId = effectiveMessageDeduplicationId;
+        if (!string.IsNullOrEmpty(entryOptions.MessageGroupId))
+            entry.MessageGroupId = entryOptions.MessageGroupId;
 
-        if (effectiveDelaySeconds.HasValue)
-            entry.DelaySeconds = (int)effectiveDelaySeconds;
+        if (!string.IsNullOrEmpty(entryOptions.MessageDeduplicationId))
+            entry.MessageDeduplicationId = entryOptions.MessageDeduplicationId;
 
-        if (effectiveMessageAttributes is not null)
-            entry.MessageAttributes = effectiveMessageAttributes;
+        if (entryOptions.DelaySeconds.HasValue)
+            entry.DelaySeconds = (int)entryOptions.DelaySeconds;
+
+        if (entryOptions.MessageAttributes is not null)
+            entry.MessageAttributes = entryOptions.MessageAttributes;
 
         return entry;
     }
@@ -365,7 +361,7 @@ internal class SQSPublisher : ISQSPublisher
         return request;
     }
 
-    private string GetPublisherEndpoint(ITelemetryTrace trace, Type messageType, SQSOptions? sqsOptions)
+    private string GetPublisherEndpoint(ITelemetryTrace trace, Type messageType, string? queueUrlOverride)
     {
         var mapping = _messageConfiguration.GetPublisherMapping(messageType);
         if (mapping is null)
@@ -382,10 +378,10 @@ internal class SQSPublisher : ISQSPublisher
 
         var queueUrl = mapping.PublisherConfiguration.PublisherEndpoint;
 
-        // Check if the queue was overriden on this message-specific publishing options
-        if (!string.IsNullOrEmpty(sqsOptions?.QueueUrl))
+        // Check if the queue was overridden on this message-specific publishing options
+        if (!string.IsNullOrEmpty(queueUrlOverride))
         {
-            queueUrl = sqsOptions.QueueUrl;
+            queueUrl = queueUrlOverride;
         }
 
         if (string.IsNullOrEmpty(queueUrl))

--- a/src/AWS.Messaging/Publishers/SQS/SQSPublisher.cs
+++ b/src/AWS.Messaging/Publishers/SQS/SQSPublisher.cs
@@ -132,6 +132,11 @@ internal class SQSPublisher : ISQSPublisher
     /// <exception cref="MissingMessageTypeConfigurationException">If cannot find the publisher configuration for the message type.</exception>
     public async Task<SQSSendBatchResponse> SendBatchAsync<T>(IEnumerable<T> messages, SQSOptions? sqsOptions = null, CancellationToken token = default)
     {
+        if (messages == null)
+        {
+            throw new ArgumentNullException(nameof(messages), "The messages collection cannot be null.");
+        }
+
         var entries = messages.Select(m => new SQSBatchEntry<T>(m, null));
         return await SendBatchAsync(entries, sqsOptions, token);
     }
@@ -144,8 +149,16 @@ internal class SQSPublisher : ISQSPublisher
     /// <exception cref="MissingMessageTypeConfigurationException">If cannot find the publisher configuration for the message type.</exception>
     public async Task<SQSSendBatchResponse> SendBatchAsync<T>(IEnumerable<SQSBatchEntry<T>> entries, SQSOptions? sqsOptions = null, CancellationToken token = default)
     {
+        if (entries == null)
+        {
+            throw new ArgumentNullException(nameof(entries), "The entries collection cannot be null.");
+        }
+
         using (var trace = _telemetryFactory.Trace("Publish batch to AWS SQS"))
         {
+            // Declared outside try so partial results can be captured in the catch block
+            var aggregatedResponse = new SQSSendBatchResponse();
+
             try
             {
                 trace.AddMetadata(TelemetryKeys.ObjectType, typeof(T).FullName!);
@@ -166,9 +179,15 @@ internal class SQSPublisher : ISQSPublisher
                     }
 
                     var messageEnvelope = await _envelopeSerializer.CreateEnvelopeAsync(entry.Message);
+
+                    // Record telemetry context for each envelope to support downstream trace correlation
+                    trace.RecordTelemetryContext(messageEnvelope);
+
                     var messageBody = await _envelopeSerializer.SerializeAsync(messageEnvelope);
 
-                    var batchEntry = CreateSendMessageBatchRequestEntry(queueUrl, messageBody, sqsOptions, entry.Options);
+                    // Use the MessageEnvelope.Id as the batch entry Id so callers can correlate
+                    // successes/failures in the response back to their original input messages
+                    var batchEntry = CreateSendMessageBatchRequestEntry(messageEnvelope.Id, queueUrl, messageBody, sqsOptions, entry.Options);
                     batchRequestEntries.Add(batchEntry);
                 }
 
@@ -181,8 +200,9 @@ internal class SQSPublisher : ISQSPublisher
                 _logger.LogDebug("Sending a batch of {MessageCount} message(s) of type '{MessageType}' to SQS. Publisher Endpoint: {Endpoint}",
                     batchRequestEntries.Count, typeof(T), queueUrl);
 
-                // Chunk into groups of MAX_BATCH_SIZE (10) and send each chunk
-                var aggregatedResponse = new SQSSendBatchResponse();
+                // Chunk into groups of MAX_BATCH_SIZE (10) and send each chunk.
+                // Note: If an AmazonSQSException occurs on a later chunk, earlier chunks may have already
+                // succeeded. The partial results are surfaced on the thrown FailedToPublishBatchException.
                 var chunks = Chunk(batchRequestEntries, MAX_BATCH_SIZE);
 
                 foreach (var chunk in chunks)
@@ -214,7 +234,7 @@ internal class SQSPublisher : ISQSPublisher
                         foreach (var failure in response.Failed)
                         {
                             _logger.LogError(
-                                "Failed to send message with Id '{MessageId}' in batch to SQS. Error Code: {ErrorCode}, Error Message: {ErrorMessage}",
+                                "Failed to send batch entry with Id '{BatchEntryId}' to SQS. Error Code: {ErrorCode}, Error Message: {ErrorMessage}",
                                 failure.Id, failure.Code, failure.Message);
 
                             aggregatedResponse.Failed.Add(new SQSSendBatchResponseFailedEntry
@@ -234,11 +254,18 @@ internal class SQSPublisher : ISQSPublisher
 
                 return aggregatedResponse;
             }
+            catch (Exception ex) when (ex is AmazonSQSException)
+            {
+                trace.AddException(ex);
+                // Surface partial results from chunks that may have succeeded before this failure
+                throw new FailedToPublishBatchException(
+                    "Message batch failed to publish. Some messages in earlier chunks may have been sent successfully. " +
+                    "Check the PartialResponse property for details.",
+                    ex, aggregatedResponse);
+            }
             catch (Exception ex)
             {
                 trace.AddException(ex);
-                if (ex is AmazonSQSException)
-                    throw new FailedToPublishException("Message batch failed to publish.", ex);
                 throw;
             }
         }
@@ -256,6 +283,7 @@ internal class SQSPublisher : ISQSPublisher
     }
 
     private SendMessageBatchRequestEntry CreateSendMessageBatchRequestEntry(
+        string entryId,
         string queueUrl,
         string messageBody,
         SQSOptions? sharedOptions,
@@ -281,7 +309,7 @@ internal class SQSPublisher : ISQSPublisher
 
         var entry = new SendMessageBatchRequestEntry
         {
-            Id = Guid.NewGuid().ToString(),
+            Id = entryId,
             MessageBody = messageBody
         };
 

--- a/src/AWS.Messaging/Publishers/SQS/SQSSendBatchResponse.cs
+++ b/src/AWS.Messaging/Publishers/SQS/SQSSendBatchResponse.cs
@@ -1,0 +1,67 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Publishers.SQS;
+
+/// <summary>
+/// The response for an SQS SendMessageBatch action.
+/// Contains lists of successfully sent and failed message entries.
+/// </summary>
+public class SQSSendBatchResponse
+{
+    /// <summary>
+    /// The list of successfully sent messages in the batch.
+    /// </summary>
+    public List<SQSSendBatchResponseEntry> Successful { get; set; } = new();
+
+    /// <summary>
+    /// The list of messages that failed to send in the batch.
+    /// </summary>
+    public List<SQSSendBatchResponseFailedEntry> Failed { get; set; } = new();
+}
+
+/// <summary>
+/// Represents a successfully sent message in a batch response.
+/// </summary>
+public class SQSSendBatchResponseEntry
+{
+    /// <summary>
+    /// The correlation identifier for this entry, matching the <c>Id</c> used in the batch request entry.
+    /// </summary>
+    public string? Id { get; set; }
+
+    /// <summary>
+    /// An identifier for the message assigned by SQS.
+    /// <para>
+    /// For more information, see <a href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-queue-message-identifiers.html">Queue
+    /// and Message Identifiers</a> in the <i>Amazon SQS Developer Guide</i>.
+    /// </para>
+    /// </summary>
+    public string? MessageId { get; set; }
+}
+
+/// <summary>
+/// Represents a message that failed to send in a batch response.
+/// </summary>
+public class SQSSendBatchResponseFailedEntry
+{
+    /// <summary>
+    /// The correlation identifier for this entry, matching the <c>Id</c> used in the batch request entry.
+    /// </summary>
+    public string? Id { get; set; }
+
+    /// <summary>
+    /// An error code representing why the action failed on this entry.
+    /// </summary>
+    public string? Code { get; set; }
+
+    /// <summary>
+    /// A message explaining why the action failed on this entry.
+    /// </summary>
+    public string? Message { get; set; }
+
+    /// <summary>
+    /// Specifies whether the error happened due to the caller of the batch API action.
+    /// </summary>
+    public bool SenderFault { get; set; }
+}

--- a/test/AWS.Messaging.IntegrationTests/SQSBatchPublisherFifoTests.cs
+++ b/test/AWS.Messaging.IntegrationTests/SQSBatchPublisherFifoTests.cs
@@ -1,0 +1,188 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using Microsoft.Extensions.DependencyInjection;
+using AWS.Messaging.IntegrationTests.Models;
+using AWS.Messaging.IntegrationTests.Handlers;
+using AWS.Messaging.Publishers.SQS;
+using AWS.Messaging.Serialization;
+using AWS.Messaging.Tests.Common;
+
+namespace AWS.Messaging.IntegrationTests;
+
+public class SQSBatchPublisherFifoTests : IAsyncLifetime
+{
+    private readonly IAmazonSQS _sqsClient;
+    private ServiceProvider _serviceProvider;
+    private string _sqsQueueUrl;
+
+    public SQSBatchPublisherFifoTests()
+    {
+        _sqsClient = new AmazonSQSClient();
+        _serviceProvider = default!;
+        _sqsQueueUrl = string.Empty;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _sqsQueueUrl = await AWSUtilities.CreateQueueAsync(_sqsClient, isFifo: true);
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging();
+        serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPublisher<ChatMessage>(_sqsQueueUrl);
+            builder.AddMessageSource("/aws/messaging");
+            builder.AddMessageHandler<ChatMessageHandler, ChatMessage>();
+        });
+        _serviceProvider = serviceCollection.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task PublishMessageBatch_FifoQueue_SharedGroupId()
+    {
+        var publishStartTime = DateTime.UtcNow;
+        var sqsPublisher = _serviceProvider.GetRequiredService<ISQSPublisher>();
+
+        var messages = Enumerable.Range(1, 5)
+            .Select(i => new ChatMessage { MessageDescription = $"FifoBatchTest{i}" })
+            .ToList();
+
+        var batchResponse = await sqsPublisher.SendBatchAsync(messages, new SQSOptions
+        {
+            MessageGroupId = "test-group"
+        });
+        var publishEndTime = DateTime.UtcNow;
+
+        // Verify the batch response
+        Assert.Equal(5, batchResponse.Successful.Count);
+        Assert.Empty(batchResponse.Failed);
+
+        // Wait to allow the published messages to propagate
+        await Task.Delay(5000);
+
+        // Receive all messages from the queue
+        var receivedMessages = new List<Message>();
+        for (var i = 0; i < 3; i++)
+        {
+            var receiveResponse = await _sqsClient.ReceiveMessageAsync(new ReceiveMessageRequest
+            {
+                QueueUrl = _sqsQueueUrl,
+                MaxNumberOfMessages = 10
+            });
+            receivedMessages.AddRange(receiveResponse.Messages);
+            if (receivedMessages.Count >= 5)
+                break;
+            await Task.Delay(1000);
+        }
+
+        Assert.Equal(5, receivedMessages.Count);
+
+        var envelopeSerializer = _serviceProvider.GetRequiredService<IEnvelopeSerializer>();
+        foreach (var receivedMessage in receivedMessages)
+        {
+            var result = await envelopeSerializer.ConvertToEnvelopeAsync(receivedMessage);
+            var envelope = result.Envelope as MessageEnvelope<ChatMessage>;
+
+            Assert.NotNull(envelope);
+            Assert.False(string.IsNullOrEmpty(envelope.Id));
+            Assert.Equal("/aws/messaging", envelope.Source.ToString());
+            Assert.True(envelope.TimeStamp > publishStartTime);
+            Assert.True(envelope.TimeStamp < publishEndTime);
+            Assert.NotNull(envelope.Message);
+            Assert.StartsWith("FifoBatchTest", envelope.Message.MessageDescription);
+        }
+    }
+
+    [Fact]
+    public async Task PublishMessageBatch_FifoQueue_PerMessageGroupId()
+    {
+        var sqsPublisher = _serviceProvider.GetRequiredService<ISQSPublisher>();
+
+        var entries = new List<SQSBatchEntry<ChatMessage>>
+        {
+            new(new ChatMessage { MessageDescription = "GroupA_Message1" },
+                new SQSOptions { MessageGroupId = "groupA" }),
+            new(new ChatMessage { MessageDescription = "GroupA_Message2" },
+                new SQSOptions { MessageGroupId = "groupA" }),
+            new(new ChatMessage { MessageDescription = "GroupB_Message1" },
+                new SQSOptions { MessageGroupId = "groupB" }),
+            new(new ChatMessage { MessageDescription = "GroupB_Message2" },
+                new SQSOptions { MessageGroupId = "groupB" }),
+        };
+
+        var batchResponse = await sqsPublisher.SendBatchAsync(entries);
+
+        // Verify the batch response
+        Assert.Equal(4, batchResponse.Successful.Count);
+        Assert.Empty(batchResponse.Failed);
+
+        // Wait to allow the published messages to propagate
+        await Task.Delay(5000);
+
+        // Receive all messages from the queue
+        var receivedMessages = new List<Message>();
+        for (var i = 0; i < 3; i++)
+        {
+            var receiveResponse = await _sqsClient.ReceiveMessageAsync(new ReceiveMessageRequest
+            {
+                QueueUrl = _sqsQueueUrl,
+                MaxNumberOfMessages = 10
+            });
+            receivedMessages.AddRange(receiveResponse.Messages);
+            if (receivedMessages.Count >= 4)
+                break;
+            await Task.Delay(1000);
+        }
+
+        Assert.Equal(4, receivedMessages.Count);
+
+        var envelopeSerializer = _serviceProvider.GetRequiredService<IEnvelopeSerializer>();
+        var messageDescriptions = new List<string>();
+        foreach (var receivedMessage in receivedMessages)
+        {
+            var result = await envelopeSerializer.ConvertToEnvelopeAsync(receivedMessage);
+            var envelope = result.Envelope as MessageEnvelope<ChatMessage>;
+            Assert.NotNull(envelope);
+            Assert.NotNull(envelope.Message);
+            messageDescriptions.Add(envelope.Message.MessageDescription);
+        }
+
+        // Verify all messages arrived
+        Assert.Contains("GroupA_Message1", messageDescriptions);
+        Assert.Contains("GroupA_Message2", messageDescriptions);
+        Assert.Contains("GroupB_Message1", messageDescriptions);
+        Assert.Contains("GroupB_Message2", messageDescriptions);
+    }
+
+    [Fact]
+    public async Task PublishMessageBatch_FifoQueue_WithoutMessageGroupId_ThrowsException()
+    {
+        var sqsPublisher = _serviceProvider.GetRequiredService<ISQSPublisher>();
+
+        var messages = new List<ChatMessage>
+        {
+            new() { MessageDescription = "ShouldFail" }
+        };
+
+        // Sending to a FIFO queue without MessageGroupId should throw
+        await Assert.ThrowsAsync<InvalidFifoPublishingRequestException>(
+            () => sqsPublisher.SendBatchAsync(messages));
+    }
+
+    public async Task DisposeAsync()
+    {
+        try
+        {
+            await _sqsClient.DeleteQueueAsync(_sqsQueueUrl);
+        }
+        catch { }
+    }
+}

--- a/test/AWS.Messaging.IntegrationTests/SQSBatchPublisherFifoTests.cs
+++ b/test/AWS.Messaging.IntegrationTests/SQSBatchPublisherFifoTests.cs
@@ -51,14 +51,13 @@ public class SQSBatchPublisherFifoTests : IAsyncLifetime
         var publishStartTime = DateTime.UtcNow;
         var sqsPublisher = _serviceProvider.GetRequiredService<ISQSPublisher>();
 
-        var messages = Enumerable.Range(1, 5)
-            .Select(i => new ChatMessage { MessageDescription = $"FifoBatchTest{i}" })
+        var entries = Enumerable.Range(1, 5)
+            .Select(i => new SQSBatchEntry<ChatMessage>(
+                new ChatMessage { MessageDescription = $"FifoBatchTest{i}" },
+                new SQSMessageOptions { MessageGroupId = "test-group" }))
             .ToList();
 
-        var batchResponse = await sqsPublisher.SendBatchAsync(messages, new SQSOptions
-        {
-            MessageGroupId = "test-group"
-        });
+        var batchResponse = await sqsPublisher.SendBatchAsync<ChatMessage>(entries);
         var publishEndTime = DateTime.UtcNow;
 
         // Verify the batch response
@@ -109,16 +108,16 @@ public class SQSBatchPublisherFifoTests : IAsyncLifetime
         var entries = new List<SQSBatchEntry<ChatMessage>>
         {
             new(new ChatMessage { MessageDescription = "GroupA_Message1" },
-                new SQSOptions { MessageGroupId = "groupA" }),
+                new SQSMessageOptions { MessageGroupId = "groupA" }),
             new(new ChatMessage { MessageDescription = "GroupA_Message2" },
-                new SQSOptions { MessageGroupId = "groupA" }),
+                new SQSMessageOptions { MessageGroupId = "groupA" }),
             new(new ChatMessage { MessageDescription = "GroupB_Message1" },
-                new SQSOptions { MessageGroupId = "groupB" }),
+                new SQSMessageOptions { MessageGroupId = "groupB" }),
             new(new ChatMessage { MessageDescription = "GroupB_Message2" },
-                new SQSOptions { MessageGroupId = "groupB" }),
+                new SQSMessageOptions { MessageGroupId = "groupB" }),
         };
 
-        var batchResponse = await sqsPublisher.SendBatchAsync(entries);
+        var batchResponse = await sqsPublisher.SendBatchAsync<ChatMessage>(entries);
 
         // Verify the batch response
         Assert.Equal(4, batchResponse.Successful.Count);

--- a/test/AWS.Messaging.IntegrationTests/SQSPublisherTests.cs
+++ b/test/AWS.Messaging.IntegrationTests/SQSPublisherTests.cs
@@ -1,12 +1,15 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 using Amazon.SQS;
+using Amazon.SQS.Model;
 using Microsoft.Extensions.DependencyInjection;
 using AWS.Messaging.IntegrationTests.Models;
 using System.Text.Json;
 using AWS.Messaging.IntegrationTests.Handlers;
+using AWS.Messaging.Publishers.SQS;
 using AWS.Messaging.Serialization;
 
 namespace AWS.Messaging.IntegrationTests;
@@ -78,6 +81,102 @@ public class SQSPublisherTests : IAsyncLifetime
         Assert.Equal("Test1", chatMessage.MessageDescription);
     }
 
+
+    [Fact]
+    public async Task PublishMessageBatch()
+    {
+        var publishStartTime = DateTime.UtcNow;
+        var sqsPublisher = _serviceProvider.GetRequiredService<ISQSPublisher>();
+
+        var messages = Enumerable.Range(1, 5)
+            .Select(i => new ChatMessage { MessageDescription = $"BatchTest{i}" })
+            .ToList();
+
+        var batchResponse = await sqsPublisher.SendBatchAsync(messages);
+        var publishEndTime = DateTime.UtcNow;
+
+        // Verify the batch response
+        Assert.Equal(5, batchResponse.Successful.Count);
+        Assert.Empty(batchResponse.Failed);
+        foreach (var entry in batchResponse.Successful)
+        {
+            Assert.False(string.IsNullOrEmpty(entry.MessageId));
+            Assert.False(string.IsNullOrEmpty(entry.Id));
+        }
+
+        // Wait to allow the published messages to propagate
+        await Task.Delay(5000);
+
+        // Receive all messages from the queue
+        var receivedMessages = new List<Message>();
+        for (var i = 0; i < 3; i++) // Multiple receive calls since SQS may not return all at once
+        {
+            var receiveResponse = await _sqsClient.ReceiveMessageAsync(new ReceiveMessageRequest
+            {
+                QueueUrl = _sqsQueueUrl,
+                MaxNumberOfMessages = 10
+            });
+            receivedMessages.AddRange(receiveResponse.Messages);
+            if (receivedMessages.Count >= 5)
+                break;
+            await Task.Delay(1000);
+        }
+
+        Assert.Equal(5, receivedMessages.Count);
+
+        var envelopeSerializer = _serviceProvider.GetRequiredService<IEnvelopeSerializer>();
+        for (var i = 0; i < receivedMessages.Count; i++)
+        {
+            var result = await envelopeSerializer.ConvertToEnvelopeAsync(receivedMessages[i]);
+            var envelope = result.Envelope as MessageEnvelope<ChatMessage>;
+
+            Assert.NotNull(envelope);
+            Assert.False(string.IsNullOrEmpty(envelope.Id));
+            Assert.Equal("/aws/messaging", envelope.Source.ToString());
+            Assert.True(envelope.TimeStamp > publishStartTime);
+            Assert.True(envelope.TimeStamp < publishEndTime);
+            Assert.Equal(typeof(ChatMessage).ToString(), envelope.MessageTypeIdentifier);
+            Assert.NotNull(envelope.Message);
+            Assert.StartsWith("BatchTest", envelope.Message.MessageDescription);
+        }
+    }
+
+    [Fact]
+    public async Task PublishMessageBatch_WithAutoChunking()
+    {
+        var sqsPublisher = _serviceProvider.GetRequiredService<ISQSPublisher>();
+
+        // Send 15 messages - should auto-chunk into 10 + 5
+        var messages = Enumerable.Range(1, 15)
+            .Select(i => new ChatMessage { MessageDescription = $"ChunkTest{i}" })
+            .ToList();
+
+        var batchResponse = await sqsPublisher.SendBatchAsync(messages);
+
+        // Verify the batch response has all 15 successful
+        Assert.Equal(15, batchResponse.Successful.Count);
+        Assert.Empty(batchResponse.Failed);
+
+        // Wait to allow the published messages to propagate
+        await Task.Delay(5000);
+
+        // Receive all messages from the queue. SQS may not return all messages in a single call
+        // (max 10 per request, and may return fewer), so we poll repeatedly.
+        var receivedMessages = new List<Message>();
+        var maxAttempts = 15;
+        for (var i = 0; i < maxAttempts && receivedMessages.Count < 15; i++)
+        {
+            var receiveResponse = await _sqsClient.ReceiveMessageAsync(new ReceiveMessageRequest
+            {
+                QueueUrl = _sqsQueueUrl,
+                MaxNumberOfMessages = 10,
+                WaitTimeSeconds = 5
+            });
+            receivedMessages.AddRange(receiveResponse.Messages);
+        }
+
+        Assert.Equal(15, receivedMessages.Count);
+    }
 
     public async Task DisposeAsync()
     {

--- a/test/AWS.Messaging.UnitTests/MessagePublisherTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessagePublisherTests.cs
@@ -1458,6 +1458,72 @@ public class MessagePublisherTests
     }
 
     [Fact]
+    public async Task SQSPublisher_SendBatch_PartialResultsOnChunkFailure()
+    {
+        var serviceProvider = SetupSQSPublisherDIServices();
+        var messagePublisher = SetupSQSPublisher(serviceProvider);
+
+        var callCount = 0;
+        _sqsClient.Setup(x =>
+            x.SendMessageBatchAsync(
+                It.IsAny<SendMessageBatchRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SendMessageBatchRequest req, CancellationToken _) =>
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    // First chunk succeeds
+                    return new SendMessageBatchResponse
+                    {
+                        Successful = req.Entries.Select(e => new SendMessageBatchResultEntry
+                        {
+                            Id = e.Id,
+                            MessageId = $"msg-{e.Id}"
+                        }).ToList(),
+                        Failed = new List<SQSBatchResultErrorEntry>()
+                    };
+                }
+                // Second chunk throws AmazonSQSException
+                throw new AmazonSQSException("Service unavailable");
+            });
+
+        // 15 messages = 2 chunks (10 + 5). First chunk will succeed, second will throw.
+        var messages = Enumerable.Range(1, 15)
+            .Select(i => new ChatMessage { MessageDescription = $"Message {i}" })
+            .ToList();
+
+        var ex = await Assert.ThrowsAsync<FailedToPublishBatchException>(
+            () => messagePublisher.SendBatchAsync(messages));
+
+        // Verify the exception carries partial results from the first successful chunk
+        Assert.NotNull(ex.PartialResponse);
+        Assert.Equal(10, ex.PartialResponse.Successful.Count);
+        Assert.Empty(ex.PartialResponse.Failed);
+        Assert.IsType<AmazonSQSException>(ex.InnerException);
+    }
+
+    [Fact]
+    public async Task SQSPublisher_SendBatch_NullMessagesCollectionThrowsException()
+    {
+        var serviceProvider = SetupSQSPublisherDIServices();
+        var messagePublisher = SetupSQSPublisher(serviceProvider);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => messagePublisher.SendBatchAsync((IEnumerable<ChatMessage>)null!));
+    }
+
+    [Fact]
+    public async Task SQSPublisher_SendBatch_NullEntriesCollectionThrowsException()
+    {
+        var serviceProvider = SetupSQSPublisherDIServices();
+        var messagePublisher = SetupSQSPublisher(serviceProvider);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => messagePublisher.SendBatchAsync((IEnumerable<SQSBatchEntry<ChatMessage>>)null!));
+    }
+
+    [Fact]
     public async Task PublishToFifoTopic_WithoutMessageGroupId_ThrowsException()
     {
         var serviceProvider = SetupSNSPublisherDIServices("endpoint.fifo");

--- a/test/AWS.Messaging.UnitTests/MessagePublisherTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessagePublisherTests.cs
@@ -1278,7 +1278,7 @@ public class MessagePublisherTests
     }
 
     [Fact]
-    public async Task SQSPublisher_SendBatch_FifoWithSharedMessageGroupId()
+    public async Task SQSPublisher_SendBatch_FifoWithPerEntryMessageGroupId()
     {
         var serviceProvider = SetupSQSPublisherDIServices("endpoint.fifo");
         var messagePublisher = SetupSQSPublisher(serviceProvider);
@@ -1297,16 +1297,15 @@ public class MessagePublisherTests
             Failed = new List<SQSBatchResultErrorEntry>()
         });
 
-        var messages = new List<ChatMessage>
+        var entries = new List<SQSBatchEntry<ChatMessage>>
         {
-            new() { MessageDescription = "Message 1" },
-            new() { MessageDescription = "Message 2" }
+            new(new ChatMessage { MessageDescription = "Message 1" },
+                new SQSMessageOptions { MessageGroupId = "group1" }),
+            new(new ChatMessage { MessageDescription = "Message 2" },
+                new SQSMessageOptions { MessageGroupId = "group1" })
         };
 
-        var result = await messagePublisher.SendBatchAsync(messages, new SQSOptions
-        {
-            MessageGroupId = "group1"
-        });
+        var result = await messagePublisher.SendBatchAsync<ChatMessage>(entries);
 
         Assert.Equal(2, result.Successful.Count);
         _sqsClient.Verify(x =>
@@ -1339,12 +1338,12 @@ public class MessagePublisherTests
         var entries = new List<SQSBatchEntry<ChatMessage>>
         {
             new(new ChatMessage { MessageDescription = "Message 1" },
-                new SQSOptions { MessageGroupId = "groupA" }),
+                new SQSMessageOptions { MessageGroupId = "groupA" }),
             new(new ChatMessage { MessageDescription = "Message 2" },
-                new SQSOptions { MessageGroupId = "groupB" })
+                new SQSMessageOptions { MessageGroupId = "groupB" })
         };
 
-        var result = await messagePublisher.SendBatchAsync(entries);
+        var result = await messagePublisher.SendBatchAsync<ChatMessage>(entries);
 
         Assert.Equal(2, result.Successful.Count);
 
@@ -1377,12 +1376,12 @@ public class MessagePublisherTests
             Failed = new List<SQSBatchResultErrorEntry>()
         });
 
-        var messages = new List<ChatMessage>
+        var entries = new List<SQSBatchEntry<ChatMessage>>
         {
-            new() { MessageDescription = "Message 1" }
+            new(new ChatMessage { MessageDescription = "Message 1" })
         };
 
-        var result = await messagePublisher.SendBatchAsync(messages, new SQSOptions
+        var result = await messagePublisher.SendBatchAsync(entries, new SQSBatchOptions
         {
             OverrideClient = overrideSQSClient.Object
         });
@@ -1422,12 +1421,12 @@ public class MessagePublisherTests
             Failed = new List<SQSBatchResultErrorEntry>()
         });
 
-        var messages = new List<ChatMessage>
+        var entries = new List<SQSBatchEntry<ChatMessage>>
         {
-            new() { MessageDescription = "Message 1" }
+            new(new ChatMessage { MessageDescription = "Message 1" })
         };
 
-        var result = await messagePublisher.SendBatchAsync(messages, new SQSOptions
+        var result = await messagePublisher.SendBatchAsync(entries, new SQSBatchOptions
         {
             QueueUrl = "overrideEndpoint"
         });
@@ -1454,7 +1453,7 @@ public class MessagePublisherTests
         };
 
         await Assert.ThrowsAsync<InvalidMessageException>(
-            () => messagePublisher.SendBatchAsync(entries));
+            () => messagePublisher.SendBatchAsync<ChatMessage>(entries));
     }
 
     [Fact]
@@ -1520,7 +1519,7 @@ public class MessagePublisherTests
         var messagePublisher = SetupSQSPublisher(serviceProvider);
 
         await Assert.ThrowsAsync<ArgumentNullException>(
-            () => messagePublisher.SendBatchAsync((IEnumerable<SQSBatchEntry<ChatMessage>>)null!));
+            () => messagePublisher.SendBatchAsync<ChatMessage>((IEnumerable<SQSBatchEntry<ChatMessage>>)null!));
     }
 
     [Fact]

--- a/test/AWS.Messaging.UnitTests/MessagePublisherTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessagePublisherTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using AWS.Messaging.Configuration;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -23,6 +24,7 @@ using AWS.Messaging.Telemetry;
 using Microsoft.Extensions.DependencyInjection;
 using AWS.Messaging.Publishers.SQS;
 using AWS.Messaging.Publishers.SNS;
+using SQSBatchResultErrorEntry = Amazon.SQS.Model.BatchResultErrorEntry;
 
 namespace AWS.Messaging.UnitTests;
 
@@ -1106,6 +1108,353 @@ public class MessagePublisherTests
 
         await Assert.ThrowsAsync<InvalidFifoPublishingRequestException>(() => messagePublisher.PublishAsync<ChatMessage?>(new ChatMessage()));
         await Assert.ThrowsAsync<InvalidFifoPublishingRequestException>(() => sqsMessagePublisher.SendAsync<ChatMessage?>(new ChatMessage(), new SQSOptions()));
+    }
+
+    [Fact]
+    public async Task SQSPublisher_SendBatch_HappyPath()
+    {
+        var serviceProvider = SetupSQSPublisherDIServices();
+        var messagePublisher = SetupSQSPublisher(serviceProvider);
+
+        _sqsClient.Setup(x =>
+            x.SendMessageBatchAsync(
+                It.Is<SendMessageBatchRequest>(request =>
+                    request.QueueUrl.Equals("endpoint") &&
+                    request.Entries.Count == 3),
+                It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageBatchResponse
+        {
+            Successful = new List<SendMessageBatchResultEntry>
+            {
+                new() { Id = "id1", MessageId = "msg1" },
+                new() { Id = "id2", MessageId = "msg2" },
+                new() { Id = "id3", MessageId = "msg3" }
+            },
+            Failed = new List<SQSBatchResultErrorEntry>()
+        });
+
+        var messages = new List<ChatMessage>
+        {
+            new() { MessageDescription = "Message 1" },
+            new() { MessageDescription = "Message 2" },
+            new() { MessageDescription = "Message 3" }
+        };
+
+        var result = await messagePublisher.SendBatchAsync(messages);
+
+        Assert.Equal(3, result.Successful.Count);
+        Assert.Empty(result.Failed);
+        _sqsClient.Verify(x =>
+            x.SendMessageBatchAsync(
+                It.IsAny<SendMessageBatchRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
+    }
+
+    [Fact]
+    public async Task SQSPublisher_SendBatch_PartialFailure()
+    {
+        var serviceProvider = SetupSQSPublisherDIServices();
+        var messagePublisher = SetupSQSPublisher(serviceProvider);
+
+        _sqsClient.Setup(x =>
+            x.SendMessageBatchAsync(
+                It.IsAny<SendMessageBatchRequest>(),
+                It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageBatchResponse
+        {
+            Successful = new List<SendMessageBatchResultEntry>
+            {
+                new() { Id = "id1", MessageId = "msg1" }
+            },
+            Failed = new List<SQSBatchResultErrorEntry>
+            {
+                new() { Id = "id2", Code = "InternalError", Message = "Something went wrong", SenderFault = false }
+            }
+        });
+
+        var messages = new List<ChatMessage>
+        {
+            new() { MessageDescription = "Message 1" },
+            new() { MessageDescription = "Message 2" }
+        };
+
+        var result = await messagePublisher.SendBatchAsync(messages);
+
+        Assert.Single(result.Successful);
+        Assert.Equal("msg1", result.Successful[0].MessageId);
+        Assert.Single(result.Failed);
+        Assert.Equal("InternalError", result.Failed[0].Code);
+        Assert.Equal("Something went wrong", result.Failed[0].Message);
+        Assert.False(result.Failed[0].SenderFault);
+    }
+
+    [Fact]
+    public async Task SQSPublisher_SendBatch_AutoChunking()
+    {
+        var serviceProvider = SetupSQSPublisherDIServices();
+        var messagePublisher = SetupSQSPublisher(serviceProvider);
+
+        // Set up to return success for any batch
+        _sqsClient.Setup(x =>
+            x.SendMessageBatchAsync(
+                It.IsAny<SendMessageBatchRequest>(),
+                It.IsAny<CancellationToken>())).ReturnsAsync((SendMessageBatchRequest req, CancellationToken _) =>
+            new SendMessageBatchResponse
+            {
+                Successful = req.Entries.Select(e => new SendMessageBatchResultEntry
+                {
+                    Id = e.Id,
+                    MessageId = $"msg-{e.Id}"
+                }).ToList(),
+                Failed = new List<SQSBatchResultErrorEntry>()
+            });
+
+        // 15 messages should result in 2 batch calls (10 + 5)
+        var messages = Enumerable.Range(1, 15)
+            .Select(i => new ChatMessage { MessageDescription = $"Message {i}" })
+            .ToList();
+
+        var result = await messagePublisher.SendBatchAsync(messages);
+
+        Assert.Equal(15, result.Successful.Count);
+        Assert.Empty(result.Failed);
+
+        // Verify we made exactly 2 batch calls
+        _sqsClient.Verify(x =>
+            x.SendMessageBatchAsync(
+                It.IsAny<SendMessageBatchRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+
+        // Verify first chunk had 10 entries
+        _sqsClient.Verify(x =>
+            x.SendMessageBatchAsync(
+                It.Is<SendMessageBatchRequest>(req => req.Entries.Count == 10),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
+
+        // Verify second chunk had 5 entries
+        _sqsClient.Verify(x =>
+            x.SendMessageBatchAsync(
+                It.Is<SendMessageBatchRequest>(req => req.Entries.Count == 5),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
+    }
+
+    [Fact]
+    public async Task SQSPublisher_SendBatch_EmptyList()
+    {
+        var serviceProvider = SetupSQSPublisherDIServices();
+        var messagePublisher = SetupSQSPublisher(serviceProvider);
+
+        var messages = new List<ChatMessage>();
+
+        var result = await messagePublisher.SendBatchAsync(messages);
+
+        Assert.Empty(result.Successful);
+        Assert.Empty(result.Failed);
+
+        // Verify no SQS calls were made
+        _sqsClient.Verify(x =>
+            x.SendMessageBatchAsync(
+                It.IsAny<SendMessageBatchRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never());
+    }
+
+    [Fact]
+    public async Task SQSPublisher_SendBatch_FifoValidation()
+    {
+        var serviceProvider = SetupSQSPublisherDIServices("endpoint.fifo");
+        var messagePublisher = SetupSQSPublisher(serviceProvider);
+
+        var messages = new List<ChatMessage>
+        {
+            new() { MessageDescription = "Message 1" }
+        };
+
+        // No MessageGroupId should throw
+        await Assert.ThrowsAsync<InvalidFifoPublishingRequestException>(
+            () => messagePublisher.SendBatchAsync(messages));
+    }
+
+    [Fact]
+    public async Task SQSPublisher_SendBatch_FifoWithSharedMessageGroupId()
+    {
+        var serviceProvider = SetupSQSPublisherDIServices("endpoint.fifo");
+        var messagePublisher = SetupSQSPublisher(serviceProvider);
+
+        _sqsClient.Setup(x =>
+            x.SendMessageBatchAsync(
+                It.Is<SendMessageBatchRequest>(req =>
+                    req.Entries.All(e => e.MessageGroupId == "group1")),
+                It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageBatchResponse
+        {
+            Successful = new List<SendMessageBatchResultEntry>
+            {
+                new() { Id = "id1", MessageId = "msg1" },
+                new() { Id = "id2", MessageId = "msg2" }
+            },
+            Failed = new List<SQSBatchResultErrorEntry>()
+        });
+
+        var messages = new List<ChatMessage>
+        {
+            new() { MessageDescription = "Message 1" },
+            new() { MessageDescription = "Message 2" }
+        };
+
+        var result = await messagePublisher.SendBatchAsync(messages, new SQSOptions
+        {
+            MessageGroupId = "group1"
+        });
+
+        Assert.Equal(2, result.Successful.Count);
+        _sqsClient.Verify(x =>
+            x.SendMessageBatchAsync(
+                It.Is<SendMessageBatchRequest>(req =>
+                    req.Entries.All(e => e.MessageGroupId == "group1")),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
+    }
+
+    [Fact]
+    public async Task SQSPublisher_SendBatch_PerMessageOptions()
+    {
+        var serviceProvider = SetupSQSPublisherDIServices("endpoint.fifo");
+        var messagePublisher = SetupSQSPublisher(serviceProvider);
+
+        _sqsClient.Setup(x =>
+            x.SendMessageBatchAsync(
+                It.IsAny<SendMessageBatchRequest>(),
+                It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageBatchResponse
+        {
+            Successful = new List<SendMessageBatchResultEntry>
+            {
+                new() { Id = "id1", MessageId = "msg1" },
+                new() { Id = "id2", MessageId = "msg2" }
+            },
+            Failed = new List<SQSBatchResultErrorEntry>()
+        });
+
+        var entries = new List<SQSBatchEntry<ChatMessage>>
+        {
+            new(new ChatMessage { MessageDescription = "Message 1" },
+                new SQSOptions { MessageGroupId = "groupA" }),
+            new(new ChatMessage { MessageDescription = "Message 2" },
+                new SQSOptions { MessageGroupId = "groupB" })
+        };
+
+        var result = await messagePublisher.SendBatchAsync(entries);
+
+        Assert.Equal(2, result.Successful.Count);
+
+        // Verify entries had different message group IDs
+        _sqsClient.Verify(x =>
+            x.SendMessageBatchAsync(
+                It.Is<SendMessageBatchRequest>(req =>
+                    req.Entries.Any(e => e.MessageGroupId == "groupA") &&
+                    req.Entries.Any(e => e.MessageGroupId == "groupB")),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
+    }
+
+    [Fact]
+    public async Task SQSPublisher_SendBatch_OverrideClient()
+    {
+        var serviceProvider = SetupSQSPublisherDIServices();
+        var messagePublisher = SetupSQSPublisher(serviceProvider);
+
+        var overrideSQSClient = new Mock<IAmazonSQS>();
+        overrideSQSClient.Setup(x =>
+            x.SendMessageBatchAsync(
+                It.IsAny<SendMessageBatchRequest>(),
+                It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageBatchResponse
+        {
+            Successful = new List<SendMessageBatchResultEntry>
+            {
+                new() { Id = "id1", MessageId = "msg1" }
+            },
+            Failed = new List<SQSBatchResultErrorEntry>()
+        });
+
+        var messages = new List<ChatMessage>
+        {
+            new() { MessageDescription = "Message 1" }
+        };
+
+        var result = await messagePublisher.SendBatchAsync(messages, new SQSOptions
+        {
+            OverrideClient = overrideSQSClient.Object
+        });
+
+        Assert.Single(result.Successful);
+
+        // Assert that the override client was invoked
+        overrideSQSClient.Verify(x =>
+            x.SendMessageBatchAsync(
+                It.IsAny<SendMessageBatchRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
+
+        // And not the default client
+        _sqsClient.Verify(x =>
+            x.SendMessageBatchAsync(
+                It.IsAny<SendMessageBatchRequest>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never());
+    }
+
+    [Fact]
+    public async Task SQSPublisher_SendBatch_MessageSpecificQueueUrl()
+    {
+        var serviceProvider = SetupSQSPublisherDIServices();
+        var messagePublisher = SetupSQSPublisher(serviceProvider);
+
+        _sqsClient.Setup(x =>
+            x.SendMessageBatchAsync(
+                It.Is<SendMessageBatchRequest>(req => req.QueueUrl.Equals("overrideEndpoint")),
+                It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageBatchResponse
+        {
+            Successful = new List<SendMessageBatchResultEntry>
+            {
+                new() { Id = "id1", MessageId = "msg1" }
+            },
+            Failed = new List<SQSBatchResultErrorEntry>()
+        });
+
+        var messages = new List<ChatMessage>
+        {
+            new() { MessageDescription = "Message 1" }
+        };
+
+        var result = await messagePublisher.SendBatchAsync(messages, new SQSOptions
+        {
+            QueueUrl = "overrideEndpoint"
+        });
+
+        Assert.Single(result.Successful);
+
+        _sqsClient.Verify(x =>
+            x.SendMessageBatchAsync(
+                It.Is<SendMessageBatchRequest>(req => req.QueueUrl.Equals("overrideEndpoint")),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
+    }
+
+    [Fact]
+    public async Task SQSPublisher_SendBatch_NullMessageThrowsException()
+    {
+        var serviceProvider = SetupSQSPublisherDIServices();
+        var messagePublisher = SetupSQSPublisher(serviceProvider);
+
+        var entries = new List<SQSBatchEntry<ChatMessage>>
+        {
+            new(new ChatMessage { MessageDescription = "Valid" }),
+            new() { Message = null! }
+        };
+
+        await Assert.ThrowsAsync<InvalidMessageException>(
+            () => messagePublisher.SendBatchAsync(entries));
     }
 
     [Fact]


### PR DESCRIPTION
*Issue #, if available:* #296

*Description of changes:*

Adds SQS `SendMessageBatch` support to `ISQSPublisher`, enabling batch publishing of messages for significantly higher throughput (up to 3,000 messages/second vs 300 with individual sends).

**New API surface:**
- `ISQSPublisher.SendBatchAsync<T>(IEnumerable<T>, CancellationToken)` — simple overload for standard queues where no per-message options are needed
- `ISQSPublisher.SendBatchAsync<T>(IEnumerable<SQSBatchEntry<T>>, SQSBatchOptions?, CancellationToken)` — advanced overload with per-message `SQSMessageOptions` and optional batch-level `SQSBatchOptions`

**How options work:**

Batch publishing splits options into purpose-specific types to prevent misuse:

- `SQSMessageOptions` — per-message properties (`MessageGroupId`, `MessageDeduplicationId`, `DelaySeconds`, `MessageAttributes`). Set on each `SQSBatchEntry<T>.Options`. Every property is always relevant in this context.
- `SQSBatchOptions` — batch-level properties (`QueueUrl`, `OverrideClient`). Passed to the `SendBatchAsync` method. These apply to the entire batch request.

The existing `SQSOptions` class remains unchanged and is still used by the single-message `SendAsync<T>(message, sqsOptions)` where all properties make sense together.

Messages are automatically chunked into groups of 10 (the SQS max per batch call) and results are aggregated into a single `SQSSendBatchResponse`.

**New types:**
- `SQSMessageOptions` — per-message properties for batch entries
- `SQSBatchOptions` — batch-level properties (queue URL, client override)
- `SQSBatchEntry<T>` — pairs a message with optional per-message `SQSMessageOptions`
- `SQSSendBatchResponse`, `SQSSendBatchResponseEntry`, `SQSSendBatchResponseFailedEntry` — batch response models

**Tests:**
- 13 unit tests and 5 integration tests covering batch send, auto-chunking, partial failures, FIFO validation, per-message options, client/queue overrides, and edge cases

**Documentation:**
- Updated README with "Batch publishing to SQS" section with code examples
- Added `sqs:sendmessagebatch` to the Permissions section

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
