### PR TITLE
feat(SQSMessagePoller): per-poller PollingControlToken

### DIFF
--- a/.autover/changes/c379ef1f-8642-4f05-a752-e376b31baa7b.json
+++ b/.autover/changes/c379ef1f-8642-4f05-a752-e376b31baa7b.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Added an optional per-poller PollingControlToken on SQSMessagePollerOptions, allowing SQS pollers on the same message bus to be paused and resumed independently. When not set, the poller continues to use the bus-scoped token configured via ConfigurePollingControlToken."
+      ]
+    }
+  ]
+}

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -146,7 +146,8 @@ public class MessageBusBuilder : IMessageBusBuilder
             VisibilityTimeoutExtensionThreshold = sqsMessagePollerOptions.VisibilityTimeoutExtensionThreshold,
             VisibilityTimeoutExtensionHeartbeatInterval = sqsMessagePollerOptions.VisibilityTimeoutExtensionHeartbeatInterval,
             WaitTimeSeconds = sqsMessagePollerOptions.WaitTimeSeconds,
-            IsExceptionFatal = sqsMessagePollerOptions.IsExceptionFatal
+            IsExceptionFatal = sqsMessagePollerOptions.IsExceptionFatal,
+            PollingControlToken = sqsMessagePollerOptions.PollingControlToken
         };
 
         _messageConfiguration.MessagePollerConfigurations.Add(sqsMessagePollerConfiguration);
@@ -176,6 +177,7 @@ public class MessageBusBuilder : IMessageBusBuilder
             VisibilityTimeoutExtensionHeartbeatInterval = sqsMessagePollerOptions.VisibilityTimeoutExtensionHeartbeatInterval,
             WaitTimeSeconds = sqsMessagePollerOptions.WaitTimeSeconds,
             IsExceptionFatal = sqsMessagePollerOptions.IsExceptionFatal,
+            PollingControlToken = sqsMessagePollerOptions.PollingControlToken,
 
             SingleMessageTypeIdentifier = messageTypeIdentifier,
             MessageEnvelopeMode = messageEnvelopeMode

--- a/src/AWS.Messaging/Configuration/SQSMessagePollerConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/SQSMessagePollerConfiguration.cs
@@ -95,6 +95,15 @@ public class SQSMessagePollerConfiguration : IMessagePollerConfiguration
     public Func<Exception, bool> IsExceptionFatal { get; set; } = DefaultIsExceptionFatal;
 
     /// <summary>
+    /// An optional <see cref="Configuration.PollingControlToken"/> scoped to this poller, used to start and stop it independently of other pollers on the same message bus.
+    /// </summary>
+    /// <remarks>
+    /// When <c>null</c> (the default), the poller uses the bus-scoped token configured via <see cref="IMessageBusBuilder.ConfigurePollingControlToken"/>.
+    /// When set, the poller is controlled exclusively by this token and is unaffected by the bus-scoped token.
+    /// </remarks>
+    public PollingControlToken? PollingControlToken { get; init; }
+
+    /// <summary>
     /// Construct an instance of <see cref="SQSMessagePollerConfiguration" />
     /// </summary>
     /// <param name="queueUrl">The SQS QueueUrl to poll messages from.</param>

--- a/src/AWS.Messaging/Configuration/SQSMessagePollerOptions.cs
+++ b/src/AWS.Messaging/Configuration/SQSMessagePollerOptions.cs
@@ -28,6 +28,9 @@ public class SQSMessagePollerOptions
     /// <inheritdoc cref="SQSMessagePollerConfiguration.IsExceptionFatal" />
     public Func<Exception, bool> IsExceptionFatal { get; set; } = SQSMessagePollerConfiguration.DefaultIsExceptionFatal;
 
+    /// <inheritdoc cref="SQSMessagePollerConfiguration.PollingControlToken" />
+    public PollingControlToken? PollingControlToken { get; set; }
+
     /// <summary>
     /// Validates that the options are valid against the message framework's and/or SQS limits
     /// </summary>

--- a/src/AWS.Messaging/Services/IMessagePollerFactory.cs
+++ b/src/AWS.Messaging/Services/IMessagePollerFactory.cs
@@ -41,6 +41,11 @@ internal class DefaultMessagePollerFactory : IMessagePollerFactory
     public IMessagePoller CreateMessagePoller(IMessagePollerConfiguration pollerConfiguration)
     {
         IMessagePoller poller;
+
+        // A poller-scoped token takes precedence over the bus-scoped one registered in the container.
+        var pollingControlToken = (pollerConfiguration as SQSMessagePollerConfiguration)?.PollingControlToken
+            ?? _serviceProvider.GetRequiredService<PollingControlToken>();
+
         if (pollerConfiguration is SingleTypeSQSMessagePollerConfiguration singleTypeSQSPollerConfiguration)
         {
             // If the poller is tied to a single message type, create a poller-scoped
@@ -81,11 +86,11 @@ internal class DefaultMessagePollerFactory : IMessagePollerFactory
                     singleTypeSQSPollerConfiguration.MessageEnvelopeMode);
             }
 
-            poller = ActivatorUtilities.CreateInstance<SQSMessagePoller>(_serviceProvider, singleTypeSQSPollerConfiguration, serializerToUse);
+            poller = ActivatorUtilities.CreateInstance<SQSMessagePoller>(_serviceProvider, singleTypeSQSPollerConfiguration, serializerToUse, pollingControlToken);
         }
         else if(pollerConfiguration is SQSMessagePollerConfiguration sqsPollerConfiguration)
         {
-            poller = ActivatorUtilities.CreateInstance<SQSMessagePoller>(_serviceProvider, sqsPollerConfiguration);
+            poller = ActivatorUtilities.CreateInstance<SQSMessagePoller>(_serviceProvider, sqsPollerConfiguration, pollingControlToken);
         }
         else
         {

--- a/test/AWS.Messaging.UnitTests/SQSMessagePollerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SQSMessagePollerTests.cs
@@ -120,6 +120,119 @@ public class SQSMessagePollerTests
     }
 
     /// <summary>
+    /// Tests that a poller configured with its own stopped <see cref="SQSMessagePollerOptions.PollingControlToken"/>
+    /// does not poll SQS, even when no bus-scoped token is configured.
+    /// </summary>
+    [Fact]
+    public async Task SQSMessagePoller_PerPollerPollingControlStopped_DoesNotPollSQS()
+    {
+        var client = new Mock<IAmazonSQS>();
+        client.Setup(x => x.ReceiveMessageAsync(It.IsAny<ReceiveMessageRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ReceiveMessageResponse(), TimeSpan.FromMilliseconds(50));
+        var perPollerToken = new PollingControlToken
+        {
+            PollingWaitTime = TimeSpan.FromMilliseconds(25)
+        };
+        perPollerToken.StopPolling();
+
+        await RunSQSMessagePollerTest(client, options => options.PollingControlToken = perPollerToken);
+
+        client.Verify(x => x.ReceiveMessageAsync(It.IsAny<ReceiveMessageRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Tests that a poller's own <see cref="SQSMessagePollerOptions.PollingControlToken"/> takes precedence over the
+    /// bus-scoped token: a stopped per-poller token prevents polling even while the bus-scoped token is running.
+    /// </summary>
+    [Fact]
+    public async Task SQSMessagePoller_PerPollerToken_OverridesBusScopedToken()
+    {
+        var client = new Mock<IAmazonSQS>();
+        client.Setup(x => x.ReceiveMessageAsync(It.IsAny<ReceiveMessageRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ReceiveMessageResponse(), TimeSpan.FromMilliseconds(50));
+
+        // Bus-scoped token is running, but the per-poller token is stopped and must win.
+        var busScopedToken = new PollingControlToken
+        {
+            PollingWaitTime = TimeSpan.FromMilliseconds(25)
+        };
+        var perPollerToken = new PollingControlToken
+        {
+            PollingWaitTime = TimeSpan.FromMilliseconds(25)
+        };
+        perPollerToken.StopPolling();
+
+        await RunSQSMessagePollerTest(client, options => options.PollingControlToken = perPollerToken, pollingControlToken: busScopedToken);
+
+        client.Verify(x => x.ReceiveMessageAsync(It.IsAny<ReceiveMessageRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Tests that two pollers on the same message bus, each with its own <see cref="SQSMessagePollerOptions.PollingControlToken"/>,
+    /// are paused and resumed independently. Stopping one poller's token leaves the other draining its queue.
+    /// </summary>
+    [Fact]
+    public async Task SQSMessagePoller_TwoPollers_IndependentPerPollerTokens()
+    {
+        const string runningQueueUrl = "runningQueueUrl";
+        const string stoppedQueueUrl = "stoppedQueueUrl";
+
+        var client = new Mock<IAmazonSQS>();
+        var runningQueuePolled = new TaskCompletionSource<bool>();
+        client.Setup(x => x.ReceiveMessageAsync(It.IsAny<ReceiveMessageRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ReceiveMessageResponse(), TimeSpan.FromMilliseconds(50))
+            .Callback<ReceiveMessageRequest, CancellationToken>((request, _) =>
+            {
+                if (request.QueueUrl == runningQueueUrl) runningQueuePolled.TrySetResult(true);
+            });
+
+        var runningToken = new PollingControlToken
+        {
+            PollingWaitTime = TimeSpan.FromMilliseconds(25)
+        };
+        var stoppedToken = new PollingControlToken
+        {
+            PollingWaitTime = TimeSpan.FromMilliseconds(25)
+        };
+        stoppedToken.StopPolling();
+
+        _serviceCollection.AddLogging();
+        _serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPoller(runningQueueUrl, options => options.PollingControlToken = runningToken);
+            builder.AddSQSPoller(stoppedQueueUrl, options => options.PollingControlToken = stoppedToken);
+            builder.AddMessageHandler<ChatMessageHandler, ChatMessage>();
+        });
+        _serviceCollection.AddSingleton(client.Object);
+
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+        var pump = serviceProvider.GetService<IHostedService>() as MessagePumpService;
+        Assert.NotNull(pump);
+
+        var source = new CancellationTokenSource();
+        var task = pump.StartAsync(source.Token);
+
+        // Wait until the running poller has actually polled, rather than relying on a fixed delay.
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        try
+        {
+            await runningQueuePolled.Task.WaitAsync(timeout.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            Assert.Fail("Timed out waiting for the running poller to poll SQS");
+        }
+
+        source.Cancel();
+        await task;
+
+        client.Verify(x => x.ReceiveMessageAsync(
+            It.Is<ReceiveMessageRequest>(request => request.QueueUrl == runningQueueUrl), It.IsAny<CancellationToken>()), Times.AtLeastOnce());
+        client.Verify(x => x.ReceiveMessageAsync(
+            It.Is<ReceiveMessageRequest>(request => request.QueueUrl == stoppedQueueUrl), It.IsAny<CancellationToken>()), Times.Never());
+    }
+
+    /// <summary>
     /// Tests that configuring a poller with <see cref="SQSMessagePollerConfiguration.MaxNumberOfConcurrentMessages"/>
     /// set to a value greater than SQS's current limit of 10 will only receive 10 messages at a time.
     /// </summary>
@@ -435,7 +548,7 @@ public class SQSMessagePollerTests
     /// </summary>
     /// <param name="mockSqsClient">Mocked SQS client</param>
     /// <param name="options">SQS MessagePoller options</param>
-    /// <param name="pollingControlToken">Polling control token to start or stop message receipt</param>
+    /// <param name="pollingControlToken">Bus-scoped polling control token to start or stop message receipt</param>
     private async Task RunSQSMessagePollerTest(Mock<IAmazonSQS> mockSqsClient, Action<SQSMessagePollerOptions>? options = null, PollingControlToken? pollingControlToken = null)
     {
         var pump = BuildMessagePumpService(mockSqsClient, options, pollingControlToken);
@@ -452,7 +565,7 @@ public class SQSMessagePollerTests
     /// </summary>
     /// <param name="mockSqsClient">Mocked SQS client</param>
     /// <param name="options">SQS MessagePoller options</param>
-    /// <param name="pollingControlToken">Polling control token to start or stop message receipt</param>
+    /// <param name="pollingControlToken">Bus-scoped polling control token to start or stop message receipt</param>
     private MessagePumpService BuildMessagePumpService(Mock<IAmazonSQS> mockSqsClient, Action<SQSMessagePollerOptions>? options = null, PollingControlToken? pollingControlToken = null)
     {
         _serviceCollection.AddLogging();


### PR DESCRIPTION
Adds an optional per-poller `PollingControlToken` to `SQSMessagePollerOptions`, so SQS pollers on a single message bus can be paused and resumed independently.

## Use case

A service that consumes multiple SQS queues on one bus sometimes needs to pause one queue while the others keep draining — for example, flipping a kill-switch on the primary work queue during a runbook while a bootstrap or DLQ-replay queue continues to drain. The existing bus-scoped token (`ConfigurePollingControlToken`) stops and starts every poller on the bus together, with no way to control a single one.

## Usage

```csharp
var workQueueToken = new PollingControlToken();
var bootstrapToken = new PollingControlToken();

services.AddAWSMessageBus(bus =>
{
    bus.AddSQSPoller(workQueueUrl, opts => opts.PollingControlToken = workQueueToken);
    bus.AddSQSPoller(bootstrapQueueUrl, opts => opts.PollingControlToken = bootstrapToken);
});

// Later, pause only the work queue; the bootstrap poller keeps draining.
workQueueToken.StopPolling();
```

When `PollingControlToken` is not set, the poller keeps using the bus-scoped token configured via `ConfigurePollingControlToken`, so existing behavior is unchanged.

### Resolving tokens via keyed services

Register each token as a keyed singleton so any component can resolve the right one by key to pause or resume its poller:

```csharp
var workQueueToken = new PollingControlToken();
var bootstrapToken = new PollingControlToken();

services.AddKeyedSingleton("work-queue", workQueueToken);
services.AddKeyedSingleton("bootstrap-queue", bootstrapToken);

services.AddAWSMessageBus(bus =>
{
    bus.AddSQSPoller(workQueueUrl, opts => opts.PollingControlToken = workQueueToken);
    bus.AddSQSPoller(bootstrapQueueUrl, opts => opts.PollingControlToken = bootstrapToken);
});
```

```csharp
public class QueueAdminController(
    [FromKeyedServices("work-queue")] PollingControlToken workQueueToken) : ControllerBase
{
    [HttpPost("work-queue/pause")]
    public IActionResult Pause()
    {
        workQueueToken.StopPolling();
        return Ok();
    }
}
```

Closes #345.