### PR TITLE
Refactor handler invoker logic to not use reflection

### DIFF
--- a/.autover/changes/d36d1259-619d-4807-aabd-fb51444c1381.json
+++ b/.autover/changes/d36d1259-619d-4807-aabd-fb51444c1381.json
@@ -1,0 +1,12 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Improve handler exception logging to include original exception",
+        "Fix issue not supporting handlers that use explicit interface implementation by refactoring invoker to not use reflection"
+      ]
+    }
+  ]
+}

--- a/sampleapps/AppHost/AppHost.csproj
+++ b/sampleapps/AppHost/AppHost.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.2.2" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.1.0" />
-    <PackageReference Include="Aspire.Hosting.AWS" Version="9.4.1" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.2.2" />
+    <PackageReference Include="Aspire.Hosting.AWS" Version="13.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sampleapps/LambdaMessaging/Properties/launchSettings.json
+++ b/sampleapps/LambdaMessaging/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "Aspire_LambdaMessaging": {
       "commandName": "Executable",
       "executablePath": "dotnet",
-      "commandLineArgs": "exec --depsfile ./LambdaMessaging.deps.json --runtimeconfig ./LambdaMessaging.runtimeconfig.json %USERPROFILE%\\.dotnet\\tools\\.store\\amazon.lambda.testtool\\0.9.1\\amazon.lambda.testtool\\0.9.1\\content\\Amazon.Lambda.RuntimeSupport\\net8.0\\Amazon.Lambda.RuntimeSupport.dll LambdaMessaging::LambdaMessaging.Function_FunctionHandler_Generated::FunctionHandler",
-      "workingDirectory": ".\\bin\\$(Configuration)\\net8.0"
+      "commandLineArgs": "exec --depsfile ./LambdaMessaging.deps.json --runtimeconfig ./LambdaMessaging.runtimeconfig.json %USERPROFILE%\\.dotnet\\tools\\.store\\amazon.lambda.testtool\\0.13.0\\amazon.lambda.testtool\\0.13.0\\content\\Amazon.Lambda.RuntimeSupport\\net8.0\\Amazon.Lambda.RuntimeSupport.TestTool.dll LambdaMessaging::LambdaMessaging.Function_FunctionHandler_Generated::FunctionHandler",
+      "workingDirectory": "bin\\Debug\\net8.0\\"
     }
   }
 }

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -99,12 +99,16 @@ public class MessageBusBuilder : IMessageBusBuilder
     public IMessageBusBuilder AddMessageHandler<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] THandler, TMessage>(string? messageTypeIdentifier = null)
         where THandler : IMessageHandler<TMessage>
     {
-        return AddMessageHandler(typeof(THandler), typeof(TMessage), () => new MessageEnvelope<TMessage>(), messageTypeIdentifier);
+        static Task<MessageProcessStatus> handlerInvoker(object handler, MessageEnvelope envelope, CancellationToken token)
+        {
+            return ((IMessageHandler<TMessage>)handler).HandleAsync((MessageEnvelope<TMessage>)envelope, token);
+        }
+        return AddMessageHandler(typeof(THandler), typeof(TMessage), () => new MessageEnvelope<TMessage>(), handlerInvoker, messageTypeIdentifier);
     }
 
-    private IMessageBusBuilder AddMessageHandler([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type handlerType, Type messageType, Func<MessageEnvelope> envelopeFactory, string? messageTypeIdentifier = null)
+    private IMessageBusBuilder AddMessageHandler([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type handlerType, Type messageType, Func<MessageEnvelope> envelopeFactory, Func<object, MessageEnvelope, CancellationToken, Task<MessageProcessStatus>> handlerInvoker, string? messageTypeIdentifier = null)
     {
-        var subscriberMapping = new SubscriberMapping(handlerType, messageType, envelopeFactory, messageTypeIdentifier);
+        var subscriberMapping = new SubscriberMapping(handlerType, messageType, envelopeFactory, handlerInvoker, messageTypeIdentifier);
         _messageConfiguration.SubscriberMappings.Add(subscriberMapping);
         return this;
     }
@@ -282,7 +286,15 @@ public class MessageBusBuilder : IMessageBusBuilder
                     return (MessageEnvelope)envelope;
                 }
 
-                AddMessageHandler(handlerType, messageType, envelopeFactory, messageHandler.MessageTypeIdentifier);
+                // Build a reflection-based handler invoker since the generic types are not
+                // known at compile time in this config-driven path.
+                var handlerInterfaceType = typeof(IMessageHandler<>).MakeGenericType(messageType);
+                var handleAsyncMethod = handlerInterfaceType.GetMethod(nameof(IMessageHandler<object>.HandleAsync))!;
+                Task<MessageProcessStatus> handlerInvoker(object handler, MessageEnvelope envelope, CancellationToken token)
+                {
+                    return (Task<MessageProcessStatus>)handleAsyncMethod.Invoke(handler, new object[] { envelope, token })!;
+                }
+                AddMessageHandler(handlerType, messageType, envelopeFactory, handlerInvoker, messageHandler.MessageTypeIdentifier);
             }
         }
 

--- a/src/AWS.Messaging/Configuration/SubscriberMapping.cs
+++ b/src/AWS.Messaging/Configuration/SubscriberMapping.cs
@@ -26,15 +26,20 @@ public class SubscriberMapping
     // which is not compatible with Native AOT.
     internal Func<MessageEnvelope> MessageEnvelopeFactory { get; }
 
+    // The HandlerInvokerFunc is captured at registration time when the generic types are known,
+    // allowing the handler to be invoked without reflection at runtime. This improves startup
+    // performance and is compatible with Native AOT.
+    internal Func<object, MessageEnvelope, CancellationToken, Task<MessageProcessStatus>> HandlerInvokerFunc { get; }
+
     /// <summary>
     /// Constructs an instance of <see cref="SubscriberMapping"/>
     /// </summary>
     /// <param name="handlerType">The type that implements <see cref="IMessageHandler{T}"/></param>
     /// <param name="messageType">The type that will be message data will deserialized into</param>
     /// <param name="envelopeFactory">Func for creating <see cref="MessageEnvelope{messageType}"/></param>
+    /// <param name="handlerInvoker">Func for invoking the handler's HandleAsync without reflection</param>
     /// <param name="messageTypeIdentifier">Optional message type identifier. If not set the full name of the <see cref="MessageType"/> is used.</param>
-
-    internal SubscriberMapping([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type handlerType, Type messageType, Func<MessageEnvelope> envelopeFactory, string? messageTypeIdentifier = null)
+    internal SubscriberMapping([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type handlerType, Type messageType, Func<MessageEnvelope> envelopeFactory, Func<object, MessageEnvelope, CancellationToken, Task<MessageProcessStatus>> handlerInvoker, string? messageTypeIdentifier = null)
     {
         HandlerType = handlerType;
         MessageType = messageType;
@@ -44,6 +49,7 @@ public class SubscriberMapping
             messageType.FullName ?? throw new InvalidMessageTypeException("Unable to retrieve the Full Name of the provided Message Type.");
 
         MessageEnvelopeFactory = envelopeFactory;
+        HandlerInvokerFunc = handlerInvoker;
     }
 
     /// <summary>
@@ -61,6 +67,11 @@ public class SubscriberMapping
             return new MessageEnvelope<TMessage>();
         }
 
-        return new SubscriberMapping(typeof(THandler), typeof(TMessage), envelopeFactory, messageTypeIdentifier);
+        static Task<MessageProcessStatus> handlerInvoker(object handler, MessageEnvelope envelope, CancellationToken token)
+        {
+            return ((IMessageHandler<TMessage>)handler).HandleAsync((MessageEnvelope<TMessage>)envelope, token);
+        }
+
+        return new SubscriberMapping(typeof(THandler), typeof(TMessage), envelopeFactory, handlerInvoker, messageTypeIdentifier);
     }
 }

--- a/src/AWS.Messaging/Services/HandlerInvoker.cs
+++ b/src/AWS.Messaging/Services/HandlerInvoker.cs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Collections.Concurrent;
-using System.Reflection;
 using AWS.Messaging.Configuration;
 using AWS.Messaging.Telemetry;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,12 +14,6 @@ public class HandlerInvoker : IHandlerInvoker
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<HandlerInvoker> _logger;
     private readonly ITelemetryFactory _telemetryFactory;
-
-    /// <summary>
-    /// Caches the <see cref="MethodInfo"/> of the <see cref="IMessageHandler{T}.HandleAsync(MessageEnvelope{T}, CancellationToken)"/>
-    /// method that will be invoked with the message envelope for each handler
-    /// </summary>
-    private readonly ConcurrentDictionary<Type, MethodInfo?> _handlerMethods = new();
 
     /// <summary>
     /// Constructs an instance of HandlerInvoker
@@ -63,58 +55,20 @@ public class HandlerInvoker : IHandlerInvoker
                     }
                     catch (Exception e)
                     {
-                        _logger.LogError("Unable to resolve a handler for {HandlerType} while handling message ID {MessageEnvelopeId}.", subscriberMapping.HandlerType, messageEnvelope.Id);
+                        _logger.LogError(e, "Unable to resolve a handler for {HandlerType} while handling message ID {MessageEnvelopeId}.", subscriberMapping.HandlerType, messageEnvelope.Id);
                         throw new InvalidMessageHandlerSignatureException($"Unable to resolve a handler for {subscriberMapping.HandlerType} " +
                                                                           $"while handling message ID {messageEnvelope.Id}.", e);
                     }
 
-                    var method = _handlerMethods.GetOrAdd(subscriberMapping.MessageType, x =>
-                    {
-                        return subscriberMapping.HandlerType.GetMethod(    // Look up the method on the handler type with:
-                            nameof(IMessageHandler<MessageProcessStatus>.HandleAsync),              // name "HandleAsync"
-                            new Type[] { messageEnvelope.GetType(), typeof(CancellationToken) });   // parameters (MessageEnvelope<MessageType>, CancellationToken)
-                    });
-
-                    if (method == null)
-                    {
-                        _logger.LogError("Unable to resolve a compatible HandleAsync method for {HandlerType} while handling message ID {MessageEnvelopeId}.", subscriberMapping.HandlerType, messageEnvelope.Id);
-                        throw new InvalidMessageHandlerSignatureException($"Unable to resolve a compatible HandleAsync method for {subscriberMapping.HandlerType} while handling message ID {messageEnvelope.Id}.");
-                    }
-
                     try
                     {
-                        var task = method.Invoke(handler, new object[] { messageEnvelope, token }) as Task<MessageProcessStatus>;
-
-                        if (task == null)
-                        {
-                            _logger.LogError("Unexpected return type for the HandleAsync method on {HandlerType} while handling message ID {MessageEnvelopeId}. Expected {ExpectedType}", subscriberMapping.HandlerType, messageEnvelope.Id, nameof(Task<MessageProcessStatus>));
-                            throw new InvalidMessageHandlerSignatureException($"Unexpected return type for the HandleAsync method on {subscriberMapping.HandlerType} while handling message ID {messageEnvelope.Id}. Expected {nameof(Task<MessageProcessStatus>)}");
-                        }
-
-                        return await task;
-                    }
-                    // Since we are invoking HandleAsync via reflection, we need to unwrap the TargetInvocationException
-                    // containing application exceptions that happened inside the IMessageHandler
-                    catch (TargetInvocationException ex)
-                    {
-                        trace.AddException(ex, false);
-
-                        if (ex.InnerException != null)
-                        {
-                            _logger.LogError(ex.InnerException, "A handler exception occurred while handling message ID {MessageId}.", messageEnvelope.Id);
-                            return MessageProcessStatus.Failed();
-                        }
-                        else
-                        {
-                            _logger.LogError(ex, "An unexpected exception occurred while handling message ID {MessageId}.", messageEnvelope.Id);
-                            return MessageProcessStatus.Failed();
-                        }
+                        return await subscriberMapping.HandlerInvokerFunc(handler, messageEnvelope, token);
                     }
                     catch (Exception ex)
                     {
                         trace.AddException(ex, false);
 
-                        _logger.LogError(ex, "An unexpected exception occurred while handling message ID {MessageId}.", messageEnvelope.Id);
+                        _logger.LogError(ex, "A handler exception occurred while handling message ID {MessageId}.", messageEnvelope.Id);
                         return MessageProcessStatus.Failed();
                     }
                 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-dotnet-messaging/issues/325
https://github.com/aws/aws-dotnet-messaging/issues/326

*Description of changes:*
Refactor the logic in the HandlerInvoker to avoid using reflection. The refactoring is similar to what was done before with create the generic MessageEnvelope when we refactoring to make the library Native AOT compliant.

The side affect of the refactor is it address issue https://github.com/aws/aws-dotnet-messaging/issues/325 issue about using explicit interfaces which was failing due to not be able to find the methods via reflection because explicit interface methods are private.

As part of this PR I also took care of issue https://github.com/aws/aws-dotnet-messaging/issues/326 making sure the original exception was logged when creating the handler class.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
