### PR TITLE
Dev to main - Harden GitHub Actions workflows: AppSec Findings

### DIFF
--- a/.github/workflows/aws-ci.yml
+++ b/.github/workflows/aws-ci.yml
@@ -8,15 +8,21 @@ on:
       - dev
       - 'feature/**'
 
-permissions:
-  id-token: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-ci:
+    name: Run CI
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # to assume the testing roles via OIDC
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v4
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: ${{ secrets.CI_MAIN_TESTING_ACCOUNT_ROLE_ARN }}
           role-duration-seconds: 7200
@@ -29,18 +35,20 @@ jobs:
           $roleArn=$(cat ./response.json)
           "roleArn=$($roleArn -replace '"', '')" >> $env:GITHUB_OUTPUT
       - name: Configure Test Runner Credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v4
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: ${{ steps.lambda.outputs.roleArn }}
           role-duration-seconds: 7200
           aws-region: us-west-2
       - name: Run Tests on AWS
         id: codebuild
-        uses: aws-actions/aws-codebuild-run-build@4d15a47425739ac2296ba5e7eee3bdd4bfbdd767 #v1.0.18
+        uses: aws-actions/aws-codebuild-run-build@4d15a47425739ac2296ba5e7eee3bdd4bfbdd767 # v1.0.18
         with:
           project-name: ${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}
       - name: CodeBuild Link
         shell: pwsh
+        env:
+          BUILD_ID: ${{ steps.codebuild.outputs.aws-build-id }}
         run: |
-          $buildId = "${{ steps.codebuild.outputs.aws-build-id }}"
+          $buildId = "$env:BUILD_ID"
           echo $buildId

--- a/.github/workflows/change-file-in-pr.yml
+++ b/.github/workflows/change-file-in-pr.yml
@@ -4,27 +4,36 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
-permissions:
-  contents: read
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   check-files-in-directory:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'Release Not Needed') && !contains(github.event.pull_request.labels.*.name, 'Release PR') }}
     name: Change File Included in PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # to check out the PR and read the changed files
 
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Get List of Changed Files
         id: changed-files
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 #v45
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
 
       - name: Check for Change File(s) in .autover/changes/
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           DIRECTORY=".autover/changes/"
-          if echo "${{ steps.changed-files.outputs.all_changed_files }}" | grep -q "$DIRECTORY"; then
+          if echo "$ALL_CHANGED_FILES" | grep -q "$DIRECTORY"; then
             echo "✅ One or more change files in '$DIRECTORY' are included in this PR."
           else
             echo "❌ No change files in '$DIRECTORY' are included in this PR."

--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -2,14 +2,20 @@ name: Closed Issue Message
 on:
     issues:
        types: [closed]
-permissions:
-  issues: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
     auto_comment:
+        name: Comment on closed issue
         runs-on: ubuntu-latest
+        permissions:
+          issues: write # to comment on the closed issue
         steps:
-        - uses: aws-actions/closed-issue-message@10aaf6366131b673a7c8b7742f8b3849f1d44f18 #v2
+        - uses: aws-actions/closed-issue-message@10aaf6366131b673a7c8b7742f8b3849f1d44f18 # v2
           with:
             # These inputs are both required
             repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -11,40 +11,45 @@ on:
         type: string
         required: false
 
-permissions:
-  id-token: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   release-pr:
     name: Release PR
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # to assume the AWS role that provides the release access token via OIDC
 
     env:
       INPUT_OVERRIDE_VERSION: ${{ github.event.inputs.OVERRIDE_VERSION }}
-      
+
     steps:
       # Assume an AWS Role that provides access to the Access Token
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v4
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: ${{ secrets.RELEASE_WORKFLOW_ACCESS_TOKEN_ROLE_ARN }}
           aws-region: us-west-2
       # Retrieve the Access Token from Secrets Manager
       - name: Retrieve secret from AWS Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3.0.0
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
         with:
           secret-ids: |
             AWS_SECRET, ${{ secrets.RELEASE_WORKFLOW_ACCESS_TOKEN_NAME }}
           parse-json-secrets: true
       # Checkout a full clone of the repo
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: '0'
           token: ${{ env.AWS_SECRET_TOKEN }}
       # Install .NET8 which is needed for AutoVer
       - name: Setup .NET 8.0
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5.2.0
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: 8.0.x
       # Install AutoVer to automate versioning and changelog creation
@@ -75,10 +80,11 @@ jobs:
         run: autover changelog
       # Push the release branch up as well as the created tag
       - name: Push Changes
+        env:
+          BRANCH: ${{ steps.create-release-branch.outputs.BRANCH }}
         run: |
-          branch=${{ steps.create-release-branch.outputs.BRANCH }}
-          git push origin $branch
-          git push origin $branch --tags
+          git push origin "$BRANCH"
+          git push origin "$BRANCH" --tags
       # Get the release name that will be used to create a PR
       - name: Read Release Name
         id: read-release-name
@@ -95,7 +101,10 @@ jobs:
       - name: Create Pull Request
         env:
           GITHUB_TOKEN: ${{ env.AWS_SECRET_TOKEN }}
+          VERSION: ${{ steps.read-release-name.outputs.VERSION }}
+          CHANGELOG: ${{ steps.read-changelog.outputs.CHANGELOG }}
+          BRANCH: ${{ steps.create-release-branch.outputs.BRANCH }}
         run: |
-          pr_url="$(gh pr create --title "${{ steps.read-release-name.outputs.VERSION }}" --body "${{ steps.read-changelog.outputs.CHANGELOG }}" --base dev --head ${{ steps.create-release-branch.outputs.BRANCH }})"
+          pr_url="$(gh pr create --title "$VERSION" --body "$CHANGELOG" --base dev --head "$BRANCH")"
           gh label create "Release PR" --description "A Release PR that includes versioning and changelog changes" -c "#FF0000" -f
-          gh pr edit $pr_url --add-label "Release PR"
+          gh pr edit "$pr_url" --add-label "Release PR"

--- a/.github/workflows/doc-site.yml
+++ b/.github/workflows/doc-site.yml
@@ -6,11 +6,7 @@ on:
     branches:
       - main
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -20,15 +16,23 @@ concurrency:
 
 jobs:
   publish-docs:
+    name: Publish docs
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read # to check out the repository
+      pages: write # to deploy to GitHub Pages
+      id-token: write # to verify the deployment originates from this workflow
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pinning V4 #v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Dotnet Setup
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # pinning V4 #v5.2.0
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: 8.x
 
@@ -36,14 +40,12 @@ jobs:
       - run: docfx docs/docfx.json
 
       - name: Setup Pages
-        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # pinning V5 #v6.0.0
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # pinning V3 #v4.0.0
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           # Upload entire repository
           path: "docs/_site"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # pinning V4 #v5.0.0
-
-
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/handle-stale-discussions.yml
+++ b/.github/workflows/handle-stale-discussions.yml
@@ -4,15 +4,20 @@ on:
     - cron: '0 */4 * * *'
   discussion_comment:
     types: [created]
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   handle-stale-discussions:
     name: Handle stale discussions
     runs-on: ubuntu-latest
     permissions:
-      discussions: write
+      discussions: write # to mark and comment on stale discussions
     steps:
       - name: Stale discussions action
-        uses: aws-github-ops/handle-stale-discussions@c0beee451a5d33d9c8f048a6d4e7c856b5422544 #v1.6.0
+        uses: aws-github-ops/handle-stale-discussions@c0beee451a5d33d9c8f048a6d4e7c856b5422544 # v1.6.0
         env:
           GITHUB_TOKEN:  ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/issue-regression-labeler.yml
+++ b/.github/workflows/issue-regression-labeler.yml
@@ -3,16 +3,21 @@ name: issue-regression-label
 on:
   issues:
     types: [opened, edited]
+permissions: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
 jobs:
   add-regression-label:
+    name: Add potential-regression label
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      issues: write # to add or remove the potential-regression label
     steps:
     - name: Fetch template body
       id: check_regression
-      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd #v8.0.0
-      env: 
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TEMPLATE_BODY: ${{ github.event.issue.body }}
       with:
@@ -24,9 +29,11 @@ jobs:
     - name: Manage regression label
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        IS_REGRESSION: ${{ steps.check_regression.outputs.is_regression }}
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
       run: |
-        if [ "${{ steps.check_regression.outputs.is_regression }}" == "true" ]; then
-          gh issue edit ${{ github.event.issue.number }} --add-label "potential-regression" -R ${{ github.repository }}
+        if [ "$IS_REGRESSION" == "true" ]; then
+          gh issue edit "$ISSUE_NUMBER" --add-label "potential-regression" -R "$GITHUB_REPOSITORY"
         else
-          gh issue edit ${{ github.event.issue.number }} --remove-label "potential-regression" -R ${{ github.repository }}
+          gh issue edit "$ISSUE_NUMBER" --remove-label "potential-regression" -R "$GITHUB_REPOSITORY"
         fi

--- a/.github/workflows/semgrep-analysis.yml
+++ b/.github/workflows/semgrep-analysis.yml
@@ -13,19 +13,28 @@ on:
   # Manually trigger the workflow
   workflow_dispatch:
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   semgrep:
     name: Scan
     permissions:
-      security-events: write
+      contents: read # to check out the repository
+      security-events: write # to upload SARIF results to code scanning
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep
+      image: returntocorp/semgrep@sha256:06938c1f365d3f67b8cedd8bc117607ae64253f88a0e768e9da9408548927dd6
     # Skip any PR created by dependabot to avoid permission issues
     if: (github.actor != 'dependabot[bot]')
     steps:
       # Fetch project source
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - run: semgrep ci --sarif > semgrep.sarif
         env:
@@ -35,7 +44,7 @@ jobs:
             p/owasp-top-ten
 
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 #v4.35.1
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
           sarif_file: semgrep.sarif
         if: always()

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -5,16 +5,21 @@ on:
   schedule:
   - cron: "0 0 * * *"
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    permissions:
+      issues: write # to label and close stale issues
+      pull-requests: write # to label and close stale pull requests
     steps:
-    - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440 #v7.1.1
+    - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440 # v7.1.1
       with:
         # Setting messages to an empty string will cause the automation to skip
         # that category

--- a/.github/workflows/sync-main-dev.yml
+++ b/.github/workflows/sync-main-dev.yml
@@ -9,9 +9,11 @@ on:
   pull_request:
     types: [closed]
 
-permissions: 
-  contents: write
-  id-token: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   # This job will check if the PR was successfully merged, it's source branch is `releases/next-release` and target branch is `dev`. 
@@ -24,30 +26,33 @@ jobs:
       github.event.pull_request.head.ref == 'releases/next-release' &&
       github.event.pull_request.base.ref == 'dev'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to merge dev into main and push the synchronized branches
+      id-token: write # to assume the AWS role that provides the release access token via OIDC
     steps:
       # Assume an AWS Role that provides access to the Access Token
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v4
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: ${{ secrets.RELEASE_WORKFLOW_ACCESS_TOKEN_ROLE_ARN }}
           aws-region: us-west-2
       # Retrieve the Access Token from Secrets Manager
       - name: Retrieve secret from AWS Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3.0.0
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
         with:
           secret-ids: |
             AWS_SECRET, ${{ secrets.RELEASE_WORKFLOW_ACCESS_TOKEN_NAME }}
           parse-json-secrets: true
       # Checkout a full clone of the repo
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: dev
           fetch-depth: 0
           token: ${{ env.AWS_SECRET_TOKEN }}
       # Install .NET8 which is needed for AutoVer
       - name: Setup .NET 8.0
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5.2.0
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: 8.0.x
       # Install AutoVer which is needed to retrieve information about the current release.
@@ -87,8 +92,11 @@ jobs:
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ env.AWS_SECRET_TOKEN }}
+          TAG: ${{ steps.read-tag-name.outputs.TAG }}
+          VERSION: ${{ steps.read-release-name.outputs.VERSION }}
+          CHANGELOG: ${{ steps.read-changelog.outputs.CHANGELOG }}
         run: |
-          gh release create "${{ steps.read-tag-name.outputs.TAG }}" --title "${{ steps.read-release-name.outputs.VERSION }}" --notes "${{ steps.read-changelog.outputs.CHANGELOG }}"
+          gh release create "$TAG" --title "$VERSION" --notes "$CHANGELOG"
       # Delete the `releases/next-release` branch
       - name: Clean up
         run: |
@@ -104,16 +112,18 @@ jobs:
       github.event.pull_request.head.ref == 'releases/next-release' &&
       github.event.pull_request.base.ref == 'dev'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to delete the release tag and the release branch
     steps:
       # Checkout a full clone of the repo
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: releases/next-release
           fetch-depth: 0
       # Install .NET8 which is needed for AutoVer
       - name: Setup .NET 8.0
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5.2.0
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: 8.0.x
       # Install AutoVer which is needed to retrieve information about the current release.
@@ -132,7 +142,9 @@ jobs:
           echo "TAG=$tag" >> $GITHUB_OUTPUT
       # Delete the tag created by AutoVer and the release branch
       - name: Clean up
+        env:
+          TAG: ${{ steps.read-tag-name.outputs.TAG }}
         run: |
           git fetch origin
-          git push --delete origin ${{ steps.read-tag-name.outputs.TAG }}
+          git push --delete origin "$TAG"
           git push origin --delete releases/next-release


### PR DESCRIPTION
## What

Hardening our GitHub Actions workflows with zizmor — same change already merged to `dev`, brought to `main` via a clean cherry-pick (the rest of `dev` isn't ready for `main` yet). Same approach as aws-sdk-net-staging#1375.

## Changes

- Move untrusted `${{ }}` values into `env:` vars to prevent script injection
- Pin all actions to commit SHAs (no version bumps)
- Set top-level `permissions: {}` with minimal per-job grants
- Add concurrency groups and job names
- Pin the semgrep container image by digest

## Notes

Workflow files only — no behavior changes. The release/sync checkouts intentionally keep persisted credentials (they push afterwards). Verified clean with zizmor; only expected `artipacked` findings remain on those push steps.