### PR TITLE
Add ISerializationCallback<T> for type-specific serialization callbacks

### DIFF
--- a/.autover/changes/8182ce75-83d8-465c-b65c-d29f7b731729.json
+++ b/.autover/changes/8182ce75-83d8-465c-b65c-d29f7b731729.json
@@ -4,7 +4,7 @@
       "Name": "AWS.Messaging",
       "Type": "Minor",
       "ChangelogMessages": [
-        "Added generic PreSerializationAsync\u003CT\u003E(MessageEnvelope\u003CT\u003E) overload to ISerializationCallback, allowing typed access to the message payload during pre-serialization callbacks. This enables extracting values from the message to set as CloudEvents extension attributes (e.g., subject)."
+        "Added ISerializationCallback\u003CT\u003E generic interface for type-specific serialization callbacks. Callbacks registered via AddSerializationCallback\u003CTCallback, TMessage\u003E() are only invoked when the message type matches, providing direct typed access to the message payload with zero casting. Also fixed ArgumentNullException constructor usage in EnvelopeSerializer."
       ]
     }
   ]

--- a/.autover/changes/8182ce75-83d8-465c-b65c-d29f7b731729.json
+++ b/.autover/changes/8182ce75-83d8-465c-b65c-d29f7b731729.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Added generic PreSerializationAsync\u003CT\u003E(MessageEnvelope\u003CT\u003E) overload to ISerializationCallback, allowing typed access to the message payload during pre-serialization callbacks. This enables extracting values from the message to set as CloudEvents extension attributes (e.g., subject)."
+      ]
+    }
+  ]
+}

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -92,6 +92,16 @@ public interface IMessageBusBuilder
     IMessageBusBuilder AddSerializationCallback(ISerializationCallback serializationCallback);
 
     /// <summary>
+    /// Adds a type-specific serialization callback that is only invoked when the message being
+    /// serialized matches <typeparamref name="TMessage"/>. This provides direct typed access to
+    /// the message payload without requiring any casting.
+    /// </summary>
+    /// <typeparam name="TCallback">The callback implementation type.</typeparam>
+    /// <typeparam name="TMessage">The message type this callback handles.</typeparam>
+    IMessageBusBuilder AddSerializationCallback<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TCallback, TMessage>()
+        where TCallback : class, ISerializationCallback<TMessage>;
+
+    /// <summary>
     /// Adds a global message source to the message bus.
     /// This source will be added to the message envelope of all the messages sent through the framework.
     /// </summary>

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -185,6 +185,14 @@ public class MessageBusBuilder : IMessageBusBuilder
     }
 
     /// <inheritdoc/>
+    public IMessageBusBuilder AddSerializationCallback<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TCallback, TMessage>()
+        where TCallback : class, ISerializationCallback<TMessage>
+    {
+        _serviceCollection.AddSingleton<ISerializationCallback<TMessage>, TCallback>();
+        return this;
+    }
+
+    /// <inheritdoc/>
     public IMessageBusBuilder AddMessageSource(string messageSource)
     {
         _messageConfiguration.Source = messageSource;

--- a/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
+++ b/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
@@ -91,7 +91,7 @@ internal class EnvelopeSerializer : IEnvelopeSerializer
     {
         try
         {
-            await InvokePreSerializationCallback(envelope);
+            await InvokePreSerializationCallback<T>(envelope);
             var message = envelope.Message ?? throw new ArgumentNullException("The underlying application message cannot be null");
 
             // This blob serves as an intermediate data container because the underlying application message
@@ -410,7 +410,7 @@ internal class EnvelopeSerializer : IEnvelopeSerializer
         return subscriberMapping;
     }
 
-    private async ValueTask InvokePreSerializationCallback(MessageEnvelope messageEnvelope)
+    private async ValueTask InvokePreSerializationCallback<T>(MessageEnvelope<T> messageEnvelope)
     {
         foreach (var serializationCallback in _messageConfiguration.SerializationCallbacks)
         {

--- a/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
+++ b/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
@@ -11,6 +11,7 @@ using AWS.Messaging.Services;
 using Microsoft.Extensions.Logging;
 using AWS.Messaging.Serialization.Parsers;
 using System.Collections.Frozen;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace AWS.Messaging.Serialization;
 
@@ -26,6 +27,7 @@ internal class EnvelopeSerializer : IEnvelopeSerializer
     private readonly IDateTimeHandler _dateTimeHandler;
     private readonly IMessageIdGenerator _messageIdGenerator;
     private readonly IMessageSourceHandler _messageSourceHandler;
+    private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<EnvelopeSerializer> _logger;
 
     // Order matters for the SQS parser (must be last), but SNS and EventBridge parsers
@@ -43,7 +45,8 @@ internal class EnvelopeSerializer : IEnvelopeSerializer
         IMessageSerializer messageSerializer,
         IDateTimeHandler dateTimeHandler,
         IMessageIdGenerator messageIdGenerator,
-        IMessageSourceHandler messageSourceHandler)
+        IMessageSourceHandler messageSourceHandler,
+        IServiceProvider serviceProvider)
     {
         _logger = logger;
         _messageConfiguration = messageConfiguration;
@@ -51,6 +54,7 @@ internal class EnvelopeSerializer : IEnvelopeSerializer
         _dateTimeHandler = dateTimeHandler;
         _messageIdGenerator = messageIdGenerator;
         _messageSourceHandler = messageSourceHandler;
+        _serviceProvider = serviceProvider;
     }
 
     /// <inheritdoc/>
@@ -91,8 +95,9 @@ internal class EnvelopeSerializer : IEnvelopeSerializer
     {
         try
         {
-            await InvokePreSerializationCallback<T>(envelope);
-            var message = envelope.Message ?? throw new ArgumentNullException("The underlying application message cannot be null");
+            await InvokePreSerializationCallback(envelope);
+            await InvokeTypedPreSerializationCallbacks(envelope);
+            var message = envelope.Message ?? throw new ArgumentNullException(nameof(envelope.Message), "The underlying application message cannot be null");
 
             // This blob serves as an intermediate data container because the underlying application message
             // must be serialized separately as the _messageSerializer can have a user injected implementation.
@@ -410,11 +415,20 @@ internal class EnvelopeSerializer : IEnvelopeSerializer
         return subscriberMapping;
     }
 
-    private async ValueTask InvokePreSerializationCallback<T>(MessageEnvelope<T> messageEnvelope)
+    private async ValueTask InvokePreSerializationCallback(MessageEnvelope messageEnvelope)
     {
         foreach (var serializationCallback in _messageConfiguration.SerializationCallbacks)
         {
             await serializationCallback.PreSerializationAsync(messageEnvelope);
+        }
+    }
+
+    private async ValueTask InvokeTypedPreSerializationCallbacks<T>(MessageEnvelope<T> messageEnvelope)
+    {
+        var typedCallbacks = _serviceProvider.GetServices<ISerializationCallback<T>>();
+        foreach (var callback in typedCallbacks)
+        {
+            await callback.PreSerializationAsync(messageEnvelope);
         }
     }
 

--- a/src/AWS.Messaging/Serialization/ISerializationCallback.cs
+++ b/src/AWS.Messaging/Serialization/ISerializationCallback.cs
@@ -19,19 +19,6 @@ namespace AWS.Messaging.Serialization
         }
 
         /// <summary>
-        /// This can be used to set additional metadata to the message envelope before it is serialized and published to an endpoint.
-        /// Unlike the non-generic <see cref="PreSerializationAsync(MessageEnvelope)"/>, this overload provides access to the
-        /// typed <see cref="MessageEnvelope{T}"/>, allowing direct access to the message payload via <see cref="MessageEnvelope{T}.Message"/>.
-        /// This is useful for extracting values from the message to set as envelope metadata (e.g., CloudEvents extension attributes like <c>subject</c>).
-        /// </summary>
-        /// <typeparam name="T">The .NET type of the underlying application message.</typeparam>
-        /// <param name="messageEnvelope">The typed message envelope containing the application message and CloudEvents metadata.</param>
-        ValueTask PreSerializationAsync<T>(MessageEnvelope<T> messageEnvelope)
-        {
-            return PreSerializationAsync((MessageEnvelope)messageEnvelope);
-        }
-
-        /// <summary>
         /// This can be used to encrypt or modify the serialized message envelope before publishing it to an endpoint.
         /// </summary>
         /// <param name="message">The serialized message envelope</param>

--- a/src/AWS.Messaging/Serialization/ISerializationCallback.cs
+++ b/src/AWS.Messaging/Serialization/ISerializationCallback.cs
@@ -19,6 +19,19 @@ namespace AWS.Messaging.Serialization
         }
 
         /// <summary>
+        /// This can be used to set additional metadata to the message envelope before it is serialized and published to an endpoint.
+        /// Unlike the non-generic <see cref="PreSerializationAsync(MessageEnvelope)"/>, this overload provides access to the
+        /// typed <see cref="MessageEnvelope{T}"/>, allowing direct access to the message payload via <see cref="MessageEnvelope{T}.Message"/>.
+        /// This is useful for extracting values from the message to set as envelope metadata (e.g., CloudEvents extension attributes like <c>subject</c>).
+        /// </summary>
+        /// <typeparam name="T">The .NET type of the underlying application message.</typeparam>
+        /// <param name="messageEnvelope">The typed message envelope containing the application message and CloudEvents metadata.</param>
+        ValueTask PreSerializationAsync<T>(MessageEnvelope<T> messageEnvelope)
+        {
+            return PreSerializationAsync((MessageEnvelope)messageEnvelope);
+        }
+
+        /// <summary>
         /// This can be used to encrypt or modify the serialized message envelope before publishing it to an endpoint.
         /// </summary>
         /// <param name="message">The serialized message envelope</param>

--- a/src/AWS.Messaging/Serialization/ISerializationCallback{T}.cs
+++ b/src/AWS.Messaging/Serialization/ISerializationCallback{T}.cs
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Serialization
+{
+    /// <summary>
+    /// A type-specific serialization callback that is only invoked when the message being serialized
+    /// matches the type <typeparamref name="T"/>. This provides direct typed access to the message payload
+    /// via <see cref="MessageEnvelope{T}.Message"/> without requiring any casting.
+    /// <para/>
+    /// This is useful for extracting values from the message to set as envelope metadata,
+    /// such as CloudEvents extension attributes like <c>subject</c>.
+    /// <para/>
+    /// For cross-cutting concerns that apply to all message types (e.g., encryption, logging),
+    /// use the non-generic <see cref="ISerializationCallback"/> instead.
+    /// </summary>
+    /// <typeparam name="T">The .NET type of the message this callback handles.</typeparam>
+    public interface ISerializationCallback<T>
+    {
+        /// <summary>
+        /// This is invoked before the message envelope is serialized and published to an endpoint.
+        /// It is only called when the message type matches <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="messageEnvelope">The typed message envelope containing the application message and CloudEvents metadata.</param>
+        ValueTask PreSerializationAsync(MessageEnvelope<T> messageEnvelope);
+    }
+}

--- a/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
@@ -437,7 +437,8 @@ public class EnvelopeSerializerTests
         var dateTimeHandler = new Mock<IDateTimeHandler>();
         var messageIdGenerator = new Mock<IMessageIdGenerator>();
         var messageSourceHandler = new Mock<IMessageSourceHandler>();
-        var envelopeSerializer = new EnvelopeSerializer(logger.Object, messageConfiguration, messageSerializer.Object, dateTimeHandler.Object, messageIdGenerator.Object, messageSourceHandler.Object);
+        var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var envelopeSerializer = new EnvelopeSerializer(logger.Object, messageConfiguration, messageSerializer.Object, dateTimeHandler.Object, messageIdGenerator.Object, messageSourceHandler.Object, serviceProvider);
         var messageEnvelope = new MessageEnvelope<AddressInfo>
         {
             Id = "123",
@@ -512,7 +513,8 @@ public class EnvelopeSerializerTests
             messageSerializer.Object,
             dateTimeHandler.Object,
             messageIdGenerator.Object,
-            messageSourceHandler.Object);
+            messageSourceHandler.Object,
+            serviceProvider);
 
         var messageEnvelope = new MessageEnvelope<AddressInfo>
         {
@@ -573,13 +575,15 @@ public class EnvelopeSerializerTests
         var dateTimeHandler = new Mock<IDateTimeHandler>();
         var messageIdGenerator = new Mock<IMessageIdGenerator>();
         var messageSourceHandler = new Mock<IMessageSourceHandler>();
+        var serviceProvider = new ServiceCollection().BuildServiceProvider();
         var envelopeSerializer = new EnvelopeSerializer(
             logger.Object,
             messageConfiguration,
             messageSerializer.Object,
             dateTimeHandler.Object,
             messageIdGenerator.Object,
-            messageSourceHandler.Object);
+            messageSourceHandler.Object,
+            serviceProvider);
 
         // Create an SQS message with invalid JSON that will cause JsonDocument.Parse to fail
         var sqsMessage = new Message
@@ -755,7 +759,7 @@ public class EnvelopeSerializerTests
         var dateTimeHandler = new Mock<IDateTimeHandler>();
         var messageIdGenerator = new Mock<IMessageIdGenerator>();
         var messageSourceHandler = new Mock<IMessageSourceHandler>();
-        var envelopeSerializer = new EnvelopeSerializer(logger.Object, messageConfiguration, messageSerializer.Object, dateTimeHandler.Object, messageIdGenerator.Object, messageSourceHandler.Object);
+        var envelopeSerializer = new EnvelopeSerializer(logger.Object, messageConfiguration, messageSerializer.Object, dateTimeHandler.Object, messageIdGenerator.Object, messageSourceHandler.Object, serviceProvider);
         var plainTextContent = "Hello, this is plain text content";
         var messageEnvelope = new MessageEnvelope<string>
         {
@@ -800,14 +804,15 @@ public class EnvelopeSerializerTests
     }
 
     [Fact]
-    public async Task GenericSerializationCallback_ExtractsSubjectFromTypedMessage()
+    public async Task TypedSerializationCallback_ExtractsSubjectWithZeroCasting()
     {
-        // ARRANGE
+        // ARRANGE — Register a typed ISerializationCallback<AddressInfo> via DI.
+        // The callback has direct typed access to the message with no casting required.
         _serviceCollection.AddAWSMessageBus(builder =>
         {
             builder.AddSQSPublisher<AddressInfo>("sqsQueueUrl", "addressInfo");
             builder.AddMessageHandler<AddressInfoHandler, AddressInfo>("addressInfo");
-            builder.AddSerializationCallback(new GenericSerializationCallback());
+            builder.AddSerializationCallback<AddressInfoSubjectCallback, AddressInfo>();
         });
         var serviceProvider = _serviceCollection.BuildServiceProvider();
         var envelopeSerializer = serviceProvider.GetRequiredService<IEnvelopeSerializer>();
@@ -836,40 +841,36 @@ public class EnvelopeSerializerTests
     }
 
     [Fact]
-    public async Task NonGenericSerializationCallback_StillWorksViaDefaultGenericDelegation()
+    public async Task TypedSerializationCallback_NotInvokedForNonMatchingType()
     {
-        // ARRANGE - Register a callback that only overrides the non-generic PreSerializationAsync.
-        // The default generic method should delegate to it.
+        // ARRANGE — Register a typed callback for AddressInfo, but serialize a ChatMessage.
+        // The callback should NOT be invoked because the type doesn't match.
         _serviceCollection.AddAWSMessageBus(builder =>
         {
-            builder.AddSQSPublisher<AddressInfo>("sqsQueueUrl", "addressInfo");
-            builder.AddMessageHandler<AddressInfoHandler, AddressInfo>("addressInfo");
-            builder.AddSerializationCallback(new NonGenericOnlySerializationCallback());
+            builder.AddSQSPublisher<ChatMessage>("sqsQueueUrl", "chatMessage");
+            builder.AddSerializationCallback<AddressInfoSubjectCallback, AddressInfo>();
         });
         var serviceProvider = _serviceCollection.BuildServiceProvider();
         var envelopeSerializer = serviceProvider.GetRequiredService<IEnvelopeSerializer>();
-        var messageEnvelope = new MessageEnvelope<AddressInfo>
+        var messageEnvelope = new MessageEnvelope<ChatMessage>
         {
             Id = "456",
             Source = new Uri("/aws/messaging", UriKind.Relative),
             Version = "1.0",
-            MessageTypeIdentifier = "addressInfo",
+            MessageTypeIdentifier = "chatMessage",
             TimeStamp = _testdate,
-            Message = new AddressInfo
+            Message = new ChatMessage
             {
-                Street = "Main St",
-                Unit = 1,
-                ZipCode = "99999"
+                MessageDescription = "Hello"
             }
         };
 
         // ACT
         var serializedMessage = await envelopeSerializer.SerializeAsync(messageEnvelope);
 
-        // ASSERT - Verify the non-generic callback was invoked via the default generic delegation
+        // ASSERT - Verify the "subject" key is NOT present since the callback is for AddressInfo, not ChatMessage
         var jsonDoc = JsonDocument.Parse(serializedMessage);
-        Assert.True(jsonDoc.RootElement.TryGetProperty("callback-type", out var callbackTypeElement));
-        Assert.Equal("non-generic", callbackTypeElement.GetString());
+        Assert.False(jsonDoc.RootElement.TryGetProperty("subject", out _));
     }
 
     [Fact]
@@ -985,31 +986,17 @@ public class MockSerializationCallback : ISerializationCallback
 }
 
 /// <summary>
-/// A serialization callback that uses the generic <see cref="ISerializationCallback.PreSerializationAsync{T}"/>
-/// to extract a subject from the typed message payload and set it as envelope metadata.
+/// A type-specific serialization callback that implements <see cref="ISerializationCallback{T}"/>
+/// for <see cref="AddressInfo"/>. It extracts the ZipCode as a "subject" CloudEvents extension attribute.
+/// No casting is required — the callback receives direct typed access to the message.
 /// This demonstrates the use case from GitHub discussion #317.
 /// </summary>
-public class GenericSerializationCallback : ISerializationCallback
+public class AddressInfoSubjectCallback : ISerializationCallback<AddressInfo>
 {
-    public ValueTask PreSerializationAsync<T>(MessageEnvelope<T> messageEnvelope)
+    public ValueTask PreSerializationAsync(MessageEnvelope<AddressInfo> messageEnvelope)
     {
-        if (messageEnvelope.Message is AddressInfo addressInfo)
-        {
-            messageEnvelope.Metadata["subject"] = JsonSerializer.SerializeToElement(addressInfo.ZipCode);
-        }
-        return ValueTask.CompletedTask;
-    }
-}
-
-/// <summary>
-/// A serialization callback that only overrides the non-generic <see cref="ISerializationCallback.PreSerializationAsync(MessageEnvelope)"/>.
-/// This verifies backward compatibility: the default generic method delegates to the non-generic one.
-/// </summary>
-public class NonGenericOnlySerializationCallback : ISerializationCallback
-{
-    public ValueTask PreSerializationAsync(MessageEnvelope messageEnvelope)
-    {
-        messageEnvelope.Metadata["callback-type"] = JsonSerializer.SerializeToElement("non-generic");
+        // Zero casting — direct typed access to the message payload
+        messageEnvelope.Metadata["subject"] = JsonSerializer.SerializeToElement(messageEnvelope.Message.ZipCode);
         return ValueTask.CompletedTask;
     }
 }

--- a/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
@@ -800,6 +800,79 @@ public class EnvelopeSerializerTests
     }
 
     [Fact]
+    public async Task GenericSerializationCallback_ExtractsSubjectFromTypedMessage()
+    {
+        // ARRANGE
+        _serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPublisher<AddressInfo>("sqsQueueUrl", "addressInfo");
+            builder.AddMessageHandler<AddressInfoHandler, AddressInfo>("addressInfo");
+            builder.AddSerializationCallback(new GenericSerializationCallback());
+        });
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+        var envelopeSerializer = serviceProvider.GetRequiredService<IEnvelopeSerializer>();
+        var messageEnvelope = new MessageEnvelope<AddressInfo>
+        {
+            Id = "123",
+            Source = new Uri("/aws/messaging", UriKind.Relative),
+            Version = "1.0",
+            MessageTypeIdentifier = "addressInfo",
+            TimeStamp = _testdate,
+            Message = new AddressInfo
+            {
+                Street = "Prince St",
+                Unit = 123,
+                ZipCode = "00001"
+            }
+        };
+
+        // ACT
+        var serializedMessage = await envelopeSerializer.SerializeAsync(messageEnvelope);
+
+        // ASSERT - Verify the serialized output contains the "subject" key extracted from the message payload
+        var jsonDoc = JsonDocument.Parse(serializedMessage);
+        Assert.True(jsonDoc.RootElement.TryGetProperty("subject", out var subjectElement));
+        Assert.Equal("00001", subjectElement.GetString());
+    }
+
+    [Fact]
+    public async Task NonGenericSerializationCallback_StillWorksViaDefaultGenericDelegation()
+    {
+        // ARRANGE - Register a callback that only overrides the non-generic PreSerializationAsync.
+        // The default generic method should delegate to it.
+        _serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPublisher<AddressInfo>("sqsQueueUrl", "addressInfo");
+            builder.AddMessageHandler<AddressInfoHandler, AddressInfo>("addressInfo");
+            builder.AddSerializationCallback(new NonGenericOnlySerializationCallback());
+        });
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+        var envelopeSerializer = serviceProvider.GetRequiredService<IEnvelopeSerializer>();
+        var messageEnvelope = new MessageEnvelope<AddressInfo>
+        {
+            Id = "456",
+            Source = new Uri("/aws/messaging", UriKind.Relative),
+            Version = "1.0",
+            MessageTypeIdentifier = "addressInfo",
+            TimeStamp = _testdate,
+            Message = new AddressInfo
+            {
+                Street = "Main St",
+                Unit = 1,
+                ZipCode = "99999"
+            }
+        };
+
+        // ACT
+        var serializedMessage = await envelopeSerializer.SerializeAsync(messageEnvelope);
+
+        // ASSERT - Verify the non-generic callback was invoked via the default generic delegation
+        var jsonDoc = JsonDocument.Parse(serializedMessage);
+        Assert.True(jsonDoc.RootElement.TryGetProperty("callback-type", out var callbackTypeElement));
+        Assert.Equal("non-generic", callbackTypeElement.GetString());
+    }
+
+    [Fact]
     public async Task ConvertToEnvelope_WithCustomJsonContentType()
     {
         // ARRANGE
@@ -907,6 +980,36 @@ public class MockSerializationCallback : ISerializationCallback
     public ValueTask PostDeserializationAsync(MessageEnvelope messageEnvelope)
     {
         messageEnvelope.Metadata["Is-Delivered"] = JsonSerializer.SerializeToElement(true);
+        return ValueTask.CompletedTask;
+    }
+}
+
+/// <summary>
+/// A serialization callback that uses the generic <see cref="ISerializationCallback.PreSerializationAsync{T}"/>
+/// to extract a subject from the typed message payload and set it as envelope metadata.
+/// This demonstrates the use case from GitHub discussion #317.
+/// </summary>
+public class GenericSerializationCallback : ISerializationCallback
+{
+    public ValueTask PreSerializationAsync<T>(MessageEnvelope<T> messageEnvelope)
+    {
+        if (messageEnvelope.Message is AddressInfo addressInfo)
+        {
+            messageEnvelope.Metadata["subject"] = JsonSerializer.SerializeToElement(addressInfo.ZipCode);
+        }
+        return ValueTask.CompletedTask;
+    }
+}
+
+/// <summary>
+/// A serialization callback that only overrides the non-generic <see cref="ISerializationCallback.PreSerializationAsync(MessageEnvelope)"/>.
+/// This verifies backward compatibility: the default generic method delegates to the non-generic one.
+/// </summary>
+public class NonGenericOnlySerializationCallback : ISerializationCallback
+{
+    public ValueTask PreSerializationAsync(MessageEnvelope messageEnvelope)
+    {
+        messageEnvelope.Metadata["callback-type"] = JsonSerializer.SerializeToElement("non-generic");
         return ValueTask.CompletedTask;
     }
 }


### PR DESCRIPTION
## Description

Adds a new `ISerializationCallback<T>` generic interface for type-specific serialization callbacks. Callbacks are only invoked when the message being serialized matches `T`, providing **direct typed access to the message payload with zero casting required**. This addresses the challenge described in [Discussion #317](https://github.com/aws/aws-dotnet-messaging/discussions/317).

Also fixes `ArgumentNullException` constructor misuse in `EnvelopeSerializer` where the error message was passed as `paramName`.

### Problem

Users want to set CloudEvents extension attributes (like `subject`) by extracting values from the message payload. The existing `ISerializationCallback.PreSerializationAsync(MessageEnvelope)` only provides the abstract `MessageEnvelope`, forcing users to cast:

```csharp
// Before — user must cast to access the message
public class MyCallback : ISerializationCallback
{
    public ValueTask PreSerializationAsync(MessageEnvelope messageEnvelope)
    {
        if (messageEnvelope is MessageEnvelope<UserCreatedEvent> typed) // casting required!
        {
            typed.Metadata["subject"] = JsonSerializer.SerializeToElement(typed.Message.UserId);
        }
        return ValueTask.CompletedTask;
    }
}
```

### Solution

New `ISerializationCallback<T>` interface following the same pattern as `IMessageHandler<T>`:

```csharp
public interface ISerializationCallback<T>
{
    ValueTask PreSerializationAsync(MessageEnvelope<T> messageEnvelope);
}
```

Callbacks are registered via DI and automatically type-routed — they're only invoked when `T` matches:

```csharp
// After — zero casting, direct typed access, DI-resolved
public class UserCreatedCallback : ISerializationCallback<UserCreatedEvent>
{
    public ValueTask PreSerializationAsync(MessageEnvelope<UserCreatedEvent> messageEnvelope)
    {
        // Direct typed access — no casting!
        messageEnvelope.Metadata["subject"] = 
            JsonSerializer.SerializeToElement(messageEnvelope.Message.UserId);
        return ValueTask.CompletedTask;
    }
}

// Registration
services.AddAWSMessageBus(builder =>
{
    builder.AddSQSPublisher<UserCreatedEvent>("queue-url", "user.created");
    builder.AddSerializationCallback<UserCreatedCallback, UserCreatedEvent>();
});
```

### How It Works

1. **Registration**: `AddSerializationCallback<TCallback, TMessage>()` registers the callback in the DI container as `ISerializationCallback<TMessage>`
2. **Invocation**: In `EnvelopeSerializer.SerializeAsync<T>()`, after invoking non-generic callbacks, it calls `_serviceProvider.GetServices<ISerializationCallback<T>>()` — the DI container returns **only** callbacks matching `T`
3. **Type safety**: No reflection needed. Since `SerializeAsync<T>` knows `T` at compile time, the DI container handles all type routing automatically


### Produces the Output the User Wanted

```json
{
  "type": "user.created",
  "source": "my-service",
  "subject": "123",
  "data": { "userId": "123" }
}
```

### Changes

| File | Change |
|------|--------|
| `ISerializationCallback{T}.cs` | **New** — generic typed callback interface |
| `IMessageBusBuilder.cs` | Added `AddSerializationCallback<TCallback, TMessage>()` |
| `MessageBusBuilder.cs` | DI registration for typed callbacks |
| `EnvelopeSerializer.cs` | Added `IServiceProvider` dep, typed callback invocation, fixed `ArgumentNullException` |
| `ISerializationCallback.cs` | Reverted previous generic method (replaced by this approach) |
| `EnvelopeSerializerTests.cs` | New typed callback tests, updated direct constructor calls |

### Breaking Changes

None. The existing `ISerializationCallback` (non-generic) continues to work unchanged for cross-cutting concerns.

### Testing

- All 20 existing EnvelopeSerializer tests pass
- 2 new tests:
  - `TypedSerializationCallback_ExtractsSubjectWithZeroCasting` — verifies typed callback extracts subject with no casting
  - `TypedSerializationCallback_NotInvokedForNonMatchingType` — verifies callback is NOT invoked for non-matching message types

*Issue #, if available:* Resolves discussion #317

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
