### PR TITLE
Feat: Expose ApproximateReceiveCount on SQSMetadata

### DIFF
--- a/.autover/changes/3372593a-1585-4e5e-9ab9-f683ac784120.json
+++ b/.autover/changes/3372593a-1585-4e5e-9ab9-f683ac784120.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Expose ApproximateReceiveCount on SQSMetadata so handlers can distinguish first deliveries from redeliveries."
+      ]
+    }
+  ]
+}

--- a/src/AWS.Messaging/SQSMetadata.cs
+++ b/src/AWS.Messaging/SQSMetadata.cs
@@ -36,6 +36,11 @@ namespace AWS.Messaging
         public DateTimeOffset? SentTimestamp { get; set; }
 
         /// <summary>
+        /// The approximate number of times a message has been received across all delivery attempts but not deleted.
+        /// </summary>
+        public int? ApproximateReceiveCount { get; set; }
+
+        /// <summary>
         /// Each message attribute consists of a Name, Type, and Value.For more information, see Amazon SQS message attributes (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-metadata.html#sqs-message-attributes)
         /// </summary>
         public Dictionary<string, MessageAttributeValue>? MessageAttributes { get; set; }

--- a/src/AWS.Messaging/Serialization/Handlers/MessageMetadataHandler.cs
+++ b/src/AWS.Messaging/Serialization/Handlers/MessageMetadataHandler.cs
@@ -37,6 +37,12 @@ internal static class MessageMetadataHandler
             {
                 metadata.SentTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(epochMilliseconds);
             }
+
+            var approximateReceiveCount = JsonPropertyHelper.GetAttributeValue(message.Attributes, "ApproximateReceiveCount");
+            if (!string.IsNullOrEmpty(approximateReceiveCount) && int.TryParse(approximateReceiveCount, out var receiveCount))
+            {
+                metadata.ApproximateReceiveCount = receiveCount;
+            }
         }
 
         return metadata;

--- a/test/AWS.Messaging.UnitTests/SerializationTests/Handlers/MessageDataHandlerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/Handlers/MessageDataHandlerTests.cs
@@ -143,6 +143,66 @@ public class MessageMetadataHandlerTests
     }
 
     [Fact]
+    public void CreateSQSMetadata_WithValidApproximateReceiveCount_ReturnsCorrectMetadata()
+    {
+        // Arrange
+        var message = new Message
+        {
+            MessageId = "test-message-id",
+            Attributes = new Dictionary<string, string>
+            {
+                { "ApproximateReceiveCount", "3" }
+            }
+        };
+
+        // Act
+        var metadata = MessageMetadataHandler.CreateSQSMetadata(message);
+
+        // Assert
+        Assert.Equal(3, metadata.ApproximateReceiveCount);
+    }
+
+    [Fact]
+    public void CreateSQSMetadata_WithMissingApproximateReceiveCount_ReturnsNullApproximateReceiveCount()
+    {
+        // Arrange
+        var message = new Message
+        {
+            MessageId = "test-message-id",
+            Attributes = new Dictionary<string, string>
+            {
+                { "MessageGroupId", "group-1" }
+            }
+        };
+
+        // Act
+        var metadata = MessageMetadataHandler.CreateSQSMetadata(message);
+
+        // Assert
+        Assert.Null(metadata.ApproximateReceiveCount);
+    }
+
+    [Fact]
+    public void CreateSQSMetadata_WithInvalidApproximateReceiveCount_ReturnsNullApproximateReceiveCount()
+    {
+        // Arrange
+        var message = new Message
+        {
+            MessageId = "test-message-id",
+            Attributes = new Dictionary<string, string>
+            {
+                { "ApproximateReceiveCount", "not-a-number" }
+            }
+        };
+
+        // Act
+        var metadata = MessageMetadataHandler.CreateSQSMetadata(message);
+
+        // Assert
+        Assert.Null(metadata.ApproximateReceiveCount);
+    }
+
+    [Fact]
     public void CreateSQSMetadata_WithNullAttributes_ReturnsNullSentTimestamp()
     {
         // Arrange


### PR DESCRIPTION
### Description

Adds `int? ApproximateReceiveCount` to `SQSMetadata` and populates it from the SQS message's `ApproximateReceiveCount` system attribute.

The `SQSMessagePoller` already requests `MessageSystemAttributeNames = ["All"]`, so this value is present on every received message. However, `MessageMetadataHandler.CreateSQSMetadata` previously mapped only `MessageGroupId`, `MessageDeduplicationId` and `SentTimestamp`, so handlers had no way to read it. This change surfaces the already-available data.

**Use case:** distinguishing a first delivery (`ApproximateReceiveCount == 1`) from a redelivery (`> 1`), for example to separate retries from first attempts in per-message metrics.

Follows the existing `SentTimestamp` mapping pattern (safe `int.TryParse`, left `null` when the attribute is absent or non-numeric).

### Motivation and Context

Resolves #353.

### Testing

- Added unit tests to `MessageMetadataHandlerTests` covering valid, missing, and invalid `ApproximateReceiveCount` values.
- `dotnet test` on `AWS.Messaging.UnitTests`: all tests pass except 5 pre-existing `MessageBusBuilderTests` that fail on any machine without AWS credentials (unrelated to this change; confirmed identical failures on a clean `dev` checkout).
- `dotnet build -c Release` on `AWS.Messaging` (which has `IsTrimmable=true`) produces no trim/IL warnings; `int?` requires no `JsonSerializerContext` changes.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed (see Testing note re: credential-dependent tests)
- [x] A change file has been added under `.autover/changes/` (Minor increment for `AWS.Messaging`)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
