### PR TITLE
Fix MessageBusBuilder unit tests not to rely on environment settings

### DIFF
--- a/test/AWS.Messaging.UnitTests/MessageBusBuilderTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessageBusBuilderTests.cs
@@ -37,7 +37,11 @@ public class MessageBusBuilderTests
         _serviceCollection.AddLogging();
         _serviceCollection.AddDefaultAWSOptions(new AWSOptions
         {
-            Region = Amazon.RegionEndpoint.USWest2
+            Region = Amazon.RegionEndpoint.USWest2,
+            // Fake credentials prevent the AWS SDK credential chain from running during unit tests.
+            // These are never used to make real API calls — they only satisfy ClientFactory<T>
+            // which resolves credentials eagerly at GetService<IAmazonSQS/SNS/EventBridge>() time.
+            Credentials = new Amazon.Runtime.BasicAWSCredentials("test", "test")
         });
     }
 


### PR DESCRIPTION
*Issue #, if available:*
#286 
*Description of changes:*

Preliminary step for #286 

This pull request updates the AWS configuration in the unit test setup to use fake credentials. This change ensures that the AWS SDK does not attempt to resolve real credentials during unit tests, preventing unnecessary calls and potential errors.

Test configuration improvements:

* Updated the `AWSOptions` initialization in `MessageBusBuilderTests.cs` to use `BasicAWSCredentials` with dummy values, ensuring the credential resolution chain does not run during unit tests. This prevents the AWS SDK from making real API calls or requiring valid credentials in the test environment.

*Before:*
On clean environment, following tests are failing:
```
MessageBusBuilderTests.MessageBus_AddEventBus
MessageBusBuilderTests.MessageBus_AddEventBus_WithEndpointID
MessageBusBuilderTests.MessageBus_AddSNSTopic
MessageBusBuilderTests.MessageBus_AddSQSPoller
MessageBusBuilderTests.MessageBus_AddSQSQueue
```
Exception reported:
```
  Message: 
Amazon.Runtime.AmazonClientException : Failed to resolve AWS credentials. The credential providers used to search for credentials returned the following errors:

Exception 1 of 4: The environment variables AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_SESSION_TOKEN were not set with AWS credentials.
Exception 2 of 4: The webIdentityTokenFile must be an absolute path. (Parameter 'webIdentityTokenFile')
Exception 3 of 4: Unable to find the "default" profile.
Exception 4 of 4: Failed to connect to EC2 instance metadata to retrieve credentials: Unable to get IAM security credentials from EC2 Instance Metadata Service..


  Stack Trace: 
DefaultAWSCredentialsIdentityResolver.InternalGetCredentials()
DefaultAWSCredentialsIdentityResolver.ResolveIdentity(IClientConfig clientConfig)
IIdentityResolver.ResolveIdentity(IClientConfig clientConfig)
DefaultIdentityResolverConfiguration.ResolveDefaultIdentity[T]()
ClientFactory`1.CreateCredentials(ILogger logger, AWSOptions options)
ClientFactory`1.CreateServiceClient(ILogger logger, AWSOptions options)
ClientFactory`1.CreateServiceClient(IServiceProvider provider)
CallSiteRuntimeResolver.VisitFactory(FactoryCallSite factoryCallSite, RuntimeResolverContext context)
CallSiteVisitor`2.VisitCallSiteMain(ServiceCallSite callSite, TArgument argument)
CallSiteRuntimeResolver.VisitRootCache(ServiceCallSite callSite, RuntimeResolverContext context)
CallSiteVisitor`2.VisitCallSite(ServiceCallSite callSite, TArgument argument)
CallSiteRuntimeResolver.Resolve(ServiceCallSite callSite, ServiceProviderEngineScope scope)
ServiceProvider.CreateServiceAccessor(ServiceIdentifier serviceIdentifier)
ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
ServiceProvider.GetService(ServiceIdentifier serviceIdentifier, ServiceProviderEngineScope serviceProviderEngineScope)
ServiceProvider.GetService(Type serviceType)
ServiceProviderServiceExtensions.GetService[T](IServiceProvider provider)
MessageBusBuilderTests.MessageBus_AddEventBus() line 355
RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```

After:
All unit tests pass on vanilla environment.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.