### PR TITLE
Per message options configuration for `IMessagePublisher`

### DIFF
--- a/.autover/changes/e46a0c0e-61c2-4c99-9dd6-173251c999ab.json
+++ b/.autover/changes/e46a0c0e-61c2-4c99-9dd6-173251c999ab.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Added per-message SQS and SNS publish option configuration for IMessagePublisher, including FIFO support."
+      ]
+    }
+  ]
+}

--- a/.autover/changes/e46a0c0e-61c2-4c99-9dd6-173251c999ab.json
+++ b/.autover/changes/e46a0c0e-61c2-4c99-9dd6-173251c999ab.json
@@ -2,7 +2,7 @@
   "Projects": [
     {
       "Name": "AWS.Messaging",
-      "Type": "Minor",
+      "Type": "Major",
       "ChangelogMessages": [
         "Added per-message SQS and SNS publish option configuration for IMessagePublisher, including FIFO support."
       ]

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ builder.Services.AddAWSMessageBus(builder =>
 {
     builder.AddSQSPublisher<TransactionInfo>(
         "https://sqs.us-west-2.amazonaws.com/012345678910/MyFifoQueue.fifo",
-        configureOptions: (message, options) =>
+        configureOptions: (serviceProvider, message, options) =>
         {
             options.MessageGroupId = message.TransactionId;
             options.MessageDeduplicationId = message.TransactionId;
@@ -66,9 +66,12 @@ builder.Services.AddAWSMessageBus(builder =>
 
     builder.AddSNSPublisher<BidInfo>(
         "arn:aws:sns:us-west-2:012345678910:MyFifoTopic.fifo",
-        configureOptions: (message, options) =>
+        configureOptions: async (serviceProvider, message, options, cancellationToken) =>
         {
-            options.MessageGroupId = message.BidId;
+            var sharedState = serviceProvider.GetRequiredService<SharedState>();
+            var groupId = await sharedState.GetGroupId(message, cancellationToken);
+
+            options.MessageGroupId = groupId;
             options.MessageDeduplicationId = message.BidId;
         });
 });
@@ -559,7 +562,7 @@ In the following example the framework will check every 1 second for messages th
 {
     options.VisibilityTimeout = 30;
     options.VisibilityTimeoutExtensionThreshold = 5;
-    VisibilityTimeoutExtensionHeartbeatInterval = 1;
+    options.VisibilityTimeoutExtensionHeartbeatInterval = 1;
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,29 @@ builder.Services.AddAWSMessageBus(builder =>
 
 Once you have registered the framework during startup, inject the generic `IMessagePublisher` into your code. Call its `PublishAsync` method to publish any of the message types that were configured above. The generic publisher will determine the destination to route the message to based on its type.
 
+When registering SQS and SNS publishers, you can also provide an optional `configureOptions` action to `AddSQSPublisher` and `AddSNSPublisher`. This action is invoked for each message published through the generic `IMessagePublisher`, allowing you to populate options for the configured AWS service using values from that message. It can also be used to override defaults configured for that service, so it should be used with care. For example, if a message is sent to an SQS FIFO queue and the message group ID or deduplication ID can be derived from the message itself, those values can be set for that message while still publishing with `IMessagePublisher`.
+
+```csharp
+builder.Services.AddAWSMessageBus(builder =>
+{
+    builder.AddSQSPublisher<TransactionInfo>(
+        "https://sqs.us-west-2.amazonaws.com/012345678910/MyFifoQueue.fifo",
+        configureOptions: (message, options) =>
+        {
+            options.MessageGroupId = message.TransactionId;
+            options.MessageDeduplicationId = message.TransactionId;
+        });
+
+    builder.AddSNSPublisher<BidInfo>(
+        "arn:aws:sns:us-west-2:012345678910:MyFifoTopic.fifo",
+        configureOptions: (message, options) =>
+        {
+            options.MessageGroupId = message.BidId;
+            options.MessageDeduplicationId = message.BidId;
+        });
+});
+```
+
 In the following example, an ASP.NET MVC controller receives both `ChatMessage` messages and `OrderInfo` events from users, and then publishes them to SQS and SNS respectively. Both message types can be published using the generic publisher that was configured above.
 
 ```csharp

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -24,7 +24,7 @@ public interface IMessageBusBuilder
     /// <param name="queueUrl">The SQS queue URL to publish the message to. If the queue URL is null, a message-specific queue
     /// URL must be specified on the <see cref="SQSOptions"/> when sending a message.</param>
     /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
-    /// <param name="configureOptions">An optional action to configure the SQS options per message on publish.</param>
+    /// <param name="configureOptions">An optional action to configure <see cref="SQSOptions"/> per message on publish.</param>
     IMessageBusBuilder AddSQSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? queueUrl, string? messageTypeIdentifier = null, Action<TMessage, SQSOptions>? configureOptions = null);
 
     /// <summary>
@@ -34,7 +34,7 @@ public interface IMessageBusBuilder
     /// <param name="topicUrl">The SNS topic URL to publish the message to. If the topic URL is null, a message-specific
     /// topic URL must be set on the <see cref="SNSOptions"/> when publishing a message.</param>
     /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
-    /// <param name="configureOptions">An optional action to configure the SNS options per message on publish.</param>
+    /// <param name="configureOptions">An optional action to configure <see cref="SNSOptions"/> per message on publish.</param>
     IMessageBusBuilder AddSNSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? topicUrl, string? messageTypeIdentifier = null, Action<TMessage, SNSOptions>? configureOptions = null);
 
     /// <summary>
@@ -45,7 +45,8 @@ public interface IMessageBusBuilder
     /// a message-specific event bus must be set on the <see cref="EventBridgeOptions"/> when sending an event.</param>
     /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
     /// <param name="options">Contains additional properties that can be set while configuring an EventBridge publisher</param>
-    IMessageBusBuilder AddEventBridgePublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? eventBusName, string? messageTypeIdentifier = null, EventBridgePublishOptions? options = null);
+    /// <param name="configureOptions">An optional action to configure <see cref="EventBridgeOptions"/> per message on publish.</param>
+    IMessageBusBuilder AddEventBridgePublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? eventBusName, string? messageTypeIdentifier = null, EventBridgePublishOptions? options = null, Action<TMessage, EventBridgeOptions>? configureOptions = null);
 
     /// <summary>
     /// Add a message handler for a given message type.

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -24,8 +24,45 @@ public interface IMessageBusBuilder
     /// <param name="queueUrl">The SQS queue URL to publish the message to. If the queue URL is null, a message-specific queue
     /// URL must be specified on the <see cref="SQSOptions"/> when sending a message.</param>
     /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
-    /// <param name="configureOptions">An optional action to configure <see cref="SQSOptions"/> per message on publish.</param>
-    IMessageBusBuilder AddSQSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? queueUrl, string? messageTypeIdentifier = null, Action<TMessage, SQSOptions>? configureOptions = null);
+    IMessageBusBuilder AddSQSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? queueUrl, string? messageTypeIdentifier = null) => AddSQSPublisher<TMessage>(queueUrl, messageTypeIdentifier, null);
+
+    /// <summary>
+    /// Adds an SQS Publisher to the framework which will handle publishing
+    /// the defined message type to the specified SQS queues URL.
+    /// </summary>
+    /// <param name="queueUrl">The SQS queue URL to publish the message to. If the queue URL is null, a message-specific queue
+    /// URL must be specified on the <see cref="SQSOptions"/> when sending a message.</param>
+    /// <param name="configureOptions">An action to configure <see cref="SQSOptions"/> per message on publish.</param>
+    IMessageBusBuilder AddSQSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? queueUrl, Action<IServiceProvider, TMessage, SQSOptions>? configureOptions) => AddSQSPublisher(queueUrl, null, configureOptions);
+
+    /// <summary>
+    /// Adds an SQS Publisher to the framework which will handle publishing
+    /// the defined message type to the specified SQS queues URL.
+    /// </summary>
+    /// <param name="queueUrl">The SQS queue URL to publish the message to. If the queue URL is null, a message-specific queue
+    /// URL must be specified on the <see cref="SQSOptions"/> when sending a message.</param>
+    /// <param name="configureOptions">A function to configure <see cref="SQSOptions"/> per message on publish.</param>
+    IMessageBusBuilder AddSQSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? queueUrl, Func<IServiceProvider, TMessage, SQSOptions, CancellationToken, ValueTask>? configureOptions) => AddSQSPublisher(queueUrl, null, configureOptions);
+
+    /// <summary>
+    /// Adds an SQS Publisher to the framework which will handle publishing
+    /// the defined message type to the specified SQS queues URL.
+    /// </summary>
+    /// <param name="queueUrl">The SQS queue URL to publish the message to. If the queue URL is null, a message-specific queue
+    /// URL must be specified on the <see cref="SQSOptions"/> when sending a message.</param>
+    /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
+    /// <param name="configureOptions">An action to configure <see cref="SQSOptions"/> per message on publish.</param>
+    IMessageBusBuilder AddSQSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? queueUrl, string? messageTypeIdentifier, Action<IServiceProvider, TMessage, SQSOptions>? configureOptions);
+
+    /// <summary>
+    /// Adds an SQS Publisher to the framework which will handle publishing
+    /// the defined message type to the specified SQS queues URL.
+    /// </summary>
+    /// <param name="queueUrl">The SQS queue URL to publish the message to. If the queue URL is null, a message-specific queue
+    /// URL must be specified on the <see cref="SQSOptions"/> when sending a message.</param>
+    /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
+    /// <param name="configureOptions">A function to configure <see cref="SQSOptions"/> per message on publish.</param>
+    IMessageBusBuilder AddSQSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? queueUrl, string? messageTypeIdentifier, Func<IServiceProvider, TMessage, SQSOptions, CancellationToken, ValueTask>? configureOptions);
 
     /// <summary>
     /// Adds an SNS Publisher to the framework which will handle publishing
@@ -34,8 +71,66 @@ public interface IMessageBusBuilder
     /// <param name="topicUrl">The SNS topic URL to publish the message to. If the topic URL is null, a message-specific
     /// topic URL must be set on the <see cref="SNSOptions"/> when publishing a message.</param>
     /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
-    /// <param name="configureOptions">An optional action to configure <see cref="SNSOptions"/> per message on publish.</param>
-    IMessageBusBuilder AddSNSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? topicUrl, string? messageTypeIdentifier = null, Action<TMessage, SNSOptions>? configureOptions = null);
+    IMessageBusBuilder AddSNSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? topicUrl, string? messageTypeIdentifier = null) => AddSNSPublisher<TMessage>(topicUrl, messageTypeIdentifier, null);
+
+    /// <summary>
+    /// Adds an SNS Publisher to the framework which will handle publishing
+    /// the defined message type to the specified SNS topic URL.
+    /// </summary>
+    /// <param name="topicUrl">The SNS topic URL to publish the message to. If the topic URL is null, a message-specific
+    /// topic URL must be set on the <see cref="SNSOptions"/> when publishing a message.</param>
+    /// <param name="configureOptions">An action to configure <see cref="SNSOptions"/> per message on publish.</param>
+    IMessageBusBuilder AddSNSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? topicUrl, Action<IServiceProvider, TMessage, SNSOptions>? configureOptions) => AddSNSPublisher(topicUrl, null, configureOptions);
+
+    /// <summary>
+    /// Adds an SNS Publisher to the framework which will handle publishing
+    /// the defined message type to the specified SNS topic URL.
+    /// </summary>
+    /// <param name="topicUrl">The SNS topic URL to publish the message to. If the topic URL is null, a message-specific
+    /// topic URL must be set on the <see cref="SNSOptions"/> when publishing a message.</param>
+    /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
+    /// <param name="configureOptions">A function to configure <see cref="SNSOptions"/> per message on publish.</param>
+    IMessageBusBuilder AddSNSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? topicUrl, string? messageTypeIdentifier, Func<IServiceProvider, TMessage, SNSOptions, CancellationToken, ValueTask>? configureOptions);
+
+    /// <summary>
+    /// Adds an SNS Publisher to the framework which will handle publishing
+    /// the defined message type to the specified SNS topic URL.
+    /// </summary>
+    /// <param name="topicUrl">The SNS topic URL to publish the message to. If the topic URL is null, a message-specific
+    /// topic URL must be set on the <see cref="SNSOptions"/> when publishing a message.</param>
+    /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
+    /// <param name="configureOptions">An action to configure <see cref="SNSOptions"/> per message on publish.</param>
+    IMessageBusBuilder AddSNSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? topicUrl, string? messageTypeIdentifier, Action<IServiceProvider, TMessage, SNSOptions>? configureOptions);
+
+
+    /// <summary>
+    /// Adds an EventBridge Publisher to the framework which will handle publishing the defined message type to the specified EventBridge event bus name.
+    /// If you are specifying a global endpoint ID via <see cref="EventBridgePublishOptions"/>, then you must also include the <see href="https://www.nuget.org/packages/AWSSDK.Extensions.CrtIntegration">AWSSDK.Extensions.CrtIntegration</see> package in your application.
+    /// </summary>
+    /// <param name="eventBusName">The EventBridge event bus name or ARN where the message will be published. If the event bus name is null,
+    /// a message-specific event bus must be set on the <see cref="EventBridgeOptions"/> when sending an event.</param>
+    /// <param name="configureOptions">An optional action to configure <see cref="EventBridgeOptions"/> per message on publish.</param>
+    IMessageBusBuilder AddEventBridgePublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? eventBusName, Action<IServiceProvider, TMessage, EventBridgeOptions>? configureOptions) => AddEventBridgePublisher(eventBusName, null, null, configureOptions);
+
+    /// <summary>
+    /// Adds an EventBridge Publisher to the framework which will handle publishing the defined message type to the specified EventBridge event bus name.
+    /// If you are specifying a global endpoint ID via <see cref="EventBridgePublishOptions"/>, then you must also include the <see href="https://www.nuget.org/packages/AWSSDK.Extensions.CrtIntegration">AWSSDK.Extensions.CrtIntegration</see> package in your application.
+    /// </summary>
+    /// <param name="eventBusName">The EventBridge event bus name or ARN where the message will be published. If the event bus name is null,
+    /// a message-specific event bus must be set on the <see cref="EventBridgeOptions"/> when sending an event.</param>
+    /// <param name="configureOptions">An optional function to configure <see cref="EventBridgeOptions"/> per message on publish.</param>
+    IMessageBusBuilder AddEventBridgePublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? eventBusName, Func<IServiceProvider, TMessage, EventBridgeOptions, CancellationToken, ValueTask>? configureOptions) => AddEventBridgePublisher(eventBusName, null, null, configureOptions);
+
+
+    /// <summary>
+    /// Adds an EventBridge Publisher to the framework which will handle publishing the defined message type to the specified EventBridge event bus name.
+    /// If you are specifying a global endpoint ID via <see cref="EventBridgePublishOptions"/>, then you must also include the <see href="https://www.nuget.org/packages/AWSSDK.Extensions.CrtIntegration">AWSSDK.Extensions.CrtIntegration</see> package in your application.
+    /// </summary>
+    /// <param name="eventBusName">The EventBridge event bus name or ARN where the message will be published. If the event bus name is null,
+    /// a message-specific event bus must be set on the <see cref="EventBridgeOptions"/> when sending an event.</param>
+    /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
+    /// <param name="options">Contains additional properties that can be set while configuring an EventBridge publisher</param>
+    IMessageBusBuilder AddEventBridgePublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? eventBusName, string? messageTypeIdentifier = null, EventBridgePublishOptions? options = null) => AddEventBridgePublisher(eventBusName, messageTypeIdentifier, options, (Action<IServiceProvider, TMessage, EventBridgeOptions>?)null);
 
     /// <summary>
     /// Adds an EventBridge Publisher to the framework which will handle publishing the defined message type to the specified EventBridge event bus name.
@@ -46,7 +141,18 @@ public interface IMessageBusBuilder
     /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
     /// <param name="options">Contains additional properties that can be set while configuring an EventBridge publisher</param>
     /// <param name="configureOptions">An optional action to configure <see cref="EventBridgeOptions"/> per message on publish.</param>
-    IMessageBusBuilder AddEventBridgePublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? eventBusName, string? messageTypeIdentifier = null, EventBridgePublishOptions? options = null, Action<TMessage, EventBridgeOptions>? configureOptions = null);
+    IMessageBusBuilder AddEventBridgePublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? eventBusName, string? messageTypeIdentifier, EventBridgePublishOptions? options, Action<IServiceProvider, TMessage, EventBridgeOptions>? configureOptions);
+
+    /// <summary>
+    /// Adds an EventBridge Publisher to the framework which will handle publishing the defined message type to the specified EventBridge event bus name.
+    /// If you are specifying a global endpoint ID via <see cref="EventBridgePublishOptions"/>, then you must also include the <see href="https://www.nuget.org/packages/AWSSDK.Extensions.CrtIntegration">AWSSDK.Extensions.CrtIntegration</see> package in your application.
+    /// </summary>
+    /// <param name="eventBusName">The EventBridge event bus name or ARN where the message will be published. If the event bus name is null,
+    /// a message-specific event bus must be set on the <see cref="EventBridgeOptions"/> when sending an event.</param>
+    /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
+    /// <param name="options">Contains additional properties that can be set while configuring an EventBridge publisher</param>
+    /// <param name="configureOptions">An optional function to configure <see cref="EventBridgeOptions"/> per message on publish.</param>
+    IMessageBusBuilder AddEventBridgePublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? eventBusName, string? messageTypeIdentifier, EventBridgePublishOptions? options, Func<IServiceProvider, TMessage, EventBridgeOptions, CancellationToken, ValueTask>? configureOptions = null);
 
     /// <summary>
     /// Add a message handler for a given message type.

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -24,7 +24,8 @@ public interface IMessageBusBuilder
     /// <param name="queueUrl">The SQS queue URL to publish the message to. If the queue URL is null, a message-specific queue
     /// URL must be specified on the <see cref="SQSOptions"/> when sending a message.</param>
     /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
-    IMessageBusBuilder AddSQSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? queueUrl, string? messageTypeIdentifier = null);
+    /// <param name="configureOptions">An optional action to configure the SQS options per message on publish.</param>
+    IMessageBusBuilder AddSQSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? queueUrl, string? messageTypeIdentifier = null, Action<TMessage, SQSOptions>? configureOptions = null);
 
     /// <summary>
     /// Adds an SNS Publisher to the framework which will handle publishing
@@ -33,7 +34,8 @@ public interface IMessageBusBuilder
     /// <param name="topicUrl">The SNS topic URL to publish the message to. If the topic URL is null, a message-specific
     /// topic URL must be set on the <see cref="SNSOptions"/> when publishing a message.</param>
     /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
-    IMessageBusBuilder AddSNSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? topicUrl, string? messageTypeIdentifier = null);
+    /// <param name="configureOptions">An optional action to configure the SNS options per message on publish.</param>
+    IMessageBusBuilder AddSNSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? topicUrl, string? messageTypeIdentifier = null, Action<TMessage, SNSOptions>? configureOptions = null);
 
     /// <summary>
     /// Adds an EventBridge Publisher to the framework which will handle publishing the defined message type to the specified EventBridge event bus name.

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 namespace AWS.Messaging.Configuration;
 
@@ -51,27 +52,39 @@ public class MessageBusBuilder : IMessageBusBuilder
     }
 
     /// <inheritdoc/>
-    public IMessageBusBuilder AddSQSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? queueUrl, string? messageTypeIdentifier = null)
+    public IMessageBusBuilder AddSQSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? queueUrl, string? messageTypeIdentifier = null, Action<TMessage, SQSOptions>? configureOptions = null)
     {
-        return AddSQSPublisher(typeof(TMessage), queueUrl, messageTypeIdentifier);
+        Action<object, object>? options = null;
+        if (configureOptions != null)
+        {
+            options = (message, sqsOptions) => configureOptions.Invoke((TMessage)message, (SQSOptions)sqsOptions);
+        }
+
+        return AddSQSPublisher(typeof(TMessage), queueUrl, messageTypeIdentifier, options);
     }
 
-    private IMessageBusBuilder AddSQSPublisher([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type messageType, string? queueUrl, string? messageTypeIdentifier = null)
+    private IMessageBusBuilder AddSQSPublisher([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type messageType, string? queueUrl, string? messageTypeIdentifier = null, Action<object, object>? configureOptions = null)
     {
         var sqsPublisherConfiguration = new SQSPublisherConfiguration(queueUrl);
-        return AddPublisher(messageType, sqsPublisherConfiguration, PublisherTargetType.SQS_PUBLISHER, messageTypeIdentifier);
+        return AddPublisher(messageType, sqsPublisherConfiguration, PublisherTargetType.SQS_PUBLISHER, messageTypeIdentifier, configureOptions);
     }
 
     /// <inheritdoc/>
-    public IMessageBusBuilder AddSNSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? topicUrl, string? messageTypeIdentifier = null)
+    public IMessageBusBuilder AddSNSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? topicUrl, string? messageTypeIdentifier = null, Action<TMessage, SNSOptions>? configureOptions = null)
     {
-        return AddSNSPublisher(typeof(TMessage), topicUrl, messageTypeIdentifier);
+        Action<object, object>? options = null;
+        if (configureOptions != null)
+        {
+            options = (message, snsOptions) => configureOptions.Invoke((TMessage)message, (SNSOptions)snsOptions);
+        }
+
+        return AddSNSPublisher(typeof(TMessage), topicUrl, messageTypeIdentifier, options);
     }
 
-    private IMessageBusBuilder AddSNSPublisher([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type messageType, string? topicUrl, string? messageTypeIdentifier = null)
+    private IMessageBusBuilder AddSNSPublisher([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type messageType, string? topicUrl, string? messageTypeIdentifier = null, Action<object, object>? configureOptions = null)
     {
         var snsPublisherConfiguration = new SNSPublisherConfiguration(topicUrl);
-        return AddPublisher(messageType, snsPublisherConfiguration, PublisherTargetType.SNS_PUBLISHER, messageTypeIdentifier);
+        return AddPublisher(messageType, snsPublisherConfiguration, PublisherTargetType.SNS_PUBLISHER, messageTypeIdentifier, configureOptions);
     }
 
     /// <inheritdoc/>
@@ -89,9 +102,9 @@ public class MessageBusBuilder : IMessageBusBuilder
         return AddPublisher(messageType, eventBridgePublisherConfiguration, PublisherTargetType.EVENTBRIDGE_PUBLISHER, messageTypeIdentifier);
     }
 
-    private IMessageBusBuilder AddPublisher([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type messageType, IMessagePublisherConfiguration publisherConfiguration, string publisherType, string? messageTypeIdentifier = null)
+    private IMessageBusBuilder AddPublisher([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type messageType, IMessagePublisherConfiguration publisherConfiguration, string publisherType, string? messageTypeIdentifier = null, Action<object, object>? configureOptions = null)
     {
-        var publisherMapping = new PublisherMapping(messageType, publisherConfiguration, publisherType, messageTypeIdentifier);
+        var publisherMapping = new PublisherMapping(messageType, publisherConfiguration, publisherType, messageTypeIdentifier, configureOptions);
         _messageConfiguration.PublisherMappings.Add(publisherMapping);
         return this;
     }

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
+using Amazon.Extensions.NETCore.Setup;
 using AWS.Messaging.Configuration.Internal;
 using AWS.Messaging.Publishers;
 using AWS.Messaging.Publishers.EventBridge;
@@ -54,13 +55,13 @@ public class MessageBusBuilder : IMessageBusBuilder
     /// <inheritdoc/>
     public IMessageBusBuilder AddSQSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? queueUrl, string? messageTypeIdentifier = null, Action<TMessage, SQSOptions>? configureOptions = null)
     {
-        Action<object, object>? options = null;
+        Action<object, object>? messageOptions = null;
         if (configureOptions != null)
         {
-            options = (message, sqsOptions) => configureOptions.Invoke((TMessage)message, (SQSOptions)sqsOptions);
+            messageOptions = (message, sqsOptions) => configureOptions.Invoke((TMessage)message, (SQSOptions)sqsOptions);
         }
 
-        return AddSQSPublisher(typeof(TMessage), queueUrl, messageTypeIdentifier, options);
+        return AddSQSPublisher(typeof(TMessage), queueUrl, messageTypeIdentifier, messageOptions);
     }
 
     private IMessageBusBuilder AddSQSPublisher([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type messageType, string? queueUrl, string? messageTypeIdentifier = null, Action<object, object>? configureOptions = null)
@@ -72,13 +73,13 @@ public class MessageBusBuilder : IMessageBusBuilder
     /// <inheritdoc/>
     public IMessageBusBuilder AddSNSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? topicUrl, string? messageTypeIdentifier = null, Action<TMessage, SNSOptions>? configureOptions = null)
     {
-        Action<object, object>? options = null;
+        Action<object, object>? messageOptions = null;
         if (configureOptions != null)
         {
-            options = (message, snsOptions) => configureOptions.Invoke((TMessage)message, (SNSOptions)snsOptions);
+            messageOptions = (message, snsOptions) => configureOptions.Invoke((TMessage)message, (SNSOptions)snsOptions);
         }
 
-        return AddSNSPublisher(typeof(TMessage), topicUrl, messageTypeIdentifier, options);
+        return AddSNSPublisher(typeof(TMessage), topicUrl, messageTypeIdentifier, messageOptions);
     }
 
     private IMessageBusBuilder AddSNSPublisher([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type messageType, string? topicUrl, string? messageTypeIdentifier = null, Action<object, object>? configureOptions = null)
@@ -88,18 +89,24 @@ public class MessageBusBuilder : IMessageBusBuilder
     }
 
     /// <inheritdoc/>
-    public IMessageBusBuilder AddEventBridgePublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? eventBusName, string? messageTypeIdentifier = null, EventBridgePublishOptions? options = null)
+    public IMessageBusBuilder AddEventBridgePublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? eventBusName, string? messageTypeIdentifier = null, EventBridgePublishOptions? options = null, Action<TMessage, EventBridgeOptions>? configureOptions = null)
     {
-        return AddEventBridgePublisher(typeof(TMessage), eventBusName, messageTypeIdentifier, options);
+        Action<object, object>? messageOptions = null;
+        if (configureOptions != null)
+        {
+            messageOptions = (message, ebOptions) => configureOptions.Invoke((TMessage)message, (EventBridgeOptions)ebOptions);
+        }
+
+        return AddEventBridgePublisher(typeof(TMessage), eventBusName, messageTypeIdentifier, options, messageOptions);
     }
 
-    private IMessageBusBuilder AddEventBridgePublisher([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type messageType, string? eventBusName, string? messageTypeIdentifier = null, EventBridgePublishOptions? options = null)
+    private IMessageBusBuilder AddEventBridgePublisher([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type messageType, string? eventBusName, string? messageTypeIdentifier = null, EventBridgePublishOptions? options = null, Action<object, object>? configureOptions = null)
     {
         var eventBridgePublisherConfiguration = new EventBridgePublisherConfiguration(eventBusName)
         {
             EndpointID = options?.EndpointID
         };
-        return AddPublisher(messageType, eventBridgePublisherConfiguration, PublisherTargetType.EVENTBRIDGE_PUBLISHER, messageTypeIdentifier);
+        return AddPublisher(messageType, eventBridgePublisherConfiguration, PublisherTargetType.EVENTBRIDGE_PUBLISHER, messageTypeIdentifier, configureOptions);
     }
 
     private IMessageBusBuilder AddPublisher([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type messageType, IMessagePublisherConfiguration publisherConfiguration, string publisherType, string? messageTypeIdentifier = null, Action<object, object>? configureOptions = null)
@@ -441,7 +448,7 @@ public class MessageBusBuilder : IMessageBusBuilder
 
         _serviceCollection.TryAddSingleton(_messageConfiguration.PollingControlToken);
         _serviceCollection.TryAddSingleton<IMessageConfiguration>(_messageConfiguration);
-        
+
         _serviceCollection.TryAddSingleton<IEnvelopeSerializer, EnvelopeSerializer>();
         _serviceCollection.TryAddSingleton<IMessageSerializer, MessageSerializer>();
 

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -5,7 +5,6 @@ using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
-using Amazon.Extensions.NETCore.Setup;
 using AWS.Messaging.Configuration.Internal;
 using AWS.Messaging.Publishers;
 using AWS.Messaging.Publishers.EventBridge;
@@ -21,7 +20,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 
 namespace AWS.Messaging.Configuration;
 
@@ -53,54 +51,102 @@ public class MessageBusBuilder : IMessageBusBuilder
     }
 
     /// <inheritdoc/>
-    public IMessageBusBuilder AddSQSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? queueUrl, string? messageTypeIdentifier = null, Action<TMessage, SQSOptions>? configureOptions = null)
+    public IMessageBusBuilder AddSQSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? queueUrl, string? messageTypeIdentifier, Action<IServiceProvider, TMessage, SQSOptions>? configureOptions)
     {
-        Action<object, object>? messageOptions = null;
+        Func<IServiceProvider, object, object, CancellationToken, ValueTask>? messageOptions = null;
         if (configureOptions != null)
         {
-            messageOptions = (message, sqsOptions) => configureOptions.Invoke((TMessage)message, (SQSOptions)sqsOptions);
+            messageOptions = (serviceProvider, message, sqsOptions, _) =>
+            {
+                configureOptions.Invoke(serviceProvider, (TMessage)message, (SQSOptions)sqsOptions);
+                return ValueTask.CompletedTask;
+            };
         }
 
         return AddSQSPublisher(typeof(TMessage), queueUrl, messageTypeIdentifier, messageOptions);
     }
 
-    private IMessageBusBuilder AddSQSPublisher([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type messageType, string? queueUrl, string? messageTypeIdentifier = null, Action<object, object>? configureOptions = null)
+    /// <inheritdoc/>
+    public IMessageBusBuilder AddSQSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? queueUrl, string? messageTypeIdentifier, Func<IServiceProvider, TMessage, SQSOptions, CancellationToken, ValueTask>? configureOptions)
+    {
+        Func<IServiceProvider, object, object, CancellationToken, ValueTask>? messageOptions = null;
+        if (configureOptions != null)
+        {
+            messageOptions = (serviceProvider, message, sqsOptions, cancellationToken) => configureOptions.Invoke(serviceProvider, (TMessage)message, (SQSOptions)sqsOptions, cancellationToken);
+        }
+
+        return AddSQSPublisher(typeof(TMessage), queueUrl, messageTypeIdentifier, messageOptions);
+    }
+
+    private IMessageBusBuilder AddSQSPublisher([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type messageType, string? queueUrl, string? messageTypeIdentifier = null, Func<IServiceProvider, object, object, CancellationToken, ValueTask>? configureOptions = null)
     {
         var sqsPublisherConfiguration = new SQSPublisherConfiguration(queueUrl);
         return AddPublisher(messageType, sqsPublisherConfiguration, PublisherTargetType.SQS_PUBLISHER, messageTypeIdentifier, configureOptions);
     }
 
     /// <inheritdoc/>
-    public IMessageBusBuilder AddSNSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? topicUrl, string? messageTypeIdentifier = null, Action<TMessage, SNSOptions>? configureOptions = null)
+    public IMessageBusBuilder AddSNSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? topicUrl, string? messageTypeIdentifier, Action<IServiceProvider, TMessage, SNSOptions>? configureOptions)
     {
-        Action<object, object>? messageOptions = null;
+        Func<IServiceProvider, object, object, CancellationToken, ValueTask>? messageOptions = null;
         if (configureOptions != null)
         {
-            messageOptions = (message, snsOptions) => configureOptions.Invoke((TMessage)message, (SNSOptions)snsOptions);
+            messageOptions = (serviceProvider, message, snsOptions, _) =>
+            {
+                configureOptions.Invoke(serviceProvider, (TMessage)message, (SNSOptions)snsOptions);
+                return ValueTask.CompletedTask;
+            };
         }
 
         return AddSNSPublisher(typeof(TMessage), topicUrl, messageTypeIdentifier, messageOptions);
     }
 
-    private IMessageBusBuilder AddSNSPublisher([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type messageType, string? topicUrl, string? messageTypeIdentifier = null, Action<object, object>? configureOptions = null)
+    /// <inheritdoc/>
+    public IMessageBusBuilder AddSNSPublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? topicUrl, string? messageTypeIdentifier, Func<IServiceProvider, TMessage, SNSOptions, CancellationToken, ValueTask>? configureOptions)
+    {
+        Func<IServiceProvider, object, object, CancellationToken, ValueTask>? messageOptions = null;
+        if (configureOptions != null)
+        {
+            messageOptions = (serviceProvider, message, snsOptions, cancellationToken) => configureOptions.Invoke(serviceProvider, (TMessage)message, (SNSOptions)snsOptions, cancellationToken);
+        }
+
+        return AddSNSPublisher(typeof(TMessage), topicUrl, messageTypeIdentifier, messageOptions);
+    }
+
+    private IMessageBusBuilder AddSNSPublisher([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type messageType, string? topicUrl, string? messageTypeIdentifier = null, Func<IServiceProvider, object, object, CancellationToken, ValueTask>? configureOptions = null)
     {
         var snsPublisherConfiguration = new SNSPublisherConfiguration(topicUrl);
         return AddPublisher(messageType, snsPublisherConfiguration, PublisherTargetType.SNS_PUBLISHER, messageTypeIdentifier, configureOptions);
     }
 
     /// <inheritdoc/>
-    public IMessageBusBuilder AddEventBridgePublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? eventBusName, string? messageTypeIdentifier = null, EventBridgePublishOptions? options = null, Action<TMessage, EventBridgeOptions>? configureOptions = null)
+    public IMessageBusBuilder AddEventBridgePublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? eventBusName, string? messageTypeIdentifier, EventBridgePublishOptions? options, Action<IServiceProvider, TMessage, EventBridgeOptions>? configureOptions)
     {
-        Action<object, object>? messageOptions = null;
+        Func<IServiceProvider, object, object, CancellationToken, ValueTask>? messageOptions = null;
         if (configureOptions != null)
         {
-            messageOptions = (message, ebOptions) => configureOptions.Invoke((TMessage)message, (EventBridgeOptions)ebOptions);
+            messageOptions = (serviceProvider, message, eventBridgeOptions, _) =>
+            {
+                configureOptions.Invoke(serviceProvider, (TMessage)message, (EventBridgeOptions)eventBridgeOptions);
+                return ValueTask.CompletedTask;
+            };
         }
 
         return AddEventBridgePublisher(typeof(TMessage), eventBusName, messageTypeIdentifier, options, messageOptions);
     }
 
-    private IMessageBusBuilder AddEventBridgePublisher([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type messageType, string? eventBusName, string? messageTypeIdentifier = null, EventBridgePublishOptions? options = null, Action<object, object>? configureOptions = null)
+    /// <inheritdoc/>
+    public IMessageBusBuilder AddEventBridgePublisher<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TMessage>(string? eventBusName, string? messageTypeIdentifier, EventBridgePublishOptions? options, Func<IServiceProvider, TMessage, EventBridgeOptions, CancellationToken, ValueTask>? configureOptions)
+    {
+        Func<IServiceProvider, object, object, CancellationToken, ValueTask>? messageOptions = null;
+        if (configureOptions != null)
+        {
+            messageOptions = (serviceProvider, message, eventBridgeOptions, cancellationToken) => configureOptions.Invoke(serviceProvider, (TMessage)message, (EventBridgeOptions)eventBridgeOptions, cancellationToken);
+        }
+
+        return AddEventBridgePublisher(typeof(TMessage), eventBusName, messageTypeIdentifier, options, messageOptions);
+    }
+
+    private IMessageBusBuilder AddEventBridgePublisher([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type messageType, string? eventBusName, string? messageTypeIdentifier, EventBridgePublishOptions? options, Func<IServiceProvider, object, object, CancellationToken, ValueTask>? configureOptions)
     {
         var eventBridgePublisherConfiguration = new EventBridgePublisherConfiguration(eventBusName)
         {
@@ -109,7 +155,7 @@ public class MessageBusBuilder : IMessageBusBuilder
         return AddPublisher(messageType, eventBridgePublisherConfiguration, PublisherTargetType.EVENTBRIDGE_PUBLISHER, messageTypeIdentifier, configureOptions);
     }
 
-    private IMessageBusBuilder AddPublisher([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type messageType, IMessagePublisherConfiguration publisherConfiguration, string publisherType, string? messageTypeIdentifier = null, Action<object, object>? configureOptions = null)
+    private IMessageBusBuilder AddPublisher([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type messageType, IMessagePublisherConfiguration publisherConfiguration, string publisherType, string? messageTypeIdentifier, Func<IServiceProvider, object, object, CancellationToken, ValueTask>? configureOptions)
     {
         var publisherMapping = new PublisherMapping(messageType, publisherConfiguration, publisherType, messageTypeIdentifier, configureOptions);
         _messageConfiguration.PublisherMappings.Add(publisherMapping);
@@ -293,7 +339,7 @@ public class MessageBusBuilder : IMessageBusBuilder
                 var messageType = GetTypeFromAssemblies(callingAssembly, eventBridgePublisher.MessageType)
                     ?? throw new InvalidAppSettingsConfigurationException($"Unable to find the provided message type '{eventBridgePublisher.MessageType}'.");
 
-                AddEventBridgePublisher(messageType, eventBridgePublisher.EventBusName, eventBridgePublisher.MessageTypeIdentifier, eventBridgePublisher.Options);
+                AddEventBridgePublisher(messageType, eventBridgePublisher.EventBusName, eventBridgePublisher.MessageTypeIdentifier, eventBridgePublisher.Options, null);
             }
         }
 
@@ -468,7 +514,7 @@ public class MessageBusBuilder : IMessageBusBuilder
 
         if (_messageConfiguration.PublisherMappings.Any())
         {
-            _serviceCollection.TryAddSingleton<IMessagePublisher, MessageRoutingPublisher>();
+            _serviceCollection.TryAddScoped<IMessagePublisher, MessageRoutingPublisher>();
 
             if (_messageConfiguration.PublisherMappings.Any(x => x.PublishTargetType == PublisherTargetType.SQS_PUBLISHER))
             {

--- a/src/AWS.Messaging/Configuration/PublisherMapping.cs
+++ b/src/AWS.Messaging/Configuration/PublisherMapping.cs
@@ -20,6 +20,9 @@ public class PublisherMapping
     /// <inheritdoc/>
     public IMessagePublisherConfiguration PublisherConfiguration { get; init; }
 
+    /// <inheritdoc/>
+    public Action<object, object>? ConfigureOptions { get; init; } = null;
+
     /// <summary>
     /// Creates a mapping object for the specified message type as well as the AWS service to publisher to.
     /// This object will be used internally by the framework to properly route the user-defined message.
@@ -28,7 +31,8 @@ public class PublisherMapping
     /// <param name="publisherConfiguration">The publisher configuration</param>
     /// <param name="publishTargetType">The type of publisher to use</param>
     /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
-    public PublisherMapping(Type messageType, IMessagePublisherConfiguration publisherConfiguration, string publishTargetType, string? messageTypeIdentifier = null)
+    /// <param name="configureOptions">An optional action to configure publisher-specific options.</param>
+    public PublisherMapping(Type messageType, IMessagePublisherConfiguration publisherConfiguration, string publishTargetType, string? messageTypeIdentifier = null, Action<object, object>? configureOptions = null)
     {
         PublishTargetType = publishTargetType;
         MessageType = messageType;
@@ -37,5 +41,6 @@ public class PublisherMapping
             messageTypeIdentifier :
             messageType.FullName ?? throw new InvalidMessageTypeException("Unable to retrieve the Full Name of the provided Message Type.");
         PublisherConfiguration = publisherConfiguration;
+        ConfigureOptions = configureOptions;
     }
 }

--- a/src/AWS.Messaging/Configuration/PublisherMapping.cs
+++ b/src/AWS.Messaging/Configuration/PublisherMapping.cs
@@ -21,7 +21,7 @@ public class PublisherMapping
     public IMessagePublisherConfiguration PublisherConfiguration { get; init; }
 
     /// <inheritdoc/>
-    public Action<object, object>? ConfigureOptions { get; init; } = null;
+    public Func<IServiceProvider, object, object, CancellationToken, ValueTask>? ConfigureOptions { get; init; } = null;
 
     /// <summary>
     /// Creates a mapping object for the specified message type as well as the AWS service to publisher to.
@@ -31,8 +31,8 @@ public class PublisherMapping
     /// <param name="publisherConfiguration">The publisher configuration</param>
     /// <param name="publishTargetType">The type of publisher to use</param>
     /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
-    /// <param name="configureOptions">An optional action to configure publisher-specific options.</param>
-    public PublisherMapping(Type messageType, IMessagePublisherConfiguration publisherConfiguration, string publishTargetType, string? messageTypeIdentifier = null, Action<object, object>? configureOptions = null)
+    /// <param name="configureOptions">An optional function to configure publisher-specific options.</param>
+    public PublisherMapping(Type messageType, IMessagePublisherConfiguration publisherConfiguration, string publishTargetType, string? messageTypeIdentifier = null, Func<IServiceProvider, object, object, CancellationToken, ValueTask>? configureOptions = null)
     {
         PublishTargetType = publishTargetType;
         MessageType = messageType;

--- a/src/AWS.Messaging/Extensions/ServiceCollectionExtensions.cs
+++ b/src/AWS.Messaging/Extensions/ServiceCollectionExtensions.cs
@@ -19,9 +19,9 @@ public static class ServiceCollectionExtensions
     /// Allows the configuration of the messaging framework by exposing methods to add publishers and subscribers.
     /// </summary>
     /// <param name="services"><see cref="IServiceCollection"/></param>
-    /// <param name="builder">An action to define the message framework configuration using <see cref="MessageBusBuilder"/></param>
+    /// <param name="builder">An action to define the message framework configuration using <see cref="IMessageBusBuilder"/></param>
     [RequiresUnreferencedCode("This API requires using unreferenced code for reflection based JSON serialization. Use AddAWSMessageBus overload that takes JsonSerializerContext parameter to avoid using unreferenced code.")]
-    public static IServiceCollection AddAWSMessageBus(this IServiceCollection services, Action<MessageBusBuilder> builder)
+    public static IServiceCollection AddAWSMessageBus(this IServiceCollection services, Action<IMessageBusBuilder> builder)
     {
         return ConfigureMessagingServices(services, new NullMessageJsonSerializerContextContainer(), builder);
     }

--- a/src/AWS.Messaging/Publishers/EventBridge/EventBridgePublisher.cs
+++ b/src/AWS.Messaging/Publishers/EventBridge/EventBridgePublisher.cs
@@ -5,7 +5,6 @@ using Amazon.EventBridge;
 using Amazon.EventBridge.Model;
 using AWS.Messaging.Configuration;
 using AWS.Messaging.Serialization;
-using AWS.Messaging.Services;
 using AWS.Messaging.Telemetry;
 using Microsoft.Extensions.Logging;
 
@@ -157,7 +156,7 @@ internal class EventBridgePublisher : IMessagePublisher, IEventBridgePublisher
 
         if (!string.IsNullOrEmpty(eventBridgeOptions?.Source))
             requestEntry.Source = eventBridgeOptions.Source;
-        else if(!string.IsNullOrEmpty(source))
+        else if (!string.IsNullOrEmpty(source))
             requestEntry.Source = source;
 
         if (!string.IsNullOrEmpty(eventBridgeOptions?.TraceHeader))

--- a/src/AWS.Messaging/Publishers/MessageRoutingPublisher.cs
+++ b/src/AWS.Messaging/Publishers/MessageRoutingPublisher.cs
@@ -49,10 +49,16 @@ internal class MessageRoutingPublisher : IMessagePublisher
         }.ToFrozenDictionary();
 
     /// <summary>
-    /// This dictionary serves as a method to cache created instances of <see cref="ICommandPublisher"/>,
+    /// This dictionary serves as a method to cache created instances of <see cref="ISQSPublisher"/>,
     /// to avoid having to create a new instance any time a message is sent.
     /// </summary>
-    private readonly ConcurrentDictionary<Type, ICommandPublisher> _commandPublisherInstances = new();
+    private readonly ConcurrentDictionary<Type, ISQSPublisher> _sqsPublisherInstances = new();
+
+    /// <summary>
+    /// This dictionary serves as a method to cache created instances of <see cref="ISNSPublisher"/>,
+    /// to avoid having to create a new instance any time a message is published.
+    /// </summary>
+    private readonly ConcurrentDictionary<Type, ISNSPublisher> _snsPublisherInstances = new();
 
     /// <summary>
     /// This dictionary serves as a method to cache created instances of <see cref="IEventPublisher"/>,
@@ -88,10 +94,29 @@ internal class MessageRoutingPublisher : IMessagePublisher
 
                 if (s_publisherTypeMapping.TryGetValue(mapping.PublishTargetType, out var publisherType))
                 {
-                    if (typeof(ICommandPublisher).IsAssignableFrom(publisherType))
+                    if (typeof(ISQSPublisher).IsAssignableFrom(publisherType))
                     {
-                        var publisher = _commandPublisherInstances.GetOrAdd(publisherType, _ => (ICommandPublisher) ActivatorUtilities.CreateInstance(_serviceProvider, publisherType));
-                        return await publisher.SendAsync(message, token);
+                        SQSOptions? options = null;
+                        if (mapping.ConfigureOptions != null)
+                        {
+                            options = new SQSOptions();
+                            mapping.ConfigureOptions?.Invoke(message!, options);
+                        }
+
+                        var publisher = _sqsPublisherInstances.GetOrAdd(publisherType, _ => (ISQSPublisher) ActivatorUtilities.CreateInstance(_serviceProvider, publisherType));
+                        return await publisher.SendAsync(message, options, token);
+                    }
+                    else if (typeof(ISNSPublisher).IsAssignableFrom(publisherType))
+                    {
+                        SNSOptions? options = null;
+                        if (mapping.ConfigureOptions != null)
+                        {
+                            options = new SNSOptions();
+                            mapping.ConfigureOptions?.Invoke(message!, options);
+                        }
+
+                        var publisher = _snsPublisherInstances.GetOrAdd(publisherType, _ => (ISNSPublisher)ActivatorUtilities.CreateInstance(_serviceProvider, publisherType));
+                        return await publisher.PublishAsync(message, options, token);
                     }
                     else if (typeof(IEventPublisher).IsAssignableFrom(publisherType))
                     {

--- a/src/AWS.Messaging/Publishers/MessageRoutingPublisher.cs
+++ b/src/AWS.Messaging/Publishers/MessageRoutingPublisher.cs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Collections.Concurrent;
-using System.Collections.Frozen;
 using AWS.Messaging.Configuration;
 using AWS.Messaging.Publishers.EventBridge;
 using AWS.Messaging.Publishers.SNS;
@@ -41,31 +39,6 @@ internal class MessageRoutingPublisher : IMessagePublisher
         _telemetryFactory = telemetryFactory;
     }
 
-    private static readonly FrozenDictionary<string, Type> s_publisherTypeMapping = new Dictionary<string, Type>
-        {
-            { PublisherTargetType.SQS_PUBLISHER, typeof(SQSPublisher) },
-            { PublisherTargetType.SNS_PUBLISHER, typeof(SNSPublisher) },
-            { PublisherTargetType.EVENTBRIDGE_PUBLISHER, typeof(EventBridgePublisher) }
-        }.ToFrozenDictionary();
-
-    /// <summary>
-    /// This dictionary serves as a method to cache created instances of <see cref="ISQSPublisher"/>,
-    /// to avoid having to create a new instance any time a message is sent.
-    /// </summary>
-    private readonly ConcurrentDictionary<Type, ISQSPublisher> _sqsPublisherInstances = new();
-
-    /// <summary>
-    /// This dictionary serves as a method to cache created instances of <see cref="ISNSPublisher"/>,
-    /// to avoid having to create a new instance any time a message is published.
-    /// </summary>
-    private readonly ConcurrentDictionary<Type, ISNSPublisher> _snsPublisherInstances = new();
-
-    /// <summary>
-    /// This dictionary serves as a method to cache created instances of <see cref="IEventPublisher"/>,
-    /// to avoid having to create a new instance any time a message is published.
-    /// </summary>
-    private readonly ConcurrentDictionary<Type, IEventBridgePublisher> _eventPublisherInstances = new();
-
     /// <summary>
     /// Publishes a user-defined message to an AWS service based on the
     /// configuration done during startup. It retrieves the <see cref="PublisherMapping"/> corresponding to the
@@ -92,56 +65,44 @@ internal class MessageRoutingPublisher : IMessagePublisher
 
                 trace.AddMetadata(TelemetryKeys.PublishTargetType, mapping.PublishTargetType);
 
-                if (s_publisherTypeMapping.TryGetValue(mapping.PublishTargetType, out var publisherType))
+                switch (mapping.PublishTargetType)
                 {
-                    if (typeof(ISQSPublisher).IsAssignableFrom(publisherType))
-                    {
-                        SQSOptions? options = null;
+                    case PublisherTargetType.SQS_PUBLISHER:
+                        SQSOptions? sqsOptions = null;
                         if (mapping.ConfigureOptions != null)
                         {
-                            options = new SQSOptions();
-                            mapping.ConfigureOptions?.Invoke(message!, options);
+                            sqsOptions = new SQSOptions();
+                            await mapping.ConfigureOptions(_serviceProvider, message!, sqsOptions, token);
                         }
 
-                        var publisher = _sqsPublisherInstances.GetOrAdd(publisherType, _ => (ISQSPublisher) ActivatorUtilities.CreateInstance(_serviceProvider, publisherType));
-                        return await publisher.SendAsync(message, options, token);
-                    }
-                    else if (typeof(ISNSPublisher).IsAssignableFrom(publisherType))
-                    {
-                        SNSOptions? options = null;
+                        var sqsPublisher = _serviceProvider.GetRequiredService<ISQSPublisher>();
+                        return await sqsPublisher.SendAsync(message, sqsOptions, token);
+
+                    case PublisherTargetType.SNS_PUBLISHER:
+                        SNSOptions? snsOptions = null;
                         if (mapping.ConfigureOptions != null)
                         {
-                            options = new SNSOptions();
-                            mapping.ConfigureOptions?.Invoke(message!, options);
+                            snsOptions = new SNSOptions();
+                            await mapping.ConfigureOptions(_serviceProvider, message!, snsOptions, token);
                         }
 
-                        var publisher = _snsPublisherInstances.GetOrAdd(publisherType, _ => (ISNSPublisher)ActivatorUtilities.CreateInstance(_serviceProvider, publisherType));
-                        return await publisher.PublishAsync(message, options, token);
-                    }
-                    else if (typeof(IEventBridgePublisher).IsAssignableFrom(publisherType))
-                    {
-                        EventBridgeOptions? options = null;
+                        var snsPublisher = _serviceProvider.GetRequiredService<ISNSPublisher>();
+                        return await snsPublisher.PublishAsync(message, snsOptions, token);
+
+                    case PublisherTargetType.EVENTBRIDGE_PUBLISHER:
+                        EventBridgeOptions? ebOptions = null;
                         if (mapping.ConfigureOptions != null)
                         {
-                            options = new EventBridgeOptions();
-                            mapping.ConfigureOptions?.Invoke(message!, options);
+                            ebOptions = new EventBridgeOptions();
+                            await mapping.ConfigureOptions(_serviceProvider, message!, ebOptions, token);
                         }
 
-                        var publisher = _eventPublisherInstances.GetOrAdd(publisherType, _ => (IEventBridgePublisher) ActivatorUtilities.CreateInstance(_serviceProvider, publisherType));
-                        return await publisher.PublishAsync(message, options, token);
-                    }
-                    else
-                    {
-                        _logger.LogError("The message publisher corresponding to the type '{PublishTargetType}' is invalid " +
-                                         "and does not implement the interface '{EventInterfaceType}' or '{SNSInterfaceType}' or '{SQSInterfaceType}'.", mapping.PublishTargetType, typeof(IEventBridgePublisher), typeof(ISNSPublisher), typeof(ISQSPublisher));
-                        throw new InvalidPublisherTypeException($"The message publisher corresponding to the type '{mapping.PublishTargetType}' is invalid " +
-                                                                $"and does not implement the interface '{typeof(IEventBridgePublisher)}' or '{typeof(ISNSPublisher)}' or '{typeof(ISQSPublisher)}'.");
-                    }
-                }
-                else
-                {
-                    _logger.LogError("The publisher type '{PublishTargetType}' is not supported.", mapping.PublishTargetType);
-                    throw new UnsupportedPublisherException($"The publisher type '{mapping.PublishTargetType}' is not supported.");
+                        var ebPublisher = _serviceProvider.GetRequiredService<IEventBridgePublisher>();
+                        return await ebPublisher.PublishAsync(message, ebOptions, token);
+
+                    default:
+                        _logger.LogError("The publisher type '{PublishTargetType}' is not supported.", mapping.PublishTargetType);
+                        throw new UnsupportedPublisherException($"The publisher type '{mapping.PublishTargetType}' is not supported.");
                 }
             }
             catch (Exception ex)

--- a/src/AWS.Messaging/Publishers/MessageRoutingPublisher.cs
+++ b/src/AWS.Messaging/Publishers/MessageRoutingPublisher.cs
@@ -126,9 +126,9 @@ internal class MessageRoutingPublisher : IMessagePublisher
                     else
                     {
                         _logger.LogError("The message publisher corresponding to the type '{PublishTargetType}' is invalid " +
-                                         "and does not implement the interface '{CommandInterfaceType}' or '{EventInterfaceType}'.", mapping.PublishTargetType, typeof(ICommandPublisher), typeof(IEventPublisher));
+                                         "and does not implement the interface '{EventInterfaceType}' or '{SNSInterfaceType}' or '{SQSInterfaceType}'.", mapping.PublishTargetType, typeof(IEventPublisher), typeof(ISNSPublisher), typeof(ISQSPublisher));
                         throw new InvalidPublisherTypeException($"The message publisher corresponding to the type '{mapping.PublishTargetType}' is invalid " +
-                                                                $"and does not implement the interface '{typeof(ICommandPublisher)}' or '{typeof(IEventPublisher)}'.");
+                                                                $"and does not implement the interface '{typeof(IEventPublisher)}' or '{typeof(ISNSPublisher)}' or '{typeof(ISQSPublisher)}'.");
                     }
                 }
                 else

--- a/src/AWS.Messaging/Publishers/MessageRoutingPublisher.cs
+++ b/src/AWS.Messaging/Publishers/MessageRoutingPublisher.cs
@@ -64,7 +64,7 @@ internal class MessageRoutingPublisher : IMessagePublisher
     /// This dictionary serves as a method to cache created instances of <see cref="IEventPublisher"/>,
     /// to avoid having to create a new instance any time a message is published.
     /// </summary>
-    private readonly ConcurrentDictionary<Type, IEventPublisher> _eventPublisherInstances = new();
+    private readonly ConcurrentDictionary<Type, IEventBridgePublisher> _eventPublisherInstances = new();
 
     /// <summary>
     /// Publishes a user-defined message to an AWS service based on the
@@ -118,17 +118,24 @@ internal class MessageRoutingPublisher : IMessagePublisher
                         var publisher = _snsPublisherInstances.GetOrAdd(publisherType, _ => (ISNSPublisher)ActivatorUtilities.CreateInstance(_serviceProvider, publisherType));
                         return await publisher.PublishAsync(message, options, token);
                     }
-                    else if (typeof(IEventPublisher).IsAssignableFrom(publisherType))
+                    else if (typeof(IEventBridgePublisher).IsAssignableFrom(publisherType))
                     {
-                        var publisher = _eventPublisherInstances.GetOrAdd(publisherType, _ => (IEventPublisher) ActivatorUtilities.CreateInstance(_serviceProvider, publisherType));
-                        return await publisher.PublishAsync(message, token);
+                        EventBridgeOptions? options = null;
+                        if (mapping.ConfigureOptions != null)
+                        {
+                            options = new EventBridgeOptions();
+                            mapping.ConfigureOptions?.Invoke(message!, options);
+                        }
+
+                        var publisher = _eventPublisherInstances.GetOrAdd(publisherType, _ => (IEventBridgePublisher) ActivatorUtilities.CreateInstance(_serviceProvider, publisherType));
+                        return await publisher.PublishAsync(message, options, token);
                     }
                     else
                     {
                         _logger.LogError("The message publisher corresponding to the type '{PublishTargetType}' is invalid " +
-                                         "and does not implement the interface '{EventInterfaceType}' or '{SNSInterfaceType}' or '{SQSInterfaceType}'.", mapping.PublishTargetType, typeof(IEventPublisher), typeof(ISNSPublisher), typeof(ISQSPublisher));
+                                         "and does not implement the interface '{EventInterfaceType}' or '{SNSInterfaceType}' or '{SQSInterfaceType}'.", mapping.PublishTargetType, typeof(IEventBridgePublisher), typeof(ISNSPublisher), typeof(ISQSPublisher));
                         throw new InvalidPublisherTypeException($"The message publisher corresponding to the type '{mapping.PublishTargetType}' is invalid " +
-                                                                $"and does not implement the interface '{typeof(IEventPublisher)}' or '{typeof(ISNSPublisher)}' or '{typeof(ISQSPublisher)}'.");
+                                                                $"and does not implement the interface '{typeof(IEventBridgePublisher)}' or '{typeof(ISNSPublisher)}' or '{typeof(ISQSPublisher)}'.");
                     }
                 }
                 else

--- a/test/AWS.Messaging.UnitTests/MessagePublisherTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessagePublisherTests.cs
@@ -4,26 +4,26 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using AWS.Messaging.Configuration;
-using Microsoft.Extensions.Logging;
-using Xunit;
-using Moq;
-using AWS.Messaging.Publishers;
-using System.Threading.Tasks;
-using AWS.Messaging.UnitTests.Models;
-using Amazon.SQS;
-using AWS.Messaging.Serialization;
 using System.Threading;
-using Amazon.SQS.Model;
-using Amazon.SimpleNotificationService;
-using Amazon.SimpleNotificationService.Model;
+using System.Threading.Tasks;
 using Amazon.EventBridge;
 using Amazon.EventBridge.Model;
+using Amazon.SimpleNotificationService;
+using Amazon.SimpleNotificationService.Model;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using AWS.Messaging.Configuration;
+using AWS.Messaging.Publishers;
 using AWS.Messaging.Publishers.EventBridge;
-using AWS.Messaging.Telemetry;
-using Microsoft.Extensions.DependencyInjection;
-using AWS.Messaging.Publishers.SQS;
 using AWS.Messaging.Publishers.SNS;
+using AWS.Messaging.Publishers.SQS;
+using AWS.Messaging.Serialization;
+using AWS.Messaging.Telemetry;
+using AWS.Messaging.UnitTests.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
 using SQSBatchResultErrorEntry = Amazon.SQS.Model.BatchResultErrorEntry;
 
 namespace AWS.Messaging.UnitTests;
@@ -83,9 +83,9 @@ public class MessagePublisherTests
                 It.Is<SendMessageRequest>(request =>
                     request.QueueUrl.Equals("endpoint")),
                 It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageResponse()
-        {
-            MessageId = "MessageId"
-        });
+                {
+                    MessageId = "MessageId"
+                });
 
         var result = await messagePublisher.PublishAsync(_chatMessage);
 
@@ -101,7 +101,7 @@ public class MessagePublisherTests
     [Fact]
     public async Task SQSPublisher_UserConfiguredOptions()
     {
-        var configureOptionsCalled = false; 
+        var configureOptionsCalled = false;
         var serviceProvider = SetupSQSPublisherDIServices(configureOptions: (message, options) =>
         {
             options.DelaySeconds = 10;
@@ -396,9 +396,9 @@ public class MessagePublisherTests
                 It.Is<SendMessageRequest>(request =>
                     request.QueueUrl.Equals("overrideEndpoint")),
                 It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageResponse()
-        {
-            MessageId = "MessageId"
-        });
+                {
+                    MessageId = "MessageId"
+                });
 
         var sendResult = await messagePublisher.SendAsync(_chatMessage,
             new SQSOptions
@@ -510,9 +510,9 @@ public class MessagePublisherTests
         _snsClient.Setup(x => x.PublishAsync(It.Is<PublishRequest>(request =>
                 request.TopicArn.Equals("endpoint")),
             It.IsAny<CancellationToken>())).ReturnsAsync(new PublishResponse()
-        {
-            MessageId = "MessageId"
-        });
+            {
+                MessageId = "MessageId"
+            });
 
         var publishResult = await messagePublisher.PublishAsync(_chatMessage);
 
@@ -545,9 +545,9 @@ public class MessagePublisherTests
         _snsClient.Setup(x => x.PublishAsync(It.Is<PublishRequest>(request =>
                 request.TopicArn.Equals("endpoint")),
             It.IsAny<CancellationToken>())).ReturnsAsync(new PublishResponse()
-        {
-            MessageId = "MessageId"
-        });
+            {
+                MessageId = "MessageId"
+            });
 
         var publishResult = await messagePublisher.PublishAsync(_chatMessage);
 
@@ -573,9 +573,9 @@ public class MessagePublisherTests
             x.PublishAsync(
                 It.IsAny<PublishRequest>(),
                 It.IsAny<CancellationToken>())).ReturnsAsync(new PublishResponse()
-        {
-            MessageId = "MessageId"
-        });
+                {
+                    MessageId = "MessageId"
+                });
 
         telemetryFactory.Setup(x => x.Trace(It.IsAny<string>())).Returns(telemetryTrace.Object);
         telemetryTrace.Setup(x => x.AddMetadata(It.IsAny<string>(), It.IsAny<string>()));
@@ -691,9 +691,9 @@ public class MessagePublisherTests
                 It.Is<PublishRequest>(request =>
                     request.TopicArn.Equals("overrideTopicArn")),
                 It.IsAny<CancellationToken>())).ReturnsAsync(new PublishResponse()
-        {
-            MessageId = "MessageId"
-        });
+                {
+                    MessageId = "MessageId"
+                });
 
         var publishResponse = await messagePublisher.PublishAsync(_chatMessage,
             new SNSOptions
@@ -756,14 +756,15 @@ public class MessagePublisherTests
         await Assert.ThrowsAsync<InvalidPublisherEndpointException>(() => messagePublisher.PublishAsync(_chatMessage, new SNSOptions()));
     }
 
-    private IServiceProvider SetupEventBridgePublisherDIServices(string eventBusName, string? endpointID = null)
+    private IServiceProvider SetupEventBridgePublisherDIServices(string eventBusName, string? endpointID = null, Action<ChatMessage, EventBridgeOptions>? configureOptions = null)
     {
         var publisherConfiguration = new EventBridgePublisherConfiguration(eventBusName)
         {
             EndpointID = endpointID
         };
 
-        var publisherMapping = new PublisherMapping(typeof(ChatMessage), publisherConfiguration, PublisherTargetType.EVENTBRIDGE_PUBLISHER);
+        Action<object, object>? configureOptionsAction = configureOptions != null ? (message, options) => configureOptions((ChatMessage)message, (EventBridgeOptions)options) : null;
+        var publisherMapping = new PublisherMapping(typeof(ChatMessage), publisherConfiguration, PublisherTargetType.EVENTBRIDGE_PUBLISHER, null, configureOptionsAction);
 
         _messageConfiguration.Setup(x => x.GetPublisherMapping(typeof(ChatMessage))).Returns(publisherMapping);
 
@@ -822,6 +823,49 @@ public class MessagePublisherTests
             Times.Exactly(1));
 
         Assert.Equal("ReturnedEventId", publishResponse.MessageId);
+    }
+
+    [Fact]
+    public async Task EventBridgePublisher_UserConfiguredOptions()
+    {
+        var configureOptionsCalled = false;
+        var serviceProvider = SetupEventBridgePublisherDIServices("event-bus-123", configureOptions: (message, options) =>
+        {
+            options.Source = "updated-source";
+            configureOptionsCalled = true;
+        });
+
+        _eventBridgeClient.Setup(x => x.PutEventsAsync(It.IsAny<PutEventsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(new PutEventsResponse
+        {
+            Entries = new List<PutEventsResultEntry>
+            {
+                new()
+                {
+                    EventId = "ReturnedEventId"
+                }
+            }
+        });
+
+        var messagePublisher = new MessageRoutingPublisher(
+            serviceProvider,
+            _messageConfiguration.Object,
+            _messagePublisherLogger.Object,
+            new DefaultTelemetryFactory(serviceProvider)
+        );
+
+        var publishResponse = await messagePublisher.PublishAsync(_chatMessage);
+
+        _eventBridgeClient.Verify(x =>
+                x.PutEventsAsync(
+                    It.Is<PutEventsRequest>(request =>
+                        request.Entries[0].EventBusName.Equals("event-bus-123") && string.IsNullOrEmpty(request.EndpointId)
+                                                                                && request.Entries[0].DetailType.Equals("AWS.Messaging.UnitTests.Models.ChatMessage")
+                                                                                && request.Entries[0].Source.Equals("updated-source")),
+                    It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
+
+        Assert.Equal("ReturnedEventId", publishResponse.MessageId);
+        Assert.True(configureOptionsCalled, "Expected user configured options to be applied, but configureOptions was not called.");
     }
 
     [Fact]
@@ -1203,15 +1247,15 @@ public class MessagePublisherTests
                     request.QueueUrl.Equals("endpoint") &&
                     request.Entries.Count == 3),
                 It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageBatchResponse
-        {
-            Successful = new List<SendMessageBatchResultEntry>
+                {
+                    Successful = new List<SendMessageBatchResultEntry>
             {
                 new() { Id = "id1", MessageId = "msg1" },
                 new() { Id = "id2", MessageId = "msg2" },
                 new() { Id = "id3", MessageId = "msg3" }
             },
-            Failed = new List<SQSBatchResultErrorEntry>()
-        });
+                    Failed = new List<SQSBatchResultErrorEntry>()
+                });
 
         var messages = new List<ChatMessage>
         {
@@ -1241,16 +1285,16 @@ public class MessagePublisherTests
             x.SendMessageBatchAsync(
                 It.IsAny<SendMessageBatchRequest>(),
                 It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageBatchResponse
-        {
-            Successful = new List<SendMessageBatchResultEntry>
+                {
+                    Successful = new List<SendMessageBatchResultEntry>
             {
                 new() { Id = "id1", MessageId = "msg1" }
             },
-            Failed = new List<SQSBatchResultErrorEntry>
+                    Failed = new List<SQSBatchResultErrorEntry>
             {
                 new() { Id = "id2", Code = "InternalError", Message = "Something went wrong", SenderFault = false }
             }
-        });
+                });
 
         var messages = new List<ChatMessage>
         {
@@ -1369,14 +1413,14 @@ public class MessagePublisherTests
                 It.Is<SendMessageBatchRequest>(req =>
                     req.Entries.All(e => e.MessageGroupId == "group1")),
                 It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageBatchResponse
-        {
-            Successful = new List<SendMessageBatchResultEntry>
+                {
+                    Successful = new List<SendMessageBatchResultEntry>
             {
                 new() { Id = "id1", MessageId = "msg1" },
                 new() { Id = "id2", MessageId = "msg2" }
             },
-            Failed = new List<SQSBatchResultErrorEntry>()
-        });
+                    Failed = new List<SQSBatchResultErrorEntry>()
+                });
 
         var entries = new List<SQSBatchEntry<ChatMessage>>
         {
@@ -1407,14 +1451,14 @@ public class MessagePublisherTests
             x.SendMessageBatchAsync(
                 It.IsAny<SendMessageBatchRequest>(),
                 It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageBatchResponse
-        {
-            Successful = new List<SendMessageBatchResultEntry>
+                {
+                    Successful = new List<SendMessageBatchResultEntry>
             {
                 new() { Id = "id1", MessageId = "msg1" },
                 new() { Id = "id2", MessageId = "msg2" }
             },
-            Failed = new List<SQSBatchResultErrorEntry>()
-        });
+                    Failed = new List<SQSBatchResultErrorEntry>()
+                });
 
         var entries = new List<SQSBatchEntry<ChatMessage>>
         {
@@ -1449,13 +1493,13 @@ public class MessagePublisherTests
             x.SendMessageBatchAsync(
                 It.IsAny<SendMessageBatchRequest>(),
                 It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageBatchResponse
-        {
-            Successful = new List<SendMessageBatchResultEntry>
+                {
+                    Successful = new List<SendMessageBatchResultEntry>
             {
                 new() { Id = "id1", MessageId = "msg1" }
             },
-            Failed = new List<SQSBatchResultErrorEntry>()
-        });
+                    Failed = new List<SQSBatchResultErrorEntry>()
+                });
 
         var entries = new List<SQSBatchEntry<ChatMessage>>
         {
@@ -1494,13 +1538,13 @@ public class MessagePublisherTests
             x.SendMessageBatchAsync(
                 It.Is<SendMessageBatchRequest>(req => req.QueueUrl.Equals("overrideEndpoint")),
                 It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageBatchResponse
-        {
-            Successful = new List<SendMessageBatchResultEntry>
+                {
+                    Successful = new List<SendMessageBatchResultEntry>
             {
                 new() { Id = "id1", MessageId = "msg1" }
             },
-            Failed = new List<SQSBatchResultErrorEntry>()
-        });
+                    Failed = new List<SQSBatchResultErrorEntry>()
+                });
 
         var entries = new List<SQSBatchEntry<ChatMessage>>
         {

--- a/test/AWS.Messaging.UnitTests/MessagePublisherTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessagePublisherTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,6 +19,7 @@ using AWS.Messaging.Publishers.EventBridge;
 using AWS.Messaging.Publishers.SNS;
 using AWS.Messaging.Publishers.SQS;
 using AWS.Messaging.Serialization;
+using AWS.Messaging.Services;
 using AWS.Messaging.Telemetry;
 using AWS.Messaging.UnitTests.Models;
 using Microsoft.Extensions.DependencyInjection;
@@ -83,9 +85,9 @@ public class MessagePublisherTests
                 It.Is<SendMessageRequest>(request =>
                     request.QueueUrl.Equals("endpoint")),
                 It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageResponse()
-                {
-                    MessageId = "MessageId"
-                });
+        {
+            MessageId = "MessageId"
+        });
 
         var result = await messagePublisher.PublishAsync(_chatMessage);
 
@@ -101,13 +103,18 @@ public class MessagePublisherTests
     [Fact]
     public async Task SQSPublisher_UserConfiguredOptions()
     {
-        var configureOptionsCalled = false;
-        var serviceProvider = SetupSQSPublisherDIServices(configureOptions: (message, options) =>
+        var configureOptionsCalled = false; 
+        var serviceProvider = SetupSQSPublisherDIServices(configureOptions: (sp, message, options, _) =>
         {
             options.DelaySeconds = 10;
             options.MessageDeduplicationId = "deduplication-id";
             options.MessageGroupId = "group-id";
             configureOptionsCalled = true;
+
+            var serviceProviderAcquiredService = sp.GetService<IMessageConfiguration>();
+            Assert.NotNull(serviceProviderAcquiredService);
+
+            return ValueTask.CompletedTask;
         });
 
         var messagePublisher = new MessageRoutingPublisher(
@@ -335,9 +342,12 @@ public class MessagePublisherTests
         await Assert.ThrowsAsync<InvalidMessageException>(() => messagePublisher.PublishAsync<ChatMessage?>(null));
     }
 
-    private IServiceProvider SetupSQSPublisherDIServices(string queueUrl = "endpoint", Action<ChatMessage, SQSOptions>? configureOptions = null)
+    private IServiceProvider SetupSQSPublisherDIServices(string queueUrl = "endpoint", Func<IServiceProvider, ChatMessage, SQSOptions, CancellationToken, ValueTask>? configureOptions = null)
     {
-        Action<object, object>? configureOptionsAction = configureOptions != null ? (message, options) => configureOptions((ChatMessage)message, (SQSOptions)options) : null;
+        Func<IServiceProvider, object, object, CancellationToken, ValueTask>? configureOptionsAction = configureOptions != null
+            ? (sp, message, option, cancellationToken) => { configureOptions(sp, (ChatMessage)message, (SQSOptions)option, cancellationToken); return ValueTask.CompletedTask; }
+            : null;
+
         var publisherConfiguration = new SQSPublisherConfiguration(queueUrl);
         var publisherMapping = new PublisherMapping(typeof(ChatMessage), publisherConfiguration, PublisherTargetType.SQS_PUBLISHER, configureOptions: configureOptionsAction);
 
@@ -350,6 +360,7 @@ public class MessagePublisherTests
         services.AddSingleton<IEnvelopeSerializer>(_envelopeSerializer.Object);
         services.AddSingleton<IAWSClientProvider, AWSClientProvider>();
         services.AddSingleton<ITelemetryFactory, DefaultTelemetryFactory>();
+        services.AddSingleton<ISQSPublisher, SQSPublisher>();
 
         return services.BuildServiceProvider();
     }
@@ -396,9 +407,9 @@ public class MessagePublisherTests
                 It.Is<SendMessageRequest>(request =>
                     request.QueueUrl.Equals("overrideEndpoint")),
                 It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageResponse()
-                {
-                    MessageId = "MessageId"
-                });
+        {
+            MessageId = "MessageId"
+        });
 
         var sendResult = await messagePublisher.SendAsync(_chatMessage,
             new SQSOptions
@@ -466,9 +477,12 @@ public class MessagePublisherTests
         await Assert.ThrowsAsync<InvalidPublisherEndpointException>(() => messagePublisher.SendAsync(_chatMessage, new SQSOptions()));
     }
 
-    private IServiceProvider SetupSNSPublisherDIServices(string topicArn = "endpoint", Action<ChatMessage, SNSOptions>? configureOptions = null)
+    private IServiceProvider SetupSNSPublisherDIServices(string topicArn = "endpoint", Func<IServiceProvider, ChatMessage, SNSOptions, CancellationToken, ValueTask>? configureOptions = null)
     {
-        Action<object, object>? configureOptionsAction = configureOptions != null ? (message, options) => configureOptions((ChatMessage)message, (SNSOptions)options) : null;
+        Func<IServiceProvider, object, object, CancellationToken, ValueTask>? configureOptionsAction = configureOptions != null
+            ? (sp, message, options, cancellationToken) => { return configureOptions(sp, (ChatMessage)message, (SNSOptions)options, cancellationToken); }
+            : null;
+
         var publisherConfiguration = new SNSPublisherConfiguration(topicArn);
         var publisherMapping = new PublisherMapping(typeof(ChatMessage), publisherConfiguration, PublisherTargetType.SNS_PUBLISHER, configureOptions: configureOptionsAction);
 
@@ -481,6 +495,7 @@ public class MessagePublisherTests
         services.AddSingleton<IEnvelopeSerializer>(_envelopeSerializer.Object);
         services.AddSingleton<IAWSClientProvider, AWSClientProvider>();
         services.AddSingleton<ITelemetryFactory, DefaultTelemetryFactory>();
+        services.AddSingleton<ISNSPublisher, SNSPublisher>();
 
         return services.BuildServiceProvider();
     }
@@ -510,9 +525,9 @@ public class MessagePublisherTests
         _snsClient.Setup(x => x.PublishAsync(It.Is<PublishRequest>(request =>
                 request.TopicArn.Equals("endpoint")),
             It.IsAny<CancellationToken>())).ReturnsAsync(new PublishResponse()
-            {
-                MessageId = "MessageId"
-            });
+        {
+            MessageId = "MessageId"
+        });
 
         var publishResult = await messagePublisher.PublishAsync(_chatMessage);
 
@@ -529,11 +544,16 @@ public class MessagePublisherTests
     public async Task SNSPublisher_UserConfiguredOptions()
     {
         var configureOptionsCalled = false;
-        var serviceProvider = SetupSNSPublisherDIServices(configureOptions: (message, options) =>
+        var serviceProvider = SetupSNSPublisherDIServices(configureOptions: (sp, message, options, _) =>
         {
             options.MessageDeduplicationId = "deduplication-id";
             options.MessageGroupId = "group-id";
             configureOptionsCalled = true;
+
+            var serviceProviderAcquiredService = sp.GetService<IMessageConfiguration>();
+            Assert.NotNull(serviceProviderAcquiredService);
+
+            return ValueTask.CompletedTask;
         });
 
         var messagePublisher = new MessageRoutingPublisher(
@@ -545,9 +565,9 @@ public class MessagePublisherTests
         _snsClient.Setup(x => x.PublishAsync(It.Is<PublishRequest>(request =>
                 request.TopicArn.Equals("endpoint")),
             It.IsAny<CancellationToken>())).ReturnsAsync(new PublishResponse()
-            {
-                MessageId = "MessageId"
-            });
+        {
+            MessageId = "MessageId"
+        });
 
         var publishResult = await messagePublisher.PublishAsync(_chatMessage);
 
@@ -573,9 +593,9 @@ public class MessagePublisherTests
             x.PublishAsync(
                 It.IsAny<PublishRequest>(),
                 It.IsAny<CancellationToken>())).ReturnsAsync(new PublishResponse()
-                {
-                    MessageId = "MessageId"
-                });
+        {
+            MessageId = "MessageId"
+        });
 
         telemetryFactory.Setup(x => x.Trace(It.IsAny<string>())).Returns(telemetryTrace.Object);
         telemetryTrace.Setup(x => x.AddMetadata(It.IsAny<string>(), It.IsAny<string>()));
@@ -691,9 +711,9 @@ public class MessagePublisherTests
                 It.Is<PublishRequest>(request =>
                     request.TopicArn.Equals("overrideTopicArn")),
                 It.IsAny<CancellationToken>())).ReturnsAsync(new PublishResponse()
-                {
-                    MessageId = "MessageId"
-                });
+        {
+            MessageId = "MessageId"
+        });
 
         var publishResponse = await messagePublisher.PublishAsync(_chatMessage,
             new SNSOptions
@@ -756,14 +776,17 @@ public class MessagePublisherTests
         await Assert.ThrowsAsync<InvalidPublisherEndpointException>(() => messagePublisher.PublishAsync(_chatMessage, new SNSOptions()));
     }
 
-    private IServiceProvider SetupEventBridgePublisherDIServices(string eventBusName, string? endpointID = null, Action<ChatMessage, EventBridgeOptions>? configureOptions = null)
+    private IServiceProvider SetupEventBridgePublisherDIServices(string eventBusName, string? endpointID = null, Func<IServiceProvider, ChatMessage, EventBridgeOptions, CancellationToken, ValueTask>? configureOptions = null)
     {
+        Func<IServiceProvider, object, object, CancellationToken, ValueTask>? configureOptionsAction = configureOptions != null
+            ? (sp, message, options, cancellationToken) => { return configureOptions(sp, (ChatMessage)message, (EventBridgeOptions)options, cancellationToken); }
+        : null;
+
         var publisherConfiguration = new EventBridgePublisherConfiguration(eventBusName)
         {
             EndpointID = endpointID
         };
 
-        Action<object, object>? configureOptionsAction = configureOptions != null ? (message, options) => configureOptions((ChatMessage)message, (EventBridgeOptions)options) : null;
         var publisherMapping = new PublisherMapping(typeof(ChatMessage), publisherConfiguration, PublisherTargetType.EVENTBRIDGE_PUBLISHER, null, configureOptionsAction);
 
         _messageConfiguration.Setup(x => x.GetPublisherMapping(typeof(ChatMessage))).Returns(publisherMapping);
@@ -775,6 +798,7 @@ public class MessagePublisherTests
         services.AddSingleton<IEnvelopeSerializer>(_envelopeSerializer.Object);
         services.AddSingleton<IAWSClientProvider, AWSClientProvider>();
         services.AddSingleton<ITelemetryFactory, DefaultTelemetryFactory>();
+        services.AddSingleton<IEventBridgePublisher, EventBridgePublisher>();
 
         return services.BuildServiceProvider();
     }
@@ -828,11 +852,14 @@ public class MessagePublisherTests
     [Fact]
     public async Task EventBridgePublisher_UserConfiguredOptions()
     {
-        var configureOptionsCalled = false;
-        var serviceProvider = SetupEventBridgePublisherDIServices("event-bus-123", configureOptions: (message, options) =>
+        var serviceProvider = SetupEventBridgePublisherDIServices("event-bus-123", configureOptions: (sp, message, options, cancellationToken) =>
         {
             options.Source = "updated-source";
-            configureOptionsCalled = true;
+
+            var serviceProviderAcquiredService = sp.GetService<IMessageConfiguration>();
+            Assert.NotNull(serviceProviderAcquiredService);
+
+            return ValueTask.CompletedTask;
         });
 
         _eventBridgeClient.Setup(x => x.PutEventsAsync(It.IsAny<PutEventsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(new PutEventsResponse
@@ -865,7 +892,6 @@ public class MessagePublisherTests
             Times.Exactly(1));
 
         Assert.Equal("ReturnedEventId", publishResponse.MessageId);
-        Assert.True(configureOptionsCalled, "Expected user configured options to be applied, but configureOptions was not called.");
     }
 
     [Fact]
@@ -1247,15 +1273,15 @@ public class MessagePublisherTests
                     request.QueueUrl.Equals("endpoint") &&
                     request.Entries.Count == 3),
                 It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageBatchResponse
-                {
-                    Successful = new List<SendMessageBatchResultEntry>
+        {
+            Successful = new List<SendMessageBatchResultEntry>
             {
                 new() { Id = "id1", MessageId = "msg1" },
                 new() { Id = "id2", MessageId = "msg2" },
                 new() { Id = "id3", MessageId = "msg3" }
             },
-                    Failed = new List<SQSBatchResultErrorEntry>()
-                });
+            Failed = new List<SQSBatchResultErrorEntry>()
+        });
 
         var messages = new List<ChatMessage>
         {
@@ -1285,16 +1311,16 @@ public class MessagePublisherTests
             x.SendMessageBatchAsync(
                 It.IsAny<SendMessageBatchRequest>(),
                 It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageBatchResponse
-                {
-                    Successful = new List<SendMessageBatchResultEntry>
+        {
+            Successful = new List<SendMessageBatchResultEntry>
             {
                 new() { Id = "id1", MessageId = "msg1" }
             },
-                    Failed = new List<SQSBatchResultErrorEntry>
+            Failed = new List<SQSBatchResultErrorEntry>
             {
                 new() { Id = "id2", Code = "InternalError", Message = "Something went wrong", SenderFault = false }
             }
-                });
+        });
 
         var messages = new List<ChatMessage>
         {
@@ -1413,14 +1439,14 @@ public class MessagePublisherTests
                 It.Is<SendMessageBatchRequest>(req =>
                     req.Entries.All(e => e.MessageGroupId == "group1")),
                 It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageBatchResponse
-                {
-                    Successful = new List<SendMessageBatchResultEntry>
+        {
+            Successful = new List<SendMessageBatchResultEntry>
             {
                 new() { Id = "id1", MessageId = "msg1" },
                 new() { Id = "id2", MessageId = "msg2" }
             },
-                    Failed = new List<SQSBatchResultErrorEntry>()
-                });
+            Failed = new List<SQSBatchResultErrorEntry>()
+        });
 
         var entries = new List<SQSBatchEntry<ChatMessage>>
         {
@@ -1451,14 +1477,14 @@ public class MessagePublisherTests
             x.SendMessageBatchAsync(
                 It.IsAny<SendMessageBatchRequest>(),
                 It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageBatchResponse
-                {
-                    Successful = new List<SendMessageBatchResultEntry>
+        {
+            Successful = new List<SendMessageBatchResultEntry>
             {
                 new() { Id = "id1", MessageId = "msg1" },
                 new() { Id = "id2", MessageId = "msg2" }
             },
-                    Failed = new List<SQSBatchResultErrorEntry>()
-                });
+            Failed = new List<SQSBatchResultErrorEntry>()
+        });
 
         var entries = new List<SQSBatchEntry<ChatMessage>>
         {
@@ -1493,13 +1519,13 @@ public class MessagePublisherTests
             x.SendMessageBatchAsync(
                 It.IsAny<SendMessageBatchRequest>(),
                 It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageBatchResponse
-                {
-                    Successful = new List<SendMessageBatchResultEntry>
+        {
+            Successful = new List<SendMessageBatchResultEntry>
             {
                 new() { Id = "id1", MessageId = "msg1" }
             },
-                    Failed = new List<SQSBatchResultErrorEntry>()
-                });
+            Failed = new List<SQSBatchResultErrorEntry>()
+        });
 
         var entries = new List<SQSBatchEntry<ChatMessage>>
         {
@@ -1538,13 +1564,13 @@ public class MessagePublisherTests
             x.SendMessageBatchAsync(
                 It.Is<SendMessageBatchRequest>(req => req.QueueUrl.Equals("overrideEndpoint")),
                 It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageBatchResponse
-                {
-                    Successful = new List<SendMessageBatchResultEntry>
+        {
+            Successful = new List<SendMessageBatchResultEntry>
             {
                 new() { Id = "id1", MessageId = "msg1" }
             },
-                    Failed = new List<SQSBatchResultErrorEntry>()
-                });
+            Failed = new List<SQSBatchResultErrorEntry>()
+        });
 
         var entries = new List<SQSBatchEntry<ChatMessage>>
         {

--- a/test/AWS.Messaging.UnitTests/MessagePublisherTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessagePublisherTests.cs
@@ -61,7 +61,6 @@ public class MessagePublisherTests
             Source = new Uri("/aws/messaging/unittest", UriKind.Relative)
         }));
 
-
         _chatMessage = new ChatMessage
         {
             MessageDescription = "Test Description"
@@ -97,6 +96,48 @@ public class MessagePublisherTests
                     It.IsAny<CancellationToken>()),
             Times.Exactly(1));
         Assert.Equal("MessageId", result.MessageId);
+    }
+
+    [Fact]
+    public async Task SQSPublisher_UserConfiguredOptions()
+    {
+        var configureOptionsCalled = false; 
+        var serviceProvider = SetupSQSPublisherDIServices(configureOptions: (message, options) =>
+        {
+            options.DelaySeconds = 10;
+            options.MessageDeduplicationId = "deduplication-id";
+            options.MessageGroupId = "group-id";
+            configureOptionsCalled = true;
+        });
+
+        var messagePublisher = new MessageRoutingPublisher(
+            serviceProvider,
+            _messageConfiguration.Object,
+            _messagePublisherLogger.Object,
+            new DefaultTelemetryFactory(serviceProvider)
+        );
+        _sqsClient.Setup(x =>
+            x.SendMessageAsync(
+                It.Is<SendMessageRequest>(request =>
+                    request.QueueUrl.Equals("endpoint")),
+                It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageResponse()
+                {
+                    MessageId = "MessageId"
+                });
+
+        var result = await messagePublisher.PublishAsync(_chatMessage);
+
+        _sqsClient.Verify(x =>
+                x.SendMessageAsync(
+                    It.Is<SendMessageRequest>(request =>
+                        request.QueueUrl.Equals("endpoint")
+                        && request.DelaySeconds == 10
+                        && request.MessageDeduplicationId == "deduplication-id"
+                        && request.MessageGroupId == "group-id"),
+                    It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
+        Assert.Equal("MessageId", result.MessageId);
+        Assert.True(configureOptionsCalled, "Expected user configured options to be applied, but configureOptions was not called.");
     }
 
     [Fact]
@@ -294,10 +335,11 @@ public class MessagePublisherTests
         await Assert.ThrowsAsync<InvalidMessageException>(() => messagePublisher.PublishAsync<ChatMessage?>(null));
     }
 
-    private IServiceProvider SetupSQSPublisherDIServices(string queueUrl = "endpoint")
+    private IServiceProvider SetupSQSPublisherDIServices(string queueUrl = "endpoint", Action<ChatMessage, SQSOptions>? configureOptions = null)
     {
+        Action<object, object>? configureOptionsAction = configureOptions != null ? (message, options) => configureOptions((ChatMessage)message, (SQSOptions)options) : null;
         var publisherConfiguration = new SQSPublisherConfiguration(queueUrl);
-        var publisherMapping = new PublisherMapping(typeof(ChatMessage), publisherConfiguration, PublisherTargetType.SQS_PUBLISHER);
+        var publisherMapping = new PublisherMapping(typeof(ChatMessage), publisherConfiguration, PublisherTargetType.SQS_PUBLISHER, configureOptions: configureOptionsAction);
 
         _messageConfiguration.Setup(x => x.GetPublisherMapping(typeof(ChatMessage))).Returns(publisherMapping);
 
@@ -424,10 +466,11 @@ public class MessagePublisherTests
         await Assert.ThrowsAsync<InvalidPublisherEndpointException>(() => messagePublisher.SendAsync(_chatMessage, new SQSOptions()));
     }
 
-    private IServiceProvider SetupSNSPublisherDIServices(string topicArn = "endpoint")
+    private IServiceProvider SetupSNSPublisherDIServices(string topicArn = "endpoint", Action<ChatMessage, SNSOptions>? configureOptions = null)
     {
+        Action<object, object>? configureOptionsAction = configureOptions != null ? (message, options) => configureOptions((ChatMessage)message, (SNSOptions)options) : null;
         var publisherConfiguration = new SNSPublisherConfiguration(topicArn);
-        var publisherMapping = new PublisherMapping(typeof(ChatMessage), publisherConfiguration, PublisherTargetType.SNS_PUBLISHER);
+        var publisherMapping = new PublisherMapping(typeof(ChatMessage), publisherConfiguration, PublisherTargetType.SNS_PUBLISHER, configureOptions: configureOptionsAction);
 
         _messageConfiguration.Setup(x => x.GetPublisherMapping(typeof(ChatMessage))).Returns(publisherMapping);
 
@@ -480,6 +523,44 @@ public class MessagePublisherTests
                     It.IsAny<CancellationToken>()),
             Times.Exactly(1));
         Assert.Equal("MessageId", publishResult.MessageId);
+    }
+
+    [Fact]
+    public async Task SNSPublisher_UserConfiguredOptions()
+    {
+        var configureOptionsCalled = false;
+        var serviceProvider = SetupSNSPublisherDIServices(configureOptions: (message, options) =>
+        {
+            options.MessageDeduplicationId = "deduplication-id";
+            options.MessageGroupId = "group-id";
+            configureOptionsCalled = true;
+        });
+
+        var messagePublisher = new MessageRoutingPublisher(
+            serviceProvider,
+            _messageConfiguration.Object,
+            _messagePublisherLogger.Object,
+            new DefaultTelemetryFactory(serviceProvider)
+        );
+        _snsClient.Setup(x => x.PublishAsync(It.Is<PublishRequest>(request =>
+                request.TopicArn.Equals("endpoint")),
+            It.IsAny<CancellationToken>())).ReturnsAsync(new PublishResponse()
+        {
+            MessageId = "MessageId"
+        });
+
+        var publishResult = await messagePublisher.PublishAsync(_chatMessage);
+
+        _snsClient.Verify(x =>
+                x.PublishAsync(
+                    It.Is<PublishRequest>(request =>
+                        request.TopicArn.Equals("endpoint")
+                        && request.MessageDeduplicationId == "deduplication-id"
+                        && request.MessageGroupId == "group-id"),
+                    It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
+        Assert.Equal("MessageId", publishResult.MessageId);
+        Assert.True(configureOptionsCalled, "Expected user configured options to be applied, but configureOptions was not called.");
     }
 
     [Fact]

--- a/test/AWS.Messaging.UnitTests/OpenTelemetryTests.cs
+++ b/test/AWS.Messaging.UnitTests/OpenTelemetryTests.cs
@@ -75,6 +75,7 @@ public class OpenTelemetryTests
         services.AddSingleton<ITelemetryFactory, DefaultTelemetryFactory>();
         services.AddSingleton<ITelemetryProvider, OpenTelemetryProvider>();
         services.AddSingleton<ChatMessageHandler>();
+        services.AddSingleton<ISQSPublisher, SQSPublisher>();
 
         _serviceProvider = services.BuildServiceProvider();
 


### PR DESCRIPTION
#340 

Adds optional per-message `configureOptions` callbacks to `IMessageBusBuilder.AddSQSPublisher` and `IMessageBusBuilder.AddSNSPublisher`.

With this change, applications using the generic `IMessagePublisher` can populate SQS- and SNS-specific publish options from the message being sent. This enables scenarios such as publishing to FIFO queues and topics by deriving values like `MessageGroupId` and `MessageDeduplicationId` from the message itself, while still using type-based routing through `IMessagePublisher`.
The change also allows these callbacks to override service-configured defaults for a given publish operation, providing additional flexibility when message-specific behavior is required. Documentation has been updated to describe this capability in the publishing guidance.

Example usage:
```csharp
builder.Services.AddAWSMessageBus(builder =>
{
    builder.AddSQSPublisher<TransactionInfo>(
        "https://sqs.us-west-2.amazonaws.com/012345678910/MyFifoQueue.fifo",
        configureOptions: (message, options) =>
        {
            options.MessageGroupId = message.TransactionId;
            options.MessageDeduplicationId = message.TransactionId;
        });

    builder.AddSNSPublisher<BidInfo>(
        "arn:aws:sns:us-west-2:012345678910:MyFifoTopic.fifo",
        configureOptions: (message, options) =>
        {
            options.MessageGroupId = message.BidId;
            options.MessageDeduplicationId = message.BidId;
        });
});
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
