### PR TITLE
Improving handler exception logging to include original exception

### DIFF
--- a/.autover/changes/2a03e039-75e3-49d7-90e8-b44c97e607c3.json
+++ b/.autover/changes/2a03e039-75e3-49d7-90e8-b44c97e607c3.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Improving handler exception logging to include original exception"
+      ]
+    }
+  ]
+}

--- a/src/AWS.Messaging/Services/HandlerInvoker.cs
+++ b/src/AWS.Messaging/Services/HandlerInvoker.cs
@@ -63,7 +63,7 @@ public class HandlerInvoker : IHandlerInvoker
                     }
                     catch (Exception e)
                     {
-                        _logger.LogError("Unable to resolve a handler for {HandlerType} while handling message ID {MessageEnvelopeId}.", subscriberMapping.HandlerType, messageEnvelope.Id);
+                        _logger.LogError(e, "Unable to resolve a handler for {HandlerType} while handling message ID {MessageEnvelopeId}.", subscriberMapping.HandlerType, messageEnvelope.Id);
                         throw new InvalidMessageHandlerSignatureException($"Unable to resolve a handler for {subscriberMapping.HandlerType} " +
                                                                           $"while handling message ID {messageEnvelope.Id}.", e);
                     }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-dotnet-messaging/issues/326

*Description of changes:*
If an exception calling the handler happen like a DI resolution issue the error was logged but without the original exception making it harder to debug. The PR updates the call to the `LogError` to include the exception.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
