### PR TITLE
Harden GitHub Actions workflows based on zizmor audit

### DIFF
--- a/.github/workflows/BuildandTest.yml
+++ b/.github/workflows/BuildandTest.yml
@@ -2,21 +2,31 @@ name: Build and Test
 
 on: [push, pull_request]
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
+    name: Build and Test
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # to check out the repository
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
       with:
         fetch-depth: '0'
+        persist-credentials: false
     - name: Setup .NET Core 6.0
-      uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # pinning V4
+      uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
       with:
         dotnet-version: 6.0.x
     - name: Setup .NET Core 8.0
-      uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # pinning V4
+      uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
       with:
         dotnet-version: 8.0.x
     - name: Restore dependencies

--- a/.github/workflows/aws-ci.yml
+++ b/.github/workflows/aws-ci.yml
@@ -6,15 +6,21 @@ on:
       - v3sdk-release
       - v3sdk-development
 
-permissions:
-  id-token: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
+    name: Run CI
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # to assume the testing roles via OIDC
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
           role-to-assume: ${{ secrets.CI_MAIN_TESTING_ACCOUNT_ROLE_ARN }}
           role-duration-seconds: 7200
@@ -35,18 +41,20 @@ jobs:
           $roleArn=$(cat ./response.json)
           "roleArn=$($roleArn -replace '"', '')" >> $env:GITHUB_OUTPUT
       - name: Configure Test Runner Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
           role-to-assume: ${{ steps.lambda.outputs.roleArn }}
           role-duration-seconds: 7200
           aws-region: us-west-2
       - name: Run Tests on AWS
         id: codebuild
-        uses: aws-actions/aws-codebuild-run-build@v1
+        uses: aws-actions/aws-codebuild-run-build@7e46c3fa1c1f217e26a73712796b1f78938b534b # v1.0.19
         with:
           project-name: ${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}
       - name: CodeBuild Link
         shell: pwsh
+        env:
+          BUILD_ID: ${{ steps.codebuild.outputs.aws-build-id }}
         run: |
-          $buildId = "${{ steps.codebuild.outputs.aws-build-id }}"
+          $buildId = "$env:BUILD_ID"
           echo $buildId

--- a/.github/workflows/change-file-in-pr.yml
+++ b/.github/workflows/change-file-in-pr.yml
@@ -4,24 +4,36 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   check-files-in-directory:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'Release Not Needed') && !contains(github.event.pull_request.labels.*.name, 'Release PR') }}
     name: Change File Included in PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # to check out the PR and read the changed files
 
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
+        with:
+          persist-credentials: false
 
       - name: Get List of Changed Files
         id: changed-files
-        uses: tj-actions/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf #v45
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
 
       - name: Check for Change File(s) in .autover/changes/
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           DIRECTORY=".autover/changes/"
-          if echo "${{ steps.changed-files.outputs.all_changed_files }}" | grep -q "$DIRECTORY"; then
+          if echo "$ALL_CHANGED_FILES" | grep -q "$DIRECTORY"; then
             echo "✅ One or more change files in '$DIRECTORY' are included in this PR."
           else
             echo "❌ No change files in '$DIRECTORY' are included in this PR."

--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -2,11 +2,20 @@ name: Closed Issue Message
 on:
     issues:
        types: [closed]
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
     auto_comment:
+        name: Comment on closed issue
         runs-on: ubuntu-latest
+        permissions:
+          issues: write # to comment on the closed issue
         steps:
-        - uses: aws-actions/closed-issue-message@v1
+        - uses: aws-actions/closed-issue-message@cf797c2463fa6b95a23b2957fe075a3fa9aa8138 # v1
           with:
             # These inputs are both required
             repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -11,40 +11,45 @@ on:
         type: string
         required: false
 
-permissions:
-  id-token: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   release-pr:
     name: Release PR
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # to assume the AWS role that provides the release access token via OIDC
 
     env:
       INPUT_OVERRIDE_VERSION: ${{ github.event.inputs.OVERRIDE_VERSION }}
-      
+
     steps:
       # Assume an AWS Role that provides access to the Access Token
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 #v4
+        uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
         with:
           role-to-assume: ${{ secrets.RELEASE_WORKFLOW_ACCESS_TOKEN_ROLE_ARN }}
           aws-region: us-west-2
       # Retrieve the Access Token from Secrets Manager
       - name: Retrieve secret from AWS Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2.0.10
         with:
           secret-ids: |
             AWS_SECRET, ${{ secrets.RELEASE_WORKFLOW_ACCESS_TOKEN_NAME }}
           parse-json-secrets: true
       # Checkout a full clone of the repo
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: '0'
           token: ${{ env.AWS_SECRET_TOKEN }}
       # Install .NET8 which is needed for AutoVer
       - name: Setup .NET 8.0
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: 8.0.x
       # Install AutoVer to automate versioning and changelog creation
@@ -75,10 +80,11 @@ jobs:
         run: autover changelog
       # Push the release branch up as well as the created tag
       - name: Push Changes
+        env:
+          BRANCH: ${{ steps.create-release-branch.outputs.BRANCH }}
         run: |
-          branch=${{ steps.create-release-branch.outputs.BRANCH }}
-          git push origin $branch
-          git push origin $branch --tags
+          git push origin "$BRANCH"
+          git push origin "$BRANCH" --tags
       # Get the release name that will be used to create a PR
       - name: Read Release Name
         id: read-release-name
@@ -95,7 +101,10 @@ jobs:
       - name: Create Pull Request
         env:
           GITHUB_TOKEN: ${{ env.AWS_SECRET_TOKEN }}
+          VERSION: ${{ steps.read-release-name.outputs.VERSION }}
+          CHANGELOG: ${{ steps.read-changelog.outputs.CHANGELOG }}
+          BRANCH: ${{ steps.create-release-branch.outputs.BRANCH }}
         run: |
-          pr_url="$(gh pr create --title "${{ steps.read-release-name.outputs.VERSION }}" --body "${{ steps.read-changelog.outputs.CHANGELOG }}" --base v3sdk-development --head ${{ steps.create-release-branch.outputs.BRANCH }})"
+          pr_url="$(gh pr create --title "$VERSION" --body "$CHANGELOG" --base v3sdk-development --head "$BRANCH")"
           gh label create "Release PR" --description "A Release PR that includes versioning and changelog changes" -c "#FF0000" -f
-          gh pr edit $pr_url --add-label "Release PR"
+          gh pr edit "$pr_url" --add-label "Release PR"

--- a/.github/workflows/doc-site.yml
+++ b/.github/workflows/doc-site.yml
@@ -6,11 +6,7 @@ on:
     branches:
       - main
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -20,15 +16,23 @@ concurrency:
 
 jobs:
   publish-docs:
+    name: Publish docs
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read # to check out the repository
+      pages: write # to deploy to GitHub Pages
+      id-token: write # to verify the deployment originates from this workflow
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pinning V4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Dotnet Setup
-        uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # pinning V4
+        uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
         with:
           dotnet-version: 8.x
 
@@ -36,14 +40,12 @@ jobs:
       - run: docfx docs/docfx.json
 
       - name: Setup Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # pinning V5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # pinning V3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           # Upload entire repository
           path: "docs/_site"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # pinning V4
-
-
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/handle-stale-discussions.yml
+++ b/.github/workflows/handle-stale-discussions.yml
@@ -4,15 +4,20 @@ on:
     - cron: '0 */4 * * *'
   discussion_comment:
     types: [created]
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   handle-stale-discussions:
     name: Handle stale discussions
     runs-on: ubuntu-latest
     permissions:
-      discussions: write
+      discussions: write # to mark and comment on stale discussions
     steps:
       - name: Stale discussions action
-        uses: aws-github-ops/handle-stale-discussions@v1
+        uses: aws-github-ops/handle-stale-discussions@711a9813957be17629fc6933afcd8bd132c57254 # v1.6
         env:
           GITHUB_TOKEN:  ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/issue-regression-labeler.yml
+++ b/.github/workflows/issue-regression-labeler.yml
@@ -3,16 +3,21 @@ name: issue-regression-label
 on:
   issues:
     types: [opened, edited]
+permissions: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
 jobs:
   add-regression-label:
+    name: Add potential-regression label
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      issues: write # to add or remove the potential-regression label
     steps:
     - name: Fetch template body
       id: check_regression
-      uses: actions/github-script@v7
-      env: 
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+      env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TEMPLATE_BODY: ${{ github.event.issue.body }}
       with:
@@ -24,9 +29,11 @@ jobs:
     - name: Manage regression label
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        IS_REGRESSION: ${{ steps.check_regression.outputs.is_regression }}
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
       run: |
-        if [ "${{ steps.check_regression.outputs.is_regression }}" == "true" ]; then
-          gh issue edit ${{ github.event.issue.number }} --add-label "potential-regression" -R ${{ github.repository }}
+        if [ "$IS_REGRESSION" == "true" ]; then
+          gh issue edit "$ISSUE_NUMBER" --add-label "potential-regression" -R "$GITHUB_REPOSITORY"
         else
-          gh issue edit ${{ github.event.issue.number }} --remove-label "potential-regression" -R ${{ github.repository }}
+          gh issue edit "$ISSUE_NUMBER" --remove-label "potential-regression" -R "$GITHUB_REPOSITORY"
         fi

--- a/.github/workflows/semgrep-analysis.yml
+++ b/.github/workflows/semgrep-analysis.yml
@@ -13,19 +13,28 @@ on:
   # Manually trigger the workflow
   workflow_dispatch:
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   semgrep:
     name: Scan
     permissions:
-      security-events: write
+      contents: read # to check out the repository
+      security-events: write # to upload SARIF results to code scanning
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep
+      image: returntocorp/semgrep@sha256:06938c1f365d3f67b8cedd8bc117607ae64253f88a0e768e9da9408548927dd6
     # Skip any PR created by dependabot to avoid permission issues
     if: (github.actor != 'dependabot[bot]')
     steps:
       # Fetch project source
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - run: semgrep ci --sarif > semgrep.sarif
         env:
@@ -35,7 +44,7 @@ jobs:
             p/owasp-top-ten
 
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3.37.0
         with:
           sarif_file: semgrep.sarif
         if: always()

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -5,12 +5,21 @@ on:
   schedule:
   - cron: "0 0 * * *"
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    permissions:
+      issues: write # to label and close stale issues
+      pull-requests: write # to label and close stale pull requests
     steps:
-    - uses: aws-actions/stale-issue-cleanup@v6
+    - uses: aws-actions/stale-issue-cleanup@7de35968489e4142233d2a6812519a82e68b5c38 # v6
       with:
         # Setting messages to an empty string will cause the automation to skip
         # that category

--- a/.github/workflows/sync-main-dev.yml
+++ b/.github/workflows/sync-main-dev.yml
@@ -8,9 +8,11 @@ on:
   pull_request:
     types: [closed]
 
-permissions: 
-  contents: write
-  id-token: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   # This job will check if the PR was successfully merged, it's source branch is `releases/next-release` and target branch is `v3sdk-development`. 
@@ -23,30 +25,33 @@ jobs:
       github.event.pull_request.head.ref == 'releases/next-release' &&
       github.event.pull_request.base.ref == 'v3sdk-development'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to merge v3sdk-development into v3sdk-release and push the synchronized branches
+      id-token: write # to assume the AWS role that provides the release access token via OIDC
     steps:
       # Assume an AWS Role that provides access to the Access Token
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 #v4
+        uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
         with:
           role-to-assume: ${{ secrets.RELEASE_WORKFLOW_ACCESS_TOKEN_ROLE_ARN }}
           aws-region: us-west-2
       # Retrieve the Access Token from Secrets Manager
       - name: Retrieve secret from AWS Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2.0.10
         with:
           secret-ids: |
             AWS_SECRET, ${{ secrets.RELEASE_WORKFLOW_ACCESS_TOKEN_NAME }}
           parse-json-secrets: true
       # Checkout a full clone of the repo
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: v3sdk-development
           fetch-depth: 0
           token: ${{ env.AWS_SECRET_TOKEN }}
       # Install .NET8 which is needed for AutoVer
       - name: Setup .NET 8.0
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: 8.0.x
       # Install AutoVer which is needed to retrieve information about the current release.
@@ -86,8 +91,11 @@ jobs:
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ env.AWS_SECRET_TOKEN }}
+          TAG: ${{ steps.read-tag-name.outputs.TAG }}
+          VERSION: ${{ steps.read-release-name.outputs.VERSION }}
+          CHANGELOG: ${{ steps.read-changelog.outputs.CHANGELOG }}
         run: |
-          gh release create "${{ steps.read-tag-name.outputs.TAG }}" --title "${{ steps.read-release-name.outputs.VERSION }}" --notes "${{ steps.read-changelog.outputs.CHANGELOG }}"
+          gh release create "$TAG" --title "$VERSION" --notes "$CHANGELOG"
       # Delete the `releases/next-release` branch
       - name: Clean up
         run: |
@@ -103,16 +111,18 @@ jobs:
       github.event.pull_request.head.ref == 'releases/next-release' &&
       github.event.pull_request.base.ref == 'v3sdk-development'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to delete the release tag and the release branch
     steps:
       # Checkout a full clone of the repo
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: releases/next-release
           fetch-depth: 0
       # Install .NET8 which is needed for AutoVer
       - name: Setup .NET 8.0
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: 8.0.x
       # Install AutoVer which is needed to retrieve information about the current release.
@@ -131,7 +141,9 @@ jobs:
           echo "TAG=$tag" >> $GITHUB_OUTPUT
       # Delete the tag created by AutoVer and the release branch
       - name: Clean up
+        env:
+          TAG: ${{ steps.read-tag-name.outputs.TAG }}
         run: |
           git fetch origin
-          git push --delete origin ${{ steps.read-tag-name.outputs.TAG }}
+          git push --delete origin "$TAG"
           git push origin --delete releases/next-release


### PR DESCRIPTION
## What

Hardening our GitHub Actions workflows with zizmor on this branch. Cherry-picked from main; conflicts resolved by keeping this branch's own content (triggers, branch names, auth, release logic) and applying only the hardening on top. Same approach as aws-sdk-net-staging#1375.

## Changes

- Move untrusted `${{ }}` values into `env:` vars to prevent script injection
- Pin all actions to commit SHAs
- Set top-level `permissions: {}` with minimal per-job grants
- Add concurrency groups and job names
- Pin the semgrep container image by digest
- **Security fix:** bump `tj-actions/changed-files` v45.0.4 -> v47.0.5 (GHSA-mrrh-fwg8-r2c3)
- **Security fix:** bump `github/codeql-action/upload-sarif` v2 -> v3.37.0 (GHSA-vqf5-2xx6-9wfm; no fix exists in the v2 line)

The branch-only `BuildandTest.yml` is hardened in a second commit (it doesn't exist on the default branch).

## Notes

Workflow files only — no behavior changes to triggers or release logic. Release/sync checkouts intentionally keep persisted credentials (they push afterwards). Verified with zizmor; only expected `artipacked` findings remain on those push steps.